### PR TITLE
[deploy] Update image to CI image

### DIFF
--- a/deploy/csv/marketplace.csv.yaml
+++ b/deploy/csv/marketplace.csv.yaml
@@ -63,7 +63,7 @@ spec:
             spec:
               containers:
                 - name: marketplace-operator
-                  image: quay.io/redhat/marketplace
+                  image: quay.io/openshift/origin-operator-marketplace
                   ports:
                   - containerPort: 60000
                     name: metrics

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: marketplace-operator
       containers:
         - name: marketplace-operator
-          image: quay.io/redhat/marketplace
+          image: quay.io/openshift/origin-operator-marketplace
           ports:
           - containerPort: 60000
             name: metrics


### PR DESCRIPTION
Use the image quay.io/openshift/origin-operator-marketplace which is built by the CI pipeline.