### PR TITLE
Fix yaml parsing error

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -825,6 +825,7 @@
   analyzer-name = "dep"
   analyzer-version = 1
   input-imports = [
+    "github.com/ghodss/yaml",
     "github.com/go-openapi/runtime",
     "github.com/go-openapi/runtime/client",
     "github.com/go-openapi/strfmt",
@@ -840,7 +841,6 @@
     "github.com/sirupsen/logrus",
     "github.com/stretchr/testify/assert",
     "github.com/stretchr/testify/require",
-    "gopkg.in/yaml.v2",
     "k8s.io/api/core/v1",
     "k8s.io/apimachinery/pkg/api/errors",
     "k8s.io/apimachinery/pkg/apis/meta/v1",

--- a/pkg/catalogsourceconfig/configuring.go
+++ b/pkg/catalogsourceconfig/configuring.go
@@ -76,18 +76,20 @@ func (r *configuringReconciler) createCatalogData(csc *v1alpha1.CatalogSourceCon
 		return data, fmt.Errorf("No packages specified in CatalogSourceConfig %s/%s", csc.Namespace, csc.Name)
 	}
 
-	// TBD: Do we create a CatalogSource per package?
-	for id := range packageIDs {
-		manifest, err := r.reader.Read(packageIDs[id])
-		if err != nil {
-			r.log.Errorf("Error \"%v\" getting manifest for package ID %s", err, packageIDs[id])
-			continue
-		}
-		// TODO: Add more error checking.
-		data[ConfigMapCRDName] += manifest.Data.CustomResourceDefinitions
-		data[ConfigMapCSVName] += manifest.Data.ClusterServiceVersions
-		data[ConfigMapPackageName] += manifest.Data.Packages
+	manifest, err := r.reader.Read(packageIDs)
+	if err != nil {
+		r.log.Errorf("Error \"%v\" getting manifest", err)
+		return nil, err
 	}
+
+	r.log.Infof("The following package(s) have been added: [%s]", packageIDs)
+
+	// TBD: Do we create a CatalogSource per package?
+	// TODO: Add more error checking
+	data[ConfigMapCRDName] = manifest.CustomResourceDefinitions
+	data[ConfigMapCSVName] = manifest.ClusterServiceVersions
+	data[ConfigMapPackageName] = manifest.Packages
+
 	return data, nil
 }
 

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -8,8 +8,8 @@ import (
 // New returns a new instance of datastore for Operator Manifest(s).
 func New() *memoryDatastore {
 	return &memoryDatastore{
-		manifests:   map[string]*OperatorManifest{},
-		unmarshaler: &blobUnmarshalerImpl{},
+		manifests: map[string]*OperatorManifest{},
+		parser:    &manifestYAMLParser{},
 	}
 }
 
@@ -40,8 +40,8 @@ type Writer interface {
 // memoryDatastore is an in-memory implementation of operator manifest datastore.
 // TODO: In future, it will be replaced by an indexable persistent datastore.
 type memoryDatastore struct {
-	manifests   map[string]*OperatorManifest
-	unmarshaler blobUnmarshaler
+	manifests map[string]*OperatorManifest
+	parser    ManifestYAMLParser
 }
 
 func (ds *memoryDatastore) Read(packageIDs []string) (*OperatorManifestData, error) {
@@ -59,12 +59,12 @@ func (ds *memoryDatastore) Read(packageIDs []string) (*OperatorManifestData, err
 		data.Packages = append(data.Packages, d.Packages...)
 	}
 
-	return ds.unmarshaler.Marshal(&data)
+	return ds.parser.Marshal(&data)
 }
 
 func (ds *memoryDatastore) Write(packages []*OperatorMetadata) error {
 	for _, pkg := range packages {
-		data, err := ds.unmarshaler.Unmarshal(pkg.RawYAML)
+		data, err := ds.parser.Unmarshal(pkg.RawYAML)
 		if err != nil {
 			return err
 		}

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -1,27 +1,29 @@
 package datastore
 
 import (
-	"errors"
+	"fmt"
 	"strings"
 )
 
-var (
-	ErrManifestNotFound = errors.New("manifest not found")
-)
-
-// New returns a new instance of datastore for Operator Manifest(s)
+// New returns a new instance of datastore for Operator Manifest(s).
 func New() *memoryDatastore {
 	return &memoryDatastore{
-		manifests:   map[string]*OperatorMetadata{},
+		manifests:   map[string]*OperatorManifest{},
 		unmarshaler: &blobUnmarshalerImpl{},
 	}
 }
 
-// Reader is the interface that wraps the Read method
+// Reader is the interface that wraps the Read method.
 //
-// Read returns the associated operator manifest given a package ID
+// Read prepares an operator manifest for a given set of package(s)
+// uniquely represeneted by the package ID(s) specified in packageIDs. It
+// returns an instance of OperatorManifestData that has the required set of
+// CRD(s), CSV(s) and package(s).
+//
+// The manifest returned can be used by the caller to create a ConfigMap object
+// for a catalog source (CatalogSource) in OLM.
 type Reader interface {
-	Read(packageID string) (*Manifest, error)
+	Read(packageIDs []string) (marshaled *OperatorManifestData, err error)
 }
 
 // Writer is an interface that is used to manage the underlying datastore
@@ -31,39 +33,48 @@ type Writer interface {
 	// all package(s) from underlying datastore.
 	GetPackageIDs() string
 
-	// Write stores the list of operator manifest(s) into datastore
+	// Write stores the list of operator manifest(s) into datastore.s
 	Write(packages []*OperatorMetadata) error
 }
 
 // memoryDatastore is an in-memory implementation of operator manifest datastore.
 // TODO: In future, it will be replaced by an indexable persistent datastore.
 type memoryDatastore struct {
-	manifests   map[string]*OperatorMetadata
+	manifests   map[string]*OperatorManifest
 	unmarshaler blobUnmarshaler
 }
 
-func (ds *memoryDatastore) Read(packageID string) (*Manifest, error) {
-	metadata, exists := ds.manifests[packageID]
-	if !exists {
-		return nil, ErrManifestNotFound
+func (ds *memoryDatastore) Read(packageIDs []string) (*OperatorManifestData, error) {
+	data := StructuredOperatorManifestData{}
+	for _, packageID := range packageIDs {
+		manifest, exists := ds.manifests[packageID]
+		if !exists {
+			return nil, fmt.Errorf("package [%s] not found", packageID)
+		}
+
+		d := manifest.Data
+
+		data.CustomResourceDefinitions = append(data.CustomResourceDefinitions, d.CustomResourceDefinitions...)
+		data.ClusterServiceVersions = append(data.ClusterServiceVersions, d.ClusterServiceVersions...)
+		data.Packages = append(data.Packages, d.Packages...)
 	}
 
-	manifest, err := ds.unmarshaler.Unmarshal(metadata.RawYAML)
-	if err != nil {
-		return nil, err
-	}
-
-	return manifest, nil
+	return ds.unmarshaler.Marshal(&data)
 }
 
 func (ds *memoryDatastore) Write(packages []*OperatorMetadata) error {
 	for _, pkg := range packages {
-		// Validate that the manifest is properly structured.
-		if _, err := ds.unmarshaler.Unmarshal(pkg.RawYAML); err != nil {
+		data, err := ds.unmarshaler.Unmarshal(pkg.RawYAML)
+		if err != nil {
 			return err
 		}
 
-		ds.manifests[pkg.ID()] = pkg
+		manifest := &OperatorManifest{
+			RegistryMetadata: pkg.RegistryMetadata,
+			Data:             *data,
+		}
+
+		ds.manifests[pkg.ID()] = manifest
 	}
 
 	return nil

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -24,12 +24,12 @@ func TestGetPackageIDs(t *testing.T) {
 	unmarshaler := NewMockblobUnmarshaler(controller)
 
 	ds := &memoryDatastore{
-		manifests:   map[string]*OperatorMetadata{},
+		manifests:   map[string]*OperatorManifest{},
 		unmarshaler: unmarshaler,
 	}
 
 	// We expect Unmarshal function to be invoked for each package.
-	unmarshaler.EXPECT().Unmarshal(gomock.Any()).Return(&Manifest{}, nil).Times(len(packages))
+	unmarshaler.EXPECT().Unmarshal(gomock.Any()).Return(&StructuredOperatorManifestData{}, nil).Times(len(packages))
 
 	err := ds.Write(packages)
 	require.NoError(t, err)

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -21,15 +21,15 @@ func TestGetPackageIDs(t *testing.T) {
 		helperNewOperatorMetadata("braz", "3"),
 	}
 
-	unmarshaler := NewMockblobUnmarshaler(controller)
+	parser := NewMockManifestYAMLParser(controller)
 
 	ds := &memoryDatastore{
-		manifests:   map[string]*OperatorManifest{},
-		unmarshaler: unmarshaler,
+		manifests: map[string]*OperatorManifest{},
+		parser:    parser,
 	}
 
 	// We expect Unmarshal function to be invoked for each package.
-	unmarshaler.EXPECT().Unmarshal(gomock.Any()).Return(&StructuredOperatorManifestData{}, nil).Times(len(packages))
+	parser.EXPECT().Unmarshal(gomock.Any()).Return(&StructuredOperatorManifestData{}, nil).Times(len(packages))
 
 	err := ds.Write(packages)
 	require.NoError(t, err)

--- a/pkg/datastore/manifest.go
+++ b/pkg/datastore/manifest.go
@@ -1,16 +1,17 @@
 package datastore
 
-// Manifest encapsulates operator manifest data.
-type Manifest struct {
-	// Publisher represents the publisher of this package.
-	Publisher string `yaml:"publisher"`
+import (
+	"encoding/json"
 
-	// Data reflects the content of the package manifest.
-	Data OperatorManifestData `yaml:"data"`
-}
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
 
 // OperatorManifestData encapsulates the list of CRD(s), CSV(s) and package(s)
-// associated with an operator manifest.
+// associated with an operator manifest. It contains a complete and
+// properly indented operator manifest.
+//
+// The Reader interface returns an object of this type so that it can be used to
+// create a ConfigMap object associated with a given operator manifest.
 type OperatorManifestData struct {
 	// CustomResourceDefinitions is the set of custom resource definition(s)
 	// associated with this package manifest.
@@ -22,4 +23,100 @@ type OperatorManifestData struct {
 
 	// Packages is the set of package(s) associated with this operator manifest.
 	Packages string `yaml:"packages"`
+}
+
+// OperatorManifest is a structured representation of an operator manifest.
+//
+// The Writer interface accepts a raw operator manifest and marshals it into
+// this type before writing it to the underlying storage.
+type OperatorManifest struct {
+	// RegistryMetadata uniquely identifies a given operator manifest and
+	// points to its source in remote registry.
+	RegistryMetadata RegistryMetadata
+
+	// Data is a structured representation of the given operator manifest.
+	Data StructuredOperatorManifestData
+}
+
+// StructuredOperatorManifestData is a structured representation of an operator
+// manifest. An operator manifest is a YAML document with the following sections:
+// - customResourceDefinitions
+// - clusterServiceVersions
+// - packages
+//
+// An operator manifest is unmarshaled into this type so that we can perform
+// certain operations like, but not limited to:
+// - Construct a new operator manifest object to be used by a CatalogSourceConfig
+//   by combining a set of existing operator manifest(s).
+// - Construct a new operator manifest object by extracting a certain
+//   operator/package from a a given operator manifest.
+type StructuredOperatorManifestData struct {
+	// CustomResourceDefinitions is the list of custom resource definition(s)
+	// associated with this operator manifest.
+	CustomResourceDefinitions []OLMObject `json:"customResourceDefinitions"`
+
+	// ClusterServiceVersions is the list of cluster service version(s)
+	//associated with this operators manifest.
+	ClusterServiceVersions []OLMObject `json:"clusterServiceVersions"`
+
+	// Packages is the list of package(s) associated with this operator manifest.
+	Packages []PackageManifest `json:"packages"`
+}
+
+// OLMObject is a structured representation of OLM object and is
+// used to unmarshal CustomResourceDefinition, ClusterServiceVersion
+// from raw operator manifest YAML.
+//
+// This allows us to achieve loose coupling with OLM type(s). We don't need to
+// parse the entire CustomResourceDefinition or ClusterServiceVersion object.
+type OLMObject struct {
+	// Type metadata.
+	metav1.TypeMeta `json:",inline"`
+
+	// Object metadata.
+	metav1.ObjectMeta `json:"metadata"`
+
+	// Spec is the raw representation of the 'spec' element of
+	// CustomResourceDefinition and ClusterServiceVersion object. Since we are
+	// not interested in the content of spec we are not parsing it.
+	Spec json.RawMessage `json:"spec"`
+}
+
+// PackageManifest holds information about a package, which is a reference to
+// one (or more) channels under a single package.
+//
+// The following type has been copied as is from OLM.
+// See https://github.com/operator-framework/operator-lifecycle-manager/blob/724b209ccfff33b6208cc5d05283800d6661d441/pkg/controller/registry/types.go#L78:6.
+//
+// We use it to unmarshal 'packages' element of an operator manifest.
+type PackageManifest struct {
+	// PackageName is the name of the overall package, ala `etcd`.
+	PackageName string `json:"packageName"`
+
+	// Channels are the declared channels for the package,
+	// ala `stable` or `alpha`.
+	Channels []PackageChannel `json:"channels"`
+
+	// DefaultChannelName is, if specified, the name of the default channel for
+	// the package. The default channel will be installed if no other channel is
+	// explicitly given. If the package has a single channel, then that
+	// channel is implicitly the default.
+	DefaultChannelName string `json:"defaultChannel"`
+}
+
+// PackageChannel defines a single channel under a package, pointing to a
+// version of that package.
+//
+// The following type has been directly copied as is from OLM.
+// See https://github.com/operator-framework/operator-lifecycle-manager/blob/724b209ccfff33b6208cc5d05283800d6661d441/pkg/controller/registry/types.go#L105.
+//
+// We use it to unmarshal 'packages/package/channels' element of
+// an operator manifest.
+type PackageChannel struct {
+	// Name is the name of the channel, e.g. `alpha` or `stable`.
+	Name string `json:"name"`
+
+	// CurrentCSVName defines a reference to the CSV holding the version of
+	// this package currently for the channel.
+	CurrentCSVName string `json:"currentCSV"`
 }

--- a/pkg/datastore/metadata.go
+++ b/pkg/datastore/metadata.go
@@ -4,33 +4,38 @@ import (
 	"fmt"
 )
 
-// OperatorMetadata encapsulates operator metadata and manifest
-// associated with a package.
+// OperatorMetadata encapsulates registry metadata and blob associated with
+// an operator manifest.
+//
+// When an operator manifest is downloaded from a remote registry, it should be
+// serialized into this type so that it can be further processed by datastore
+// package.
 type OperatorMetadata struct {
 	// Metadata that uniquely identifies the given operator manifest in registry.
 	RegistryMetadata RegistryMetadata
 
 	// Operator manifest(s) in raw YAML format that contains a set of CRD(s),
-	// CSV(s) and package channel(s).
+	// CSV(s) and package(s).
 	RawYAML []byte
 }
 
 // RegistryMetadata encapsulates metadata that uniquely describes the source of
-// a given operator manifest(s) in a registry.
+// the given operator manifest in registry.
 type RegistryMetadata struct {
-	// Namespace is the namespace in app registry server
-	// under which the package is hosted.
+	// Namespace is the namespace in application registry server
+	// under which the given operator manifest is hosted.
 	Namespace string
 
-	// Repository is the repository name for the specified package
-	// in app registry.
+	// Repository is the repository that contains the given operator manifest.
+	// The repository is located under the given namespace in application
+	// registry.
 	Repository string
 
-	// Release represents the release or version number of the given package.
+	// Release represents the version number of the given operator manifest.
 	Release string
 
 	// Digest is the sha256 hash value that uniquely corresponds to the blob
-	// associated with the release.
+	// associated with this particular release of the operator manifest.
 	Digest string
 }
 

--- a/pkg/datastore/mock_unmarshaler.go
+++ b/pkg/datastore/mock_unmarshaler.go
@@ -9,31 +9,31 @@ import (
 	reflect "reflect"
 )
 
-// MockblobUnmarshaler is a mock of blobUnmarshaler interface
-type MockblobUnmarshaler struct {
+// MockManifestYAMLParser is a mock of ManifestYAMLParser interface
+type MockManifestYAMLParser struct {
 	ctrl     *gomock.Controller
-	recorder *MockblobUnmarshalerMockRecorder
+	recorder *MockManifestYAMLParserMockRecorder
 }
 
-// MockblobUnmarshalerMockRecorder is the mock recorder for MockblobUnmarshaler
-type MockblobUnmarshalerMockRecorder struct {
-	mock *MockblobUnmarshaler
+// MockManifestYAMLParserMockRecorder is the mock recorder for MockManifestYAMLParser
+type MockManifestYAMLParserMockRecorder struct {
+	mock *MockManifestYAMLParser
 }
 
-// NewMockblobUnmarshaler creates a new mock instance
-func NewMockblobUnmarshaler(ctrl *gomock.Controller) *MockblobUnmarshaler {
-	mock := &MockblobUnmarshaler{ctrl: ctrl}
-	mock.recorder = &MockblobUnmarshalerMockRecorder{mock}
+// NewMockManifestYAMLParser creates a new mock instance
+func NewMockManifestYAMLParser(ctrl *gomock.Controller) *MockManifestYAMLParser {
+	mock := &MockManifestYAMLParser{ctrl: ctrl}
+	mock.recorder = &MockManifestYAMLParserMockRecorder{mock}
 	return mock
 }
 
 // EXPECT returns an object that allows the caller to indicate expected use
-func (m *MockblobUnmarshaler) EXPECT() *MockblobUnmarshalerMockRecorder {
+func (m *MockManifestYAMLParser) EXPECT() *MockManifestYAMLParserMockRecorder {
 	return m.recorder
 }
 
 // Unmarshal mocks base method
-func (m *MockblobUnmarshaler) Unmarshal(rawYAML []byte) (*StructuredOperatorManifestData, error) {
+func (m *MockManifestYAMLParser) Unmarshal(rawYAML []byte) (*StructuredOperatorManifestData, error) {
 	ret := m.ctrl.Call(m, "Unmarshal", rawYAML)
 	ret0, _ := ret[0].(*StructuredOperatorManifestData)
 	ret1, _ := ret[1].(error)
@@ -41,12 +41,12 @@ func (m *MockblobUnmarshaler) Unmarshal(rawYAML []byte) (*StructuredOperatorMani
 }
 
 // Unmarshal indicates an expected call of Unmarshal
-func (mr *MockblobUnmarshalerMockRecorder) Unmarshal(rawYAML interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unmarshal", reflect.TypeOf((*MockblobUnmarshaler)(nil).Unmarshal), rawYAML)
+func (mr *MockManifestYAMLParserMockRecorder) Unmarshal(rawYAML interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unmarshal", reflect.TypeOf((*MockManifestYAMLParser)(nil).Unmarshal), rawYAML)
 }
 
 // Marshal mocks base method
-func (m *MockblobUnmarshaler) Marshal(marshaled *StructuredOperatorManifestData) (*OperatorManifestData, error) {
+func (m *MockManifestYAMLParser) Marshal(marshaled *StructuredOperatorManifestData) (*OperatorManifestData, error) {
 	ret := m.ctrl.Call(m, "Marshal", marshaled)
 	ret0, _ := ret[0].(*OperatorManifestData)
 	ret1, _ := ret[1].(error)
@@ -54,6 +54,6 @@ func (m *MockblobUnmarshaler) Marshal(marshaled *StructuredOperatorManifestData)
 }
 
 // Marshal indicates an expected call of Marshal
-func (mr *MockblobUnmarshalerMockRecorder) Marshal(marshaled interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Marshal", reflect.TypeOf((*MockblobUnmarshaler)(nil).Marshal), marshaled)
+func (mr *MockManifestYAMLParserMockRecorder) Marshal(marshaled interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Marshal", reflect.TypeOf((*MockManifestYAMLParser)(nil).Marshal), marshaled)
 }

--- a/pkg/datastore/mock_unmarshaler.go
+++ b/pkg/datastore/mock_unmarshaler.go
@@ -33,14 +33,27 @@ func (m *MockblobUnmarshaler) EXPECT() *MockblobUnmarshalerMockRecorder {
 }
 
 // Unmarshal mocks base method
-func (m *MockblobUnmarshaler) Unmarshal(in []byte) (*Manifest, error) {
-	ret := m.ctrl.Call(m, "Unmarshal", in)
-	ret0, _ := ret[0].(*Manifest)
+func (m *MockblobUnmarshaler) Unmarshal(rawYAML []byte) (*StructuredOperatorManifestData, error) {
+	ret := m.ctrl.Call(m, "Unmarshal", rawYAML)
+	ret0, _ := ret[0].(*StructuredOperatorManifestData)
 	ret1, _ := ret[1].(error)
 	return ret0, ret1
 }
 
 // Unmarshal indicates an expected call of Unmarshal
-func (mr *MockblobUnmarshalerMockRecorder) Unmarshal(in interface{}) *gomock.Call {
-	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unmarshal", reflect.TypeOf((*MockblobUnmarshaler)(nil).Unmarshal), in)
+func (mr *MockblobUnmarshalerMockRecorder) Unmarshal(rawYAML interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Unmarshal", reflect.TypeOf((*MockblobUnmarshaler)(nil).Unmarshal), rawYAML)
+}
+
+// Marshal mocks base method
+func (m *MockblobUnmarshaler) Marshal(marshaled *StructuredOperatorManifestData) (*OperatorManifestData, error) {
+	ret := m.ctrl.Call(m, "Marshal", marshaled)
+	ret0, _ := ret[0].(*OperatorManifestData)
+	ret1, _ := ret[1].(error)
+	return ret0, ret1
+}
+
+// Marshal indicates an expected call of Marshal
+func (mr *MockblobUnmarshalerMockRecorder) Marshal(marshaled interface{}) *gomock.Call {
+	return mr.mock.ctrl.RecordCallWithMethodType(mr.mock, "Marshal", reflect.TypeOf((*MockblobUnmarshaler)(nil).Marshal), marshaled)
 }

--- a/pkg/datastore/unmarshaler.go
+++ b/pkg/datastore/unmarshaler.go
@@ -1,21 +1,98 @@
 package datastore
 
 import (
-	yaml "gopkg.in/yaml.v2"
+	"encoding/json"
+	"fmt"
+
+	"github.com/ghodss/yaml"
 )
 
 type blobUnmarshaler interface {
-	// Unmarshal unmarshals package blob into structured representations
-	Unmarshal(in []byte) (*Manifest, error)
+	// Unmarshal unmarshals raw operator manifest YAML into structured
+	// representation.
+	//
+	// The function accepts raw yaml specified in rawYAML and converts it into
+	// an instance of StructuredOperatorManifestData.
+	Unmarshal(rawYAML []byte) (marshaled *StructuredOperatorManifestData, err error)
+
+	// Marshal marshals a structured representation of an operator manifest into
+	// raw YAML representation so that it can be used to create a configMap
+	// object for a catalog source in OLM.
+	//
+	// The function accepts a structured representation of an operator manifest
+	// specified in marshaled and returns a raw yaml representation of it.
+	Marshal(marshaled *StructuredOperatorManifestData) (*OperatorManifestData, error)
 }
 
 type blobUnmarshalerImpl struct{}
 
-func (*blobUnmarshalerImpl) Unmarshal(in []byte) (*Manifest, error) {
-	m := &Manifest{}
-	if err := yaml.Unmarshal(in, m); err != nil {
-		return nil, err
+func (*blobUnmarshalerImpl) Unmarshal(rawYAML []byte) (*StructuredOperatorManifestData, error) {
+	var manifestYAML struct {
+		Data OperatorManifestData `yaml:"data"`
 	}
 
-	return m, nil
+	if err := yaml.Unmarshal(rawYAML, &manifestYAML); err != nil {
+		return nil, fmt.Errorf("error parsing raw YAML : %s", err)
+	}
+
+	var crds, csvs []OLMObject
+	var packages []PackageManifest
+	data := manifestYAML.Data
+
+	crdJSONRaw, err := yaml.YAMLToJSON([]byte(data.CustomResourceDefinitions))
+	if err != nil {
+		return nil, fmt.Errorf("error converting CRD list (YAML) to JSON : %s", err)
+	}
+	if err := json.Unmarshal(crdJSONRaw, &crds); err != nil {
+		return nil, fmt.Errorf("error parsing CRD list (JSON) : %s", err)
+	}
+
+	csvJSONRaw, err := yaml.YAMLToJSON([]byte(data.ClusterServiceVersions))
+	if err != nil {
+		return nil, fmt.Errorf("error converting CSV list (YAML) to JSON : %s", err)
+	}
+	if err := json.Unmarshal(csvJSONRaw, &csvs); err != nil {
+		return nil, fmt.Errorf("error parsing CSV list (JSON) : %s", err)
+	}
+
+	packageJSONRaw, err := yaml.YAMLToJSON([]byte(data.Packages))
+	if err != nil {
+		return nil, fmt.Errorf("error converting package list (JSON) to YAML : %s", err)
+	}
+	if err := json.Unmarshal(packageJSONRaw, &packages); err != nil {
+		return nil, fmt.Errorf("error parsing package list (JSON) : %s", err)
+	}
+
+	marshaled := &StructuredOperatorManifestData{
+		CustomResourceDefinitions: crds,
+		ClusterServiceVersions:    csvs,
+		Packages:                  packages,
+	}
+
+	return marshaled, nil
+}
+
+func (*blobUnmarshalerImpl) Marshal(marshaled *StructuredOperatorManifestData) (*OperatorManifestData, error) {
+	crdRaw, err := yaml.Marshal(marshaled.CustomResourceDefinitions)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling CRD list into yaml : %s", err)
+	}
+
+	csvRaw, err := yaml.Marshal(marshaled.ClusterServiceVersions)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling CSV list into YAML : %s", err)
+	}
+
+	packageRaw, err := yaml.Marshal(marshaled.Packages)
+	if err != nil {
+		return nil, fmt.Errorf("error marshaling package list into YAML : %s", err)
+	}
+
+	data := &OperatorManifestData{
+		CustomResourceDefinitions: string(crdRaw),
+		ClusterServiceVersions:    string(csvRaw),
+		Packages:                  string(packageRaw),
+	}
+
+	return data, nil
 }

--- a/pkg/datastore/unmarshaler.go
+++ b/pkg/datastore/unmarshaler.go
@@ -7,7 +7,9 @@ import (
 	"github.com/ghodss/yaml"
 )
 
-type blobUnmarshaler interface {
+// ManifestYAMLParser is an interface that is responsible for marshaling raw operator
+// manifest into structured representation and vice versa.
+type ManifestYAMLParser interface {
 	// Unmarshal unmarshals raw operator manifest YAML into structured
 	// representation.
 	//
@@ -24,9 +26,9 @@ type blobUnmarshaler interface {
 	Marshal(marshaled *StructuredOperatorManifestData) (*OperatorManifestData, error)
 }
 
-type blobUnmarshalerImpl struct{}
+type manifestYAMLParser struct{}
 
-func (*blobUnmarshalerImpl) Unmarshal(rawYAML []byte) (*StructuredOperatorManifestData, error) {
+func (*manifestYAMLParser) Unmarshal(rawYAML []byte) (*StructuredOperatorManifestData, error) {
 	var manifestYAML struct {
 		Data OperatorManifestData `yaml:"data"`
 	}
@@ -72,7 +74,7 @@ func (*blobUnmarshalerImpl) Unmarshal(rawYAML []byte) (*StructuredOperatorManife
 	return marshaled, nil
 }
 
-func (*blobUnmarshalerImpl) Marshal(marshaled *StructuredOperatorManifestData) (*OperatorManifestData, error) {
+func (*manifestYAMLParser) Marshal(marshaled *StructuredOperatorManifestData) (*OperatorManifestData, error) {
 	crdRaw, err := yaml.Marshal(marshaled.CustomResourceDefinitions)
 	if err != nil {
 		return nil, fmt.Errorf("error marshaling CRD list into yaml : %s", err)

--- a/pkg/datastore/unmarshaler_test.go
+++ b/pkg/datastore/unmarshaler_test.go
@@ -85,7 +85,7 @@ data:
 // expect it to get unmarshaled into corresponding structured type.
 func TestUnmarshal_ManifestHasCRD_SuccessfullyParsed(t *testing.T) {
 
-	u := blobUnmarshalerImpl{}
+	u := manifestYAMLParser{}
 	dataGot, err := u.Unmarshal([]byte(rawCRDs))
 
 	assert.NoError(t, err)
@@ -99,7 +99,7 @@ func TestUnmarshal_ManifestHasCRD_SuccessfullyParsed(t *testing.T) {
 // For a given set of package(s) in a raw operator manifest YAML document, we
 // expect it to get unmarshaled into corresponding structured type.
 func TestUnmarshal_ManifestHasPackages_SuccessfullyParsed(t *testing.T) {
-	u := blobUnmarshalerImpl{}
+	u := manifestYAMLParser{}
 	dataGot, err := u.Unmarshal([]byte(rawPackages))
 
 	assert.NoError(t, err)
@@ -120,7 +120,7 @@ func TestMarshal(t *testing.T) {
 		Packages:                  packagesWant,
 	}
 
-	u := blobUnmarshalerImpl{}
+	u := manifestYAMLParser{}
 	rawGot, err := u.Marshal(&marshaled)
 
 	assert.NoError(t, err)

--- a/pkg/datastore/unmarshaler_test.go
+++ b/pkg/datastore/unmarshaler_test.go
@@ -4,26 +4,128 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-func TestUnmarshal(t *testing.T) {
+var (
 	// Do not use tabs for indentation as yaml forbids tabs http://yaml.org/faq.html
-	data := `
-publisher: redhat
+	rawCRDs = `
 data:
-  customResourceDefinitions: "my crds"
-  clusterServiceVersions: "my csvs"
-  packages: "my packages"
+  customResourceDefinitions: |-      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: jbossapps-1.jboss.middleware.redhat.com
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: jbossapps-2.jboss.middleware.redhat.com
 `
 
+	crdWant = []OLMObject{
+		OLMObject{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "apiextensions.k8s.io/v1beta1",
+				Kind:       "CustomResourceDefinition",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "jbossapps-1.jboss.middleware.redhat.com",
+			},
+		},
+		OLMObject{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "apiextensions.k8s.io/v1beta1",
+				Kind:       "CustomResourceDefinition",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "jbossapps-2.jboss.middleware.redhat.com",
+			},
+		},
+	}
+
+	// Do not use tabs for indentation as yaml forbids tabs http://yaml.org/faq.html
+	rawPackages = `
+data:
+  packages: |-
+    - #! package-manifest: ./deploy/chart/catalog_resources/rh-operators/etcdoperator.v0.9.2.clusterserviceversion.yaml
+      packageName: etcd
+      channels:
+        - name: alpha
+          currentCSV: etcdoperator.v0.9.2
+        - name: nightly
+          currentCSV: etcdoperator.v0.9.2-nightly
+      defaultChannel: alpha
+`
+
+	packagesWant = []PackageManifest{
+		PackageManifest{
+			PackageName:        "etcd",
+			DefaultChannelName: "alpha",
+			Channels: []PackageChannel{
+				PackageChannel{Name: "alpha", CurrentCSVName: "etcdoperator.v0.9.2"},
+				PackageChannel{Name: "nightly", CurrentCSVName: "etcdoperator.v0.9.2-nightly"},
+			},
+		},
+	}
+
+	csvWant = []OLMObject{
+		OLMObject{
+			TypeMeta: metav1.TypeMeta{
+				APIVersion: "app.coreos.com/v1alpha1",
+				Kind:       "ClusterServiceVersion-v1",
+			},
+			ObjectMeta: metav1.ObjectMeta{
+				Name: "jbossapp-operator.v0.1.0",
+			},
+		},
+	}
+)
+
+// For a given set of CRD(s) in a raw operator manifest YAML document, we
+// expect it to get unmarshaled into corresponding structured type.
+func TestUnmarshal_ManifestHasCRD_SuccessfullyParsed(t *testing.T) {
+
 	u := blobUnmarshalerImpl{}
-	manifest, err := u.Unmarshal([]byte(data))
+	dataGot, err := u.Unmarshal([]byte(rawCRDs))
 
-	require.NoError(t, err)
+	assert.NoError(t, err)
+	assert.NotNil(t, dataGot)
 
-	assert.Equal(t, "redhat", manifest.Publisher)
-	assert.Equal(t, "my crds", manifest.Data.CustomResourceDefinitions)
-	assert.Equal(t, "my csvs", manifest.Data.ClusterServiceVersions)
-	assert.Equal(t, "my packages", manifest.Data.Packages)
+	crdGot := dataGot.CustomResourceDefinitions
+
+	assert.ElementsMatch(t, crdWant, crdGot)
+}
+
+// For a given set of package(s) in a raw operator manifest YAML document, we
+// expect it to get unmarshaled into corresponding structured type.
+func TestUnmarshal_ManifestHasPackages_SuccessfullyParsed(t *testing.T) {
+	u := blobUnmarshalerImpl{}
+	dataGot, err := u.Unmarshal([]byte(rawPackages))
+
+	assert.NoError(t, err)
+	assert.NotNil(t, dataGot)
+
+	packagesGot := dataGot.Packages
+
+	assert.ElementsMatch(t, packagesWant, packagesGot)
+}
+
+// Given a structured representation of an operator manifest we should be able
+// to convert it to raw YAML representation so that a ConfigMap object for
+// catalog source (CatalogSource) can be created successfully.
+func TestMarshal(t *testing.T) {
+	marshaled := StructuredOperatorManifestData{
+		CustomResourceDefinitions: crdWant,
+		ClusterServiceVersions:    csvWant,
+		Packages:                  packagesWant,
+	}
+
+	u := blobUnmarshalerImpl{}
+	rawGot, err := u.Marshal(&marshaled)
+
+	assert.NoError(t, err)
+	assert.NotNil(t, rawGot)
+	assert.NotEmpty(t, rawGot.Packages)
+	assert.NotEmpty(t, rawGot.CustomResourceDefinitions)
+	assert.NotEmpty(t, rawGot.ClusterServiceVersions)
 }


### PR DESCRIPTION
When datastore combines multiple manifest(s) into one, it yields malformatted YAML. This renders the associated ConfigMap and CatalogSource objects unusable as OLM throws a parsing error when
it tries to load the manifest from the ConfigMap. 

The reason "combine" operation yields malformatted YAML is because it concatenates string representation of OLM object(s) while combining multiple manifest(s). In order to resolve this issue,
we need to do the following:
- Implement more structured unmarshaling of manifest YAML document(s) so that we can break a manifest down into a set of CRD, CSV and package object(s).
- When we combine multiple manifest(s) we merge array(s) of OLM object(s) instead of string concatenation.
