### PR TITLE
CatalogSourceConfig requires field "metadata.namespace"

### DIFF
--- a/deploy/examples/catalogsourceconfig.cr.yaml
+++ b/deploy/examples/catalogsourceconfig.cr.yaml
@@ -2,6 +2,7 @@ apiVersion: "marketplace.redhat.com/v1alpha1"
 kind: "CatalogSourceConfig"
 metadata:
   name: "example"
+  namespace: "marketplace"
 spec:
   targetNamespace: "global"
   packages: "operators/marketplace-operators"

--- a/deploy/examples/operatorsource.cr.yaml
+++ b/deploy/examples/operatorsource.cr.yaml
@@ -2,6 +2,7 @@ apiVersion: "marketplace.redhat.com/v1alpha1"
 kind: "OperatorSource"
 metadata:
   name: "global-operators"
+  namespace: "marketplace"
 spec:
   type: appregistry
   endpoint: "https://quay.io/cnr"


### PR DESCRIPTION
I noticed that the marketplace operator expects CatalogSourceConfig CRs to specify the field "metadata.namespace" with the namespace that created it.