### PR TITLE
Filter by registry namespace

### DIFF
--- a/deploy/operatorsource.cr.yaml
+++ b/deploy/operatorsource.cr.yaml
@@ -1,7 +1,8 @@
 apiVersion: "marketplace.redhat.com/v1alpha1"
 kind: "OperatorSource"
 metadata:
-  name: "localhost"
+  name: "global-operators"
 spec:
   type: appregistry
-  endpoint: "http://localhost:5000/cnr"
+  endpoint: "https://quay.io/cnr"
+  registryNamespace: "operators"

--- a/pkg/apis/marketplace/v1alpha1/types.go
+++ b/pkg/apis/marketplace/v1alpha1/types.go
@@ -57,8 +57,12 @@ type OperatorSourceSpec struct {
 	// Type of operator source
 	Type string `json:"type"`
 
-	// Endpoint points to the URL from where operator manifests can be fetched
+	// Endpoint points to the remote app registry server from where operator manifests can be fetched
 	Endpoint string `json:"endpoint"`
+
+	// RegistryNamespace refers to the namespace in app registry. Only operator manifests under
+	// this namespace will be vsible. This is not a k8s namespace.
+	RegistryNamespace string `json:"registryNamespace"`
 }
 
 type OperatorSourceStatus struct {

--- a/pkg/appregistry/adapter.go
+++ b/pkg/appregistry/adapter.go
@@ -15,8 +15,10 @@ const (
 
 // This interface (internal to this package) encapsulates nitty gritty details of go-appr client bindings
 type apprApiAdapter interface {
-	// ListPackages returns a list of package(s) available to the user
-	ListPackages() (appr_models.Packages, error)
+	// ListPackages returns a list of package(s) available to the user.
+	// When namespace is specified, only package(s) associated with the given namespace are returned.
+	// If namespace is empty then visible package(s) across all namespaces are returned.
+	ListPackages(namespace string) (appr_models.Packages, error)
 
 	// GetPackageMetadata returns metadata associated with a given package
 	GetPackageMetadata(namespace string, repository string, release string) (*appr_models.Package, error)
@@ -29,8 +31,12 @@ type apprApiAdapterImpl struct {
 	client *appr.Appregistry
 }
 
-func (a *apprApiAdapterImpl) ListPackages() (appr_models.Packages, error) {
+func (a *apprApiAdapterImpl) ListPackages(namespace string) (appr_models.Packages, error) {
 	params := appr_package.NewListPackagesParams()
+
+	if namespace != "" {
+		params.SetNamespace(&namespace)
+	}
 
 	packages, err := a.client.PackageAppr.ListPackages(params)
 	if err != nil {

--- a/pkg/appregistry/appregistry.go
+++ b/pkg/appregistry/appregistry.go
@@ -19,15 +19,6 @@ type ClientFactory interface {
 	New(sourceType, source string) (Client, error)
 }
 
-// Client exposes the functionality of app registry server
-type Client interface {
-	// RetrieveAll retrieves all visible packages from the given source
-	RetrieveAll() ([]*OperatorMetadata, error)
-
-	// RetrieveOneretrieves a given package from the source
-	RetrieveOne(name, release string) (*OperatorMetadata, error)
-}
-
 type factory struct{}
 
 func (f *factory) New(sourceType, source string) (Client, error) {

--- a/pkg/appregistry/appregistry_test.go
+++ b/pkg/appregistry/appregistry_test.go
@@ -12,11 +12,12 @@ import (
 func TestRetrieveAll(t *testing.T) {
 	factory := appregistry.NewClientFactory()
 
-	client, err := factory.New("appregistry", "http://localhost:5000/cnr")
+	client, err := factory.New("appregistry", "https://quay.io/cnr")
 	require.NoError(t, err)
 
-	packages, err := client.RetrieveAll()
+	packages, err := client.RetrieveAll("operators")
 
 	assert.NoError(t, err)
 	assert.NotNil(t, packages)
+	assert.True(t, len(packages) >= 1)
 }

--- a/pkg/appregistry/client.go
+++ b/pkg/appregistry/client.go
@@ -6,6 +6,17 @@ import (
 	"strings"
 )
 
+// Client exposes the functionality of app registry server
+type Client interface {
+	// RetrieveAll retrieves all visible packages from the given source
+	// When namespace is specified, only package(s) associated with the given namespace are returned.
+	// If namespace is empty then visible package(s) across all namespaces are returned.
+	RetrieveAll(namespace string) ([]*OperatorMetadata, error)
+
+	// RetrieveOne retrieves a given package from the source
+	RetrieveOne(name, release string) (*OperatorMetadata, error)
+}
+
 // OperatorMetadata encapsulates operator metadata and manifest assocated with a package
 type OperatorMetadata struct {
 	// Namespace is the namespace in app registry server under which the package is hosted.
@@ -34,8 +45,8 @@ type client struct {
 	unmarshaller blobUnmarshaller
 }
 
-func (c *client) RetrieveAll() ([]*OperatorMetadata, error) {
-	packages, err := c.adapter.ListPackages()
+func (c *client) RetrieveAll(namespace string) ([]*OperatorMetadata, error) {
+	packages, err := c.adapter.ListPackages(namespace)
 	if err != nil {
 		return nil, err
 	}

--- a/pkg/appregistry/mock_adapter.go
+++ b/pkg/appregistry/mock_adapter.go
@@ -34,16 +34,16 @@ func (m *MockapprApiAdapter) EXPECT() *MockapprApiAdapterMockRecorder {
 }
 
 // ListPackages mocks base method
-func (m *MockapprApiAdapter) ListPackages() (models.Packages, error) {
-	ret := m.ctrl.Call(m, "ListPackages")
+func (m *MockapprApiAdapter) ListPackages(namespace string) (models.Packages, error) {
+	ret := m.ctrl.Call(m, "ListPackages", namespace)
 	ret0, _ := ret[0].(models.Packages)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // ListPackages indicates an expected call of ListPackages
-func (mr *MockapprApiAdapterMockRecorder) ListPackages() *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPackages", reflect.TypeOf((*MockapprApiAdapter)(nil).ListPackages))
+func (mr *MockapprApiAdapterMockRecorder) ListPackages(namespace interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "ListPackages", reflect.TypeOf((*MockapprApiAdapter)(nil).ListPackages), namespace)
 }
 
 // GetPackageMetadata mocks base method

--- a/pkg/operatorsource/reconciler.go
+++ b/pkg/operatorsource/reconciler.go
@@ -51,7 +51,7 @@ func (r *reconciler) Reconcile(opsrc *v1alpha1.OperatorSource) error {
 		return err
 	}
 
-	manifests, err := registry.RetrieveAll()
+	manifests, err := registry.RetrieveAll(opsrc.Spec.RegistryNamespace)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
For an `OperatorSource` type, allow the admin to specify a registry namespace to filter by