### PR TITLE
Use builder pattern to create ConfigMap and CatalogSource

### DIFF
--- a/pkg/catalogsourceconfig/catalogsourcebuilder.go
+++ b/pkg/catalogsourceconfig/catalogsourcebuilder.go
@@ -1,0 +1,50 @@
+package catalogsourceconfig
+
+import (
+	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// CatalogSourceBuilder builds a new CatalogSource object.
+type CatalogSourceBuilder struct {
+	cs olm.CatalogSource
+}
+
+// CatalogSource returns a CatalogSource object.
+func (b *CatalogSourceBuilder) CatalogSource() *olm.CatalogSource {
+	return &b.cs
+}
+
+// WithMeta sets basic TypeMeta and ObjectMeta.
+func (b *CatalogSourceBuilder) WithMeta(name, namespace string) *CatalogSourceBuilder {
+	b.cs.TypeMeta = metav1.TypeMeta{
+		Kind:       olm.CatalogSourceKind,
+		APIVersion: olm.CatalogSourceCRDAPIVersion,
+	}
+	b.cs.ObjectMeta = metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+	}
+	return b
+}
+
+// WithOwner sets the owner of the CatalogSource object to the given owner.
+func (b *CatalogSourceBuilder) WithOwner(owner *v1alpha1.CatalogSourceConfig) *CatalogSourceBuilder {
+	b.cs.SetOwnerReferences(append(b.cs.GetOwnerReferences(),
+		[]metav1.OwnerReference{
+			*metav1.NewControllerRef(owner, owner.GroupVersionKind()),
+		}[0]))
+	return b
+}
+
+// WithSpec sets Spec with input data.
+func (b *CatalogSourceBuilder) WithSpec(csType, cmName, displayName, publisher string) *CatalogSourceBuilder {
+	b.cs.Spec = olm.CatalogSourceSpec{
+		SourceType:  csType,
+		ConfigMap:   cmName,
+		DisplayName: displayName,
+		Publisher:   publisher,
+	}
+	return b
+}

--- a/pkg/catalogsourceconfig/configmapbuilder.go
+++ b/pkg/catalogsourceconfig/configmapbuilder.go
@@ -1,0 +1,45 @@
+package catalogsourceconfig
+
+import (
+	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
+	corev1 "k8s.io/api/core/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// ConfigMapBuilder builds a new CatalogSource object.
+type ConfigMapBuilder struct {
+	cm corev1.ConfigMap
+}
+
+// ConfigMap returns a ConfigMap object.
+func (b *ConfigMapBuilder) ConfigMap() *corev1.ConfigMap {
+	return &b.cm
+}
+
+// WithMeta sets TypeMeta and ObjectMeta.
+func (b *ConfigMapBuilder) WithMeta(name, namespace string) *ConfigMapBuilder {
+	b.cm.TypeMeta = metav1.TypeMeta{
+		Kind:       "ConfigMap",
+		APIVersion: "v1",
+	}
+	b.cm.ObjectMeta = metav1.ObjectMeta{
+		Name:      name,
+		Namespace: namespace,
+	}
+	return b
+}
+
+// WithOwner sets the owner of the CatalogSource object to the given owner.
+func (b *ConfigMapBuilder) WithOwner(owner *v1alpha1.CatalogSourceConfig) *ConfigMapBuilder {
+	b.cm.SetOwnerReferences(append(b.cm.GetOwnerReferences(),
+		[]metav1.OwnerReference{
+			*metav1.NewControllerRef(owner, owner.GroupVersionKind()),
+		}[0]))
+	return b
+}
+
+// WithData sets the Data.
+func (b *ConfigMapBuilder) WithData(data map[string]string) *ConfigMapBuilder {
+	b.cm.Data = data
+	return b
+}

--- a/pkg/catalogsourceconfig/configuring.go
+++ b/pkg/catalogsourceconfig/configuring.go
@@ -100,9 +100,10 @@ func (r *configuringReconciler) createCatalogData(csc *v1alpha1.CatalogSourceCon
 
 // createCatalogSource creates a new CatalogSource CR and all the resources it
 // requires.
-func (r *configuringReconciler) createCatalogSource(cr *v1alpha1.CatalogSourceConfig, data map[string]string) error {
+func (r *configuringReconciler) createCatalogSource(csc *v1alpha1.CatalogSourceConfig, data map[string]string) error {
 	// Create the ConfigMap that will be used by the CatalogSource.
-	catalogConfigMap := newConfigMap(cr, data)
+	catalogConfigMap := newConfigMap(csc, data)
+	r.log.Infof("Creating %s ConfigMap", catalogConfigMap.Name)
 	err := sdk.Create(catalogConfigMap)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		r.log.Errorf("Failed to create ConfigMap : %v", err)
@@ -110,7 +111,7 @@ func (r *configuringReconciler) createCatalogSource(cr *v1alpha1.CatalogSourceCo
 	}
 	r.log.Infof("Created ConfigMap %s", catalogConfigMap.Name)
 
-	catalogSource := newCatalogSource(cr, catalogConfigMap.Name)
+	catalogSource := newCatalogSource(csc, catalogConfigMap.Name)
 	err = sdk.Create(catalogSource)
 	if err != nil && !errors.IsAlreadyExists(err) {
 		r.log.Errorf("Failed to create CatalogSource : %v", err)


### PR DESCRIPTION
- Use csc instead of cr in createCatalogSource 
- Move ConfigMap data creation
- Use builder pattern to create ConfigMap and CatalogSource
