### PR TITLE
Handle CatalogSourceConfig updates

### DIFF
--- a/pkg/catalogsourceconfig/cache.go
+++ b/pkg/catalogsourceconfig/cache.go
@@ -1,0 +1,97 @@
+package catalogsourceconfig
+
+import (
+	"sort"
+
+	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// cache is an in-memory cache of CatalogSourceConfig UID : Spec.
+// Note: This is a temporary construct which will be removed when we move to
+// using the Operator Registry as the data store for CatalogSources. If this
+// is required even after, then it should be replaced with an existing thread
+// safe caching library like go-cache or cash.
+type cache struct {
+	entries map[types.UID]*v1alpha1.CatalogSourceConfigSpec
+}
+
+// Cache is the interface for the CatalogSourceConfig caching functions.
+type Cache interface {
+	// Get returns the cached CatalogSourceConfigSpec of the CatalogSourceConfig
+	// object if it is present in the cache. The bool value indicates if the
+	// Spec for the object was in the cache or not.
+	Get(csc *v1alpha1.CatalogSourceConfig) (*v1alpha1.CatalogSourceConfigSpec, bool)
+
+	// IsEntryStale figures out if the CatalogSourceConfigSpec in the
+	// CatalogSourceConfig object matches its entry in the cache. Cache is
+	// considered stale if it does not match. pkgStale is true then the Packages
+	// have changed. If targetStale is true then the TargetNamespace has
+	// changed. This implies that pkgStale is also true.
+	IsEntryStale(csc *v1alpha1.CatalogSourceConfig) (pkgStale bool, targetStale bool)
+
+	// Evict removes the entry for the CatalogSourceConfig object from the cache.
+	Evict(csc *v1alpha1.CatalogSourceConfig)
+
+	// Set adds the CatalogSourceConfigSpec for the CatalogSourceConfig object
+	// into the cache.
+	Set(csc *v1alpha1.CatalogSourceConfig)
+}
+
+func (c *cache) Get(csc *v1alpha1.CatalogSourceConfig) (*v1alpha1.CatalogSourceConfigSpec, bool) {
+	entry, found := c.entries[csc.ObjectMeta.UID]
+	if !found {
+		return &v1alpha1.CatalogSourceConfigSpec{}, false
+	}
+	return entry, true
+}
+
+func (c *cache) IsEntryStale(csc *v1alpha1.CatalogSourceConfig) (bool, bool) {
+	spec, found := c.Get(csc)
+	if !found {
+		return false, false
+	}
+
+	if spec.TargetNamespace != csc.Spec.TargetNamespace {
+		return true, true
+	}
+
+	cachedPackages := GetPackageIDs(spec.Packages)
+	inPackageIDs := GetPackageIDs(csc.Spec.Packages)
+
+	if len(cachedPackages) != len(inPackageIDs) {
+		return true, false
+	}
+
+	sort.Strings(cachedPackages)
+	sort.Strings(inPackageIDs)
+	for i, v := range cachedPackages {
+		if v != inPackageIDs[i] {
+			return true, false
+		}
+	}
+	return false, false
+}
+
+func (c *cache) Evict(csc *v1alpha1.CatalogSourceConfig) {
+	UID := csc.ObjectMeta.UID
+	_, found := c.entries[UID]
+	if !found {
+		return
+	}
+	delete(c.entries, UID)
+}
+
+func (c *cache) Set(csc *v1alpha1.CatalogSourceConfig) {
+	c.entries[csc.ObjectMeta.UID] = &v1alpha1.CatalogSourceConfigSpec{
+		Packages:        csc.Spec.Packages,
+		TargetNamespace: csc.Spec.TargetNamespace,
+	}
+}
+
+// NewCache returns an initialized Cache
+func NewCache() Cache {
+	return &cache{
+		entries: make(map[types.UID]*v1alpha1.CatalogSourceConfigSpec),
+	}
+}

--- a/pkg/catalogsourceconfig/cache_test.go
+++ b/pkg/catalogsourceconfig/cache_test.go
@@ -1,0 +1,95 @@
+package catalogsourceconfig_test
+
+import (
+	"os"
+	"testing"
+
+	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/catalogsourceconfig"
+	"github.com/stretchr/testify/assert"
+
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+var cache catalogsourceconfig.Cache
+var inPackages []string
+var csc *v1alpha1.CatalogSourceConfig
+var testUID types.UID
+
+func TestMain(m *testing.M) {
+	cache = catalogsourceconfig.NewCache()
+
+	testUID = types.UID("123")
+	inPackages = []string{"foo", "bar"}
+	csc = helperNewCatalogSourceConfig(testUID, "target", "foo,bar")
+	cache.Set(csc)
+
+	exitCode := m.Run()
+	os.Exit(exitCode)
+}
+
+// TestGet tests if an CatalogSourceConfig object inserted into the cache is found.
+func TestGet(t *testing.T) {
+	spec, found := cache.Get(csc)
+	outPackages := catalogsourceconfig.GetPackageIDs(spec.Packages)
+	assert.ElementsMatch(t, inPackages, outPackages)
+	assert.True(t, found)
+}
+
+// Test cache eviction
+func TestEviction(t *testing.T) {
+	evictcsc := helperNewCatalogSourceConfig("678", "target", "foo,bar")
+	cache.Set(evictcsc)
+	cache.Evict(evictcsc)
+	_, found := cache.Get(evictcsc)
+	assert.False(t, found)
+}
+
+// TestNotFound asserts that a CatalogSourceConfig object not inserted into
+// cache is not found.
+func TestNotFound(t *testing.T) {
+	_, found := cache.Get(helperNewCatalogSourceConfig(types.UID("456"), "target", "foo,bar"))
+	assert.False(t, found)
+}
+
+// TestStale tests various combination of cache staleness
+func TestStale(t *testing.T) {
+	// Test if cache is not stale given a CatalogSourceConfig with the expected
+	// packages.
+	pkgStale, targetStale := cache.IsEntryStale(csc)
+	assert.False(t, pkgStale)
+	assert.False(t, targetStale)
+
+	// Test if cache is not stale given a CatalogSourceConfig with the expected
+	// packages in different order.
+	csc = helperNewCatalogSourceConfig(testUID, "target", "bar,foo")
+	pkgStale, targetStale = cache.IsEntryStale(csc)
+	assert.False(t, pkgStale)
+	assert.False(t, targetStale)
+
+	// Test if cache is stale given a CatalogSourceConfig with new packages.
+	csc = helperNewCatalogSourceConfig(testUID, "target", "foo,bar,baz")
+	pkgStale, targetStale = cache.IsEntryStale(csc)
+	assert.True(t, pkgStale)
+	assert.False(t, targetStale)
+
+	// Test if cache is stale given a CatalogSourceConfig with the a new
+	// TargetNamespace.
+	csc = helperNewCatalogSourceConfig(testUID, "newtarget", "foo,bar,baz")
+	pkgStale, targetStale = cache.IsEntryStale(csc)
+	assert.True(t, pkgStale)
+	assert.True(t, targetStale)
+}
+
+func helperNewCatalogSourceConfig(UID types.UID, targetNamespace, packages string) *v1alpha1.CatalogSourceConfig {
+	return &v1alpha1.CatalogSourceConfig{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: UID,
+		},
+		Spec: v1alpha1.CatalogSourceConfigSpec{
+			TargetNamespace: targetNamespace,
+			Packages:        packages,
+		},
+	}
+}

--- a/pkg/catalogsourceconfig/catalogsourcebuilder.go
+++ b/pkg/catalogsourceconfig/catalogsourcebuilder.go
@@ -16,12 +16,18 @@ func (b *CatalogSourceBuilder) CatalogSource() *olm.CatalogSource {
 	return &b.cs
 }
 
-// WithMeta sets basic TypeMeta and ObjectMeta.
-func (b *CatalogSourceBuilder) WithMeta(name, namespace string) *CatalogSourceBuilder {
+// WithTypeMeta sets basic TypeMeta.
+func (b *CatalogSourceBuilder) WithTypeMeta() *CatalogSourceBuilder {
 	b.cs.TypeMeta = metav1.TypeMeta{
 		Kind:       olm.CatalogSourceKind,
 		APIVersion: olm.CatalogSourceCRDAPIVersion,
 	}
+	return b
+}
+
+// WithMeta sets basic TypeMeta and ObjectMeta.
+func (b *CatalogSourceBuilder) WithMeta(name, namespace string) *CatalogSourceBuilder {
+	b.WithTypeMeta()
 	b.cs.ObjectMeta = metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,

--- a/pkg/catalogsourceconfig/configmapbuilder.go
+++ b/pkg/catalogsourceconfig/configmapbuilder.go
@@ -16,12 +16,18 @@ func (b *ConfigMapBuilder) ConfigMap() *corev1.ConfigMap {
 	return &b.cm
 }
 
-// WithMeta sets TypeMeta and ObjectMeta.
-func (b *ConfigMapBuilder) WithMeta(name, namespace string) *ConfigMapBuilder {
+// WithTypeMeta sets TypeMeta.
+func (b *ConfigMapBuilder) WithTypeMeta() *ConfigMapBuilder {
 	b.cm.TypeMeta = metav1.TypeMeta{
 		Kind:       "ConfigMap",
 		APIVersion: "v1",
 	}
+	return b
+}
+
+// WithMeta sets TypeMeta and ObjectMeta.
+func (b *ConfigMapBuilder) WithMeta(name, namespace string) *ConfigMapBuilder {
+	b.WithTypeMeta()
 	b.cm.ObjectMeta = metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,

--- a/pkg/catalogsourceconfig/factory.go
+++ b/pkg/catalogsourceconfig/factory.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/sirupsen/logrus"
 
+	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
@@ -14,8 +15,8 @@ import (
 // PhaseReconcilerFactory is the interface that wraps GetPhaseReconciler method.
 //
 // GetPhaseReconciler returns an appropriate phase.Reconciler based on the
-// current phase of an CatalogSourceConfig object.
-// The following chain shows how an CatalogSourceConfig object progresses through
+// current phase of the csc object.
+// The following chain shows how a CatalogSourceConfig object progresses through
 // a series of transitions from the initial phase to complete reconciled state.
 //
 //  Initial --> Configuring --> Succeeded
@@ -26,22 +27,31 @@ import (
 //
 //  On error, the object is transitioned into "Failed" phase.
 type PhaseReconcilerFactory interface {
-	GetPhaseReconciler(log *logrus.Entry, currentPhase string) (Reconciler, error)
+	GetPhaseReconciler(log *logrus.Entry, csc *v1alpha1.CatalogSourceConfig) (Reconciler, error)
 }
 
 // phaseReconcilerFactory implements PhaseReconcilerFactory interface.
 type phaseReconcilerFactory struct {
 	reader datastore.Reader
 	client client.Client
+	cache  Cache
 }
 
-func (f *phaseReconcilerFactory) GetPhaseReconciler(log *logrus.Entry, currentPhase string) (Reconciler, error) {
+func (f *phaseReconcilerFactory) GetPhaseReconciler(log *logrus.Entry, csc *v1alpha1.CatalogSourceConfig) (Reconciler, error) {
+	// Check if the cache is stale. A stale cache entry is an indicator that the
+	// object has changed and requires updating.
+	pkgStale, targetStale := f.cache.IsEntryStale(csc)
+	if pkgStale || targetStale {
+		return NewUpdateReconciler(log, f.client, f.cache, targetStale), nil
+	}
+
+	currentPhase := csc.Status.CurrentPhase.Name
 	switch currentPhase {
 	case phase.Initial:
 		return NewInitialReconciler(log), nil
 
 	case phase.Configuring:
-		return NewConfiguringReconciler(log, f.reader, f.client), nil
+		return NewConfiguringReconciler(log, f.reader, f.client, f.cache), nil
 
 	case phase.Succeeded:
 		return NewSucceededReconciler(log), nil

--- a/pkg/catalogsourceconfig/handler.go
+++ b/pkg/catalogsourceconfig/handler.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -16,7 +15,6 @@ import (
 func NewHandler(mgr manager.Manager, client client.Client) Handler {
 	return &catalogsourceconfighandler{
 		client: client,
-		scheme: mgr.GetScheme(),
 		factory: &phaseReconcilerFactory{
 			reader: datastore.Cache,
 			client: client,
@@ -33,7 +31,6 @@ type Handler interface {
 
 type catalogsourceconfighandler struct {
 	client       client.Client
-	scheme       *runtime.Scheme
 	factory      PhaseReconcilerFactory
 	transitioner phase.Transitioner
 	reader       datastore.Reader

--- a/pkg/catalogsourceconfig/handler.go
+++ b/pkg/catalogsourceconfig/handler.go
@@ -13,13 +13,13 @@ import (
 	"github.com/sirupsen/logrus"
 )
 
-func NewHandler(mgr manager.Manager) Handler {
+func NewHandler(mgr manager.Manager, client client.Client) Handler {
 	return &catalogsourceconfighandler{
-		client: mgr.GetClient(),
+		client: client,
 		scheme: mgr.GetScheme(),
 		factory: &phaseReconcilerFactory{
 			reader: datastore.Cache,
-			client: mgr.GetClient(),
+			client: client,
 		},
 		transitioner: phase.NewTransitioner(),
 		reader:       datastore.Cache,

--- a/pkg/catalogsourceconfig/update.go
+++ b/pkg/catalogsourceconfig/update.go
@@ -1,0 +1,93 @@
+package catalogsourceconfig
+
+import (
+	"context"
+	"fmt"
+
+	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/phase"
+	"github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewUpdateReconciler returns a Reconciler that reconciles a
+// CatalogSourceConfig object that needs to be updated
+func NewUpdateReconciler(log *logrus.Entry, client client.Client, cache Cache, targetChanged bool) Reconciler {
+	return &updateReconciler{
+		cache:         cache,
+		client:        client,
+		log:           log,
+		targetChanged: targetChanged,
+	}
+}
+
+// updateReconciler is an implementation of Reconciler interface that
+// reconciles an CatalogSourceConfig object that needs to be updated.
+type updateReconciler struct {
+	cache         Cache
+	client        client.Client
+	log           *logrus.Entry
+	targetChanged bool
+}
+
+// Reconcile reconciles an CatalogSourceConfig object that needs to be updated.
+// It returns "Configuring" as the next desired phase.
+func (r *updateReconciler) Reconcile(ctx context.Context, in *v1alpha1.CatalogSourceConfig) (out *v1alpha1.CatalogSourceConfig, nextPhase *v1alpha1.Phase, err error) {
+	out = in.DeepCopy()
+
+	// The TargetNamespace of the CatalogSourceConfig object has changed
+	if r.targetChanged {
+		// Delete the objects in the old TargetNamespace
+		err = r.deleteObjects(in)
+		if err != nil {
+			nextPhase = phase.GetNextWithMessage(phase.Failed, err.Error())
+			return
+		}
+	}
+
+	// Remove it from the cache so that it does not get picked up during
+	// the "Configuring" phase
+	r.cache.Evict(in)
+
+	// Drop existing Status field so that reconciliation can start anew.
+	out.Status = v1alpha1.CatalogSourceConfigStatus{}
+	nextPhase = phase.GetNext(phase.Configuring)
+
+	r.log.Info("Spec has changed, scheduling for configuring")
+
+	return
+}
+
+// deleteObjects deletes the CatalogSource and ConfigMap in the old TargetNamespace.
+func (r *updateReconciler) deleteObjects(in *v1alpha1.CatalogSourceConfig) error {
+	cachedCSCSpec, found := r.cache.Get(in)
+	// This should never happen as it is because the cached Spec has changed
+	// that we are in the update reconciler.
+	if !found {
+		return fmt.Errorf("Unexpected cache miss")
+	}
+
+	// Delete the ConfigMap
+	name := v1alpha1.ConfigMapPrefix + in.Name
+	configMap := new(ConfigMapBuilder).
+		WithMeta(name, cachedCSCSpec.TargetNamespace).
+		ConfigMap()
+	err := r.client.Delete(context.TODO(), configMap)
+	if err != nil {
+		r.log.Errorf("Error %v deleting ConfigMap %s/%s", err, cachedCSCSpec.TargetNamespace, name)
+	}
+	r.log.Infof("Deleted ConfigMap %s/%s", cachedCSCSpec.TargetNamespace, name)
+
+	// Delete the CatalogSource
+	name = v1alpha1.CatalogSourcePrefix + in.Name
+	catalogSource := new(CatalogSourceBuilder).
+		WithMeta(name, cachedCSCSpec.TargetNamespace).
+		CatalogSource()
+	err = r.client.Delete(context.TODO(), catalogSource)
+	if err != nil {
+		r.log.Errorf("Error %v deleting CatalogSource %s/%s", err, cachedCSCSpec.TargetNamespace, name)
+	}
+	r.log.Infof("Deleted CatalogSource %s/%s", cachedCSCSpec.TargetNamespace, name)
+
+	return nil
+}

--- a/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
+++ b/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
@@ -8,6 +8,7 @@ import (
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/config"
 	"sigs.k8s.io/controller-runtime/pkg/controller"
 	"sigs.k8s.io/controller-runtime/pkg/handler"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -18,16 +19,34 @@ import (
 // Add creates a new CatalogSourceConfig Controller and adds it to the Manager. The Manager will set fields on the Controller
 // and Start it when the Manager is Started.
 func Add(mgr manager.Manager) error {
-	return add(mgr, newReconciler(mgr))
+	reconciler, err := newReconciler(mgr)
+	if err != nil {
+		return err
+	}
+	return add(mgr, reconciler)
 }
 
 // newReconciler returns a new reconcile.Reconciler
-func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	client := mgr.GetClient()
+func newReconciler(mgr manager.Manager) (reconcile.Reconciler, error) {
+	// The default client serves read requests from the cache which contains
+	// objects only from the namespace the operator is watching. Given we need
+	// to query other namespaces for ConfigMaps and CatalogSources, we create
+	// our own client and pass it the manager's scheme which has all our
+	// registered types
+	cfg, err := config.GetConfig()
+	if err != nil {
+		return nil, err
+	}
+
+	client, err := client.New(cfg, client.Options{Scheme: mgr.GetScheme()})
+	if err != nil {
+		return nil, err
+	}
+
 	return &ReconcileCatalogSourceConfig{
 		CatalogSourceConfigHandler: catalogsourceconfighandler.NewHandler(mgr, client),
 		client:                     client,
-	}
+	}, nil
 }
 
 // add adds a new Controller to mgr with r as the reconcile.Reconciler

--- a/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
+++ b/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
@@ -23,9 +23,10 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	client := mgr.GetClient()
 	return &ReconcileCatalogSourceConfig{
-		CatalogSourceConfigHandler: catalogsourceconfighandler.NewHandler(mgr),
-		client: mgr.GetClient(),
+		CatalogSourceConfigHandler: catalogsourceconfighandler.NewHandler(mgr, client),
+		client:                     client,
 	}
 }
 

--- a/pkg/controller/operatorsource/operatorsource_controller.go
+++ b/pkg/controller/operatorsource/operatorsource_controller.go
@@ -23,9 +23,10 @@ func Add(mgr manager.Manager) error {
 
 // newReconciler returns a new reconcile.Reconciler
 func newReconciler(mgr manager.Manager) reconcile.Reconciler {
-	handler := operatorsourcehandler.NewHandler(mgr)
+	client := mgr.GetClient()
+	handler := operatorsourcehandler.NewHandler(mgr, client)
 	return &ReconcileOperatorSource{
-		client:                mgr.GetClient(),
+		client:                client,
 		OperatorSourceHandler: handler,
 	}
 }

--- a/pkg/operatorsource/handler.go
+++ b/pkg/operatorsource/handler.go
@@ -23,14 +23,14 @@ func NewHandlerWithParams(client client.Client, scheme *runtime.Scheme, factory 
 	}
 }
 
-func NewHandler(mgr manager.Manager) Handler {
+func NewHandler(mgr manager.Manager, client client.Client) Handler {
 	return &operatorsourcehandler{
-		client: mgr.GetClient(),
+		client: client,
 		scheme: mgr.GetScheme(),
 		factory: &phaseReconcilerFactory{
 			registryClientFactory: appregistry.NewClientFactory(),
 			datastore:             datastore.Cache,
-			client:                mgr.GetClient(),
+			client:                client,
 		},
 		transitioner: phase.NewTransitioner(),
 	}

--- a/pkg/operatorsource/handler.go
+++ b/pkg/operatorsource/handler.go
@@ -8,16 +8,14 @@ import (
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apimachinery/pkg/runtime"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
 // NewHandlerWithParams returns a new Handler.
-func NewHandlerWithParams(client client.Client, scheme *runtime.Scheme, factory PhaseReconcilerFactory, transitioner phase.Transitioner) Handler {
+func NewHandlerWithParams(client client.Client, factory PhaseReconcilerFactory, transitioner phase.Transitioner) Handler {
 	return &operatorsourcehandler{
 		client:       client,
-		scheme:       scheme,
 		factory:      factory,
 		transitioner: transitioner,
 	}
@@ -26,7 +24,6 @@ func NewHandlerWithParams(client client.Client, scheme *runtime.Scheme, factory 
 func NewHandler(mgr manager.Manager, client client.Client) Handler {
 	return &operatorsourcehandler{
 		client: client,
-		scheme: mgr.GetScheme(),
 		factory: &phaseReconcilerFactory{
 			registryClientFactory: appregistry.NewClientFactory(),
 			datastore:             datastore.Cache,
@@ -51,7 +48,6 @@ type operatorsourcehandler struct {
 	// This client, initialized using mgr.Client() above, is a split client
 	// that reads objects from the cache and writes to the apiserver
 	client       client.Client
-	scheme       *runtime.Scheme
 	factory      PhaseReconcilerFactory
 	transitioner phase.Transitioner
 }


### PR DESCRIPTION
- Introduce an in-memory CatalogSourceConfig UID : Spec
This cache is used to detect when a CR needs to be updated. Note that
this cache is a temporary construct which will be removed when we move
to using the Operator Registry as the data store for CatalogSources.

- Introduce a new Update reconciler
This reconciler sets the phase back to "Configuring" allowing the
ConfigMap and CatalogSource to be updated or deleted and recreated
depending on whether the target namespace changed. The "Configuring"
reconciler has been updated to detect if the respective object is
already present and to create or update it depending on that.

- Replace default controller client with a non-default one
Now that we need to query other namespaces for ConfigMaps and
CatalogSources, we no longer can use the default client as it serves
read requests from the cache which contains objects only from the
namespace the operator is watching. So we have to create our own client
and pass it the manager's scheme which has all our registered types.