### PR TITLE
[tests] Fix datastore unit test case

### DIFF
--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -27,5 +27,5 @@ func TestGetPackageIDs(t *testing.T) {
 	result := ds.GetPackageIDs()
 	actual := strings.Split(result, ",")
 
-	assert.EqualValues(t, expected, actual)
+	assert.ElementsMatch(t, expected, actual)
 }


### PR DESCRIPTION
Use assert.ElementsMatch to compare the lists instead of
assert.EqualValues which compares objects.