### PR TITLE
Reconcile OperatorSource Spec update

### DIFF
--- a/pkg/apis/marketplace/v1alpha1/operatorsource_types.go
+++ b/pkg/apis/marketplace/v1alpha1/operatorsource_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -50,10 +52,6 @@ type OperatorSourceStatus struct {
 	CurrentPhase ObjectPhase `json:"currentPhase,omitempty"`
 }
 
-func init() {
-	SchemeBuilder.Register(&OperatorSource{}, &OperatorSourceList{})
-}
-
 // Set group, version, and kind strings
 // from the internal reference that we defined in the v1alpha1 package.
 // The object the sdk client returns does not set these
@@ -65,4 +63,27 @@ func (opsrc *OperatorSource) EnsureGVK() {
 		Kind:    OperatorSourceKind,
 	}
 	opsrc.SetGroupVersionKind(gvk)
+}
+
+// IsEqual returns true if the Spec specified in this is the same as the other.
+// Otherwise, the function returns false.
+//
+// The function performs a case insensitive comparison of corresponding
+// attributes.
+//
+// If the Spec specified in other is nil then the function returns false.
+func (s *OperatorSourceSpec) IsEqual(other *OperatorSourceSpec) bool {
+	if other == nil {
+		return false
+	}
+	if strings.EqualFold(s.Endpoint, other.Endpoint) &&
+		strings.EqualFold(s.RegistryNamespace, other.RegistryNamespace) &&
+		strings.EqualFold(s.Type, other.Type) {
+		return true
+	}
+	return false
+}
+
+func init() {
+	SchemeBuilder.Register(&OperatorSource{}, &OperatorSourceList{})
 }

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -1,4 +1,4 @@
-package datastore
+package datastore_test
 
 import (
 	"io/ioutil"
@@ -7,13 +7,17 @@ import (
 	"testing"
 
 	"github.com/ghodss/yaml"
+	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // In this test we make sure that datastore can successfully process the
 // rh-operators.yaml manifest file.
-func TestWrite(t *testing.T) {
+func TestWriteWithRedHatOperatorsYAML(t *testing.T) {
 	// The following packages are defined in rh-operators.yaml and we expect
 	// datastore to return this list after it processes the manifest.
 	packagesWant := []string{
@@ -24,12 +28,18 @@ func TestWrite(t *testing.T) {
 		"service-catalog",
 	}
 
-	metadata := []*OperatorMetadata{
+	opsrc := &v1alpha1.OperatorSource{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID("123456"),
+		},
+	}
+
+	metadata := []*datastore.OperatorMetadata{
 		helperLoadFromFile(t, "rh-operators.yaml"),
 	}
 
-	ds := newDataStore()
-	err := ds.Write(metadata)
+	ds := datastore.New()
+	err := ds.Write(opsrc, metadata)
 	require.NoError(t, err)
 
 	list := ds.GetPackageIDs()
@@ -40,13 +50,19 @@ func TestWrite(t *testing.T) {
 // Given a list of package ID(s), we expect datastore to return the correspnding
 // manifest YAML that is complete and includes all the package(s) CRD(s)
 // and CSV(s) that are required.
-func TestGetPackageIDs(t *testing.T) {
-	metadata := []*OperatorMetadata{
+func TestGetPackageIDsWithRedHatOperatorsYAML(t *testing.T) {
+	opsrc := &v1alpha1.OperatorSource{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID("123456"),
+		},
+	}
+
+	metadata := []*datastore.OperatorMetadata{
 		helperLoadFromFile(t, "rh-operators.yaml"),
 	}
 
-	ds := newDataStore()
-	err := ds.Write(metadata)
+	ds := datastore.New()
+	err := ds.Write(opsrc, metadata)
 	require.NoError(t, err)
 
 	dataGot, errGot := ds.Read([]string{"etcd", "prometheus"})
@@ -62,7 +78,47 @@ func TestGetPackageIDs(t *testing.T) {
 	assert.NoError(t, csvParseErrGot)
 }
 
-func helperLoadFromFile(t *testing.T, filename string) *OperatorMetadata {
+func TestGetPackageIDsWithMultipleOperatorSources(t *testing.T) {
+	opsrc1 := &v1alpha1.OperatorSource{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID("123456"),
+		},
+	}
+	opsrc2 := &v1alpha1.OperatorSource{
+		ObjectMeta: metav1.ObjectMeta{
+			UID: types.UID("987654"),
+		},
+	}
+
+	// Both 'source-1.yaml' and 'source-2.yaml' have the following packages
+	// combined.
+	packagesWant := []string{
+		"foo-source-1",
+		"foo-source-2",
+		"bar-source-1",
+		"bar-source-2",
+		"baz-source-1",
+		"baz-source-2",
+	}
+
+	metadata1 := helperLoadFromFile(t, "source-1.yaml")
+	metadata2 := helperLoadFromFile(t, "source-2.yaml")
+
+	ds := datastore.New()
+
+	errGot1 := ds.Write(opsrc1, []*datastore.OperatorMetadata{metadata1})
+	require.NoError(t, errGot1)
+
+	errGot2 := ds.Write(opsrc2, []*datastore.OperatorMetadata{metadata2})
+	require.NoError(t, errGot2)
+
+	value := ds.GetPackageIDs()
+	packagesGot := strings.Split(value, ",")
+
+	assert.ElementsMatch(t, packagesWant, packagesGot)
+}
+
+func helperLoadFromFile(t *testing.T, filename string) *datastore.OperatorMetadata {
 	path := filepath.Join("testdata", filename)
 
 	bytes, err := ioutil.ReadFile(path)
@@ -70,8 +126,8 @@ func helperLoadFromFile(t *testing.T, filename string) *OperatorMetadata {
 		t.Fatal(err)
 	}
 
-	return &OperatorMetadata{
-		RegistryMetadata: RegistryMetadata{
+	return &datastore.OperatorMetadata{
+		RegistryMetadata: datastore.RegistryMetadata{
 			Namespace:  "operators",
 			Repository: "redhat",
 		},

--- a/pkg/datastore/testdata/source-1.yaml
+++ b/pkg/datastore/testdata/source-1.yaml
@@ -1,0 +1,27 @@
+data:
+  customResourceDefinitions: |-
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: mycrd.foo.redhat.com  
+  clusterServiceVersions: |-
+    - apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: mycsv-v0.1.0
+      spec:
+        owned:
+        required:         
+  packages: |-
+    - packageName: foo-source-1
+      channels:
+      - name: alpha
+        currentCSV: mycsv-v0.1.0
+    - packageName: bar-source-1
+      channels:
+      - name: alpha
+        currentCSV: mycsv-v0.1.0
+    - packageName: baz-source-1
+      channels:
+      - name: alpha
+        currentCSV: mycsv-v0.1.0

--- a/pkg/datastore/testdata/source-2.yaml
+++ b/pkg/datastore/testdata/source-2.yaml
@@ -1,0 +1,27 @@
+data:
+  customResourceDefinitions: |-      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: mycrd.foo.redhat.com
+  clusterServiceVersions: |-
+    - apiVersion: app.coreos.com/v1alpha1
+      kind: ClusterServiceVersion-v1
+      metadata:
+        name: mycsv-v0.1.0
+      spec:
+        owned:
+        required:   
+  packages: |-
+    - packageName: foo-source-2
+      channels:
+      - name: alpha
+        currentCSV: mycsv-v0.1.0
+    - packageName: bar-source-2
+      channels:
+      - name: alpha
+        currentCSV: mycsv-v0.1.0
+    - packageName: baz-source-2
+      channels:
+      - name: alpha
+        currentCSV: mycsv-v0.1.0

--- a/pkg/operatorsource/downloading.go
+++ b/pkg/operatorsource/downloading.go
@@ -77,7 +77,7 @@ func (r *downloadingReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 
 	r.logger.Infof("Downloaded %d manifest(s) from the operator source endpoint", len(manifests))
 
-	err = r.datastore.Write(manifests)
+	err = r.datastore.Write(in, manifests)
 	if err != nil {
 		nextPhase = phase.GetNextWithMessage(phase.Failed, err.Error())
 		return

--- a/pkg/operatorsource/downloading_test.go
+++ b/pkg/operatorsource/downloading_test.go
@@ -51,7 +51,7 @@ func TestReconcile_ScheduledForDownload_Success(t *testing.T) {
 	registryClient.EXPECT().RetrieveAll(opsrcIn.Spec.RegistryNamespace).Return(manifestExpected, nil).Times(1)
 
 	// We expect the datastore to save downloaded manifest(s) returned by the registry.
-	writer.EXPECT().Write(manifestExpected).Return(nil)
+	writer.EXPECT().Write(opsrcIn, manifestExpected).Return(nil)
 
 	opsrcGot, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
 

--- a/pkg/operatorsource/handler.go
+++ b/pkg/operatorsource/handler.go
@@ -63,7 +63,7 @@ func (h *operatorsourcehandler) Handle(ctx context.Context, in *v1alpha1.Operato
 		"name":      in.GetName(),
 	})
 
-	reconciler, err := h.factory.GetPhaseReconciler(logger, in.Status.CurrentPhase.Name)
+	reconciler, err := h.factory.GetPhaseReconciler(logger, in)
 	if err != nil {
 		return err
 	}

--- a/pkg/operatorsource/updated.go
+++ b/pkg/operatorsource/updated.go
@@ -1,0 +1,69 @@
+package operatorsource
+
+import (
+	"context"
+
+	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/datastore"
+	"github.com/operator-framework/operator-marketplace/pkg/phase"
+	log "github.com/sirupsen/logrus"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewUpdatedEventReconciler returns a Reconciler that reconciles
+// an OperatorSource object that has been updated.
+func NewUpdatedEventReconciler(logger *log.Entry, datastore datastore.Writer, client client.Client) Reconciler {
+	return &updatedEventReconciler{
+		logger:    logger,
+		datastore: datastore,
+		client:    client,
+	}
+}
+
+// updatedEventReconciler implements Reconciler interface.
+type updatedEventReconciler struct {
+	logger    *log.Entry
+	datastore datastore.Writer
+	client    client.Client
+}
+
+// Reconcile reconciles an OperatorSource object whose Spec has been updated.
+//
+// in represents the original OperatorSource object received from the sdk
+// and before reconciliation has started.
+//
+// out represents the OperatorSource object after reconciliation has completed
+// and could be different from the original. The OperatorSource object received
+// (in) should be deep copied into (out) before changes are made.
+//
+// nextPhase represents the next desired phase for the given OperatorSource
+// object. If nil is returned, it implies that no phase transition is expected.
+//
+// On an update we purge the current OperatorSource object, drop the Status
+// field and trigger reconciliation anew from "Validating" phase.
+//
+// If the purge fails the OperatorSource object is moved to "Failed" phase.
+func (r *updatedEventReconciler) Reconcile(ctx context.Context, in *v1alpha1.OperatorSource) (out *v1alpha1.OperatorSource, nextPhase *v1alpha1.Phase, err error) {
+	out = in.DeepCopy()
+
+	r.logger.Info("Spec has changed, purging all resource(s) associated with it")
+
+	r.datastore.RemoveOperatorSource(in.GetUID())
+
+	builder := &CatalogSourceConfigBuilder{}
+	csc := builder.WithMeta(in.Namespace, getCatalogSourceConfigName(in.Name)).CatalogSourceConfig()
+
+	if err = r.client.Delete(ctx, csc); err != nil && !k8s_errors.IsNotFound(err) {
+		nextPhase = phase.GetNextWithMessage(phase.Failed, err.Error())
+		return
+	}
+
+	// Drop existing Status field so that reconciliation can start anew.
+	out.Status = v1alpha1.OperatorSourceStatus{}
+
+	nextPhase = phase.GetNext(phase.OperatorSourceValidating)
+	r.logger.Info("Spec has changed, scheduling for reconciliation from 'Validating' phase")
+
+	return
+}

--- a/pkg/operatorsource/updated_test.go
+++ b/pkg/operatorsource/updated_test.go
@@ -1,0 +1,89 @@
+package operatorsource_test
+
+import (
+	"context"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+
+	gomock "github.com/golang/mock/gomock"
+	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
+	mocks "github.com/operator-framework/operator-marketplace/pkg/mocks/operatorsource_mocks"
+	"github.com/operator-framework/operator-marketplace/pkg/operatorsource"
+	"github.com/operator-framework/operator-marketplace/pkg/phase"
+)
+
+// Use Case: Admin has changed the Spec to point to different endpoint or namespace.
+// Expected Result: Current operator source should be purged and the next phase
+// should be set to "Validating" so that reconciliation is triggered.
+func TestReconcile_SpecHasChanged_ReconciliationTriggered(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	ctx := context.TODO()
+
+	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.Succeeded)
+	opsrcWant := opsrcIn.DeepCopy()
+	opsrcWant.Status = v1alpha1.OperatorSourceStatus{}
+
+	nextPhaseWant := &v1alpha1.Phase{
+		Name:    phase.OperatorSourceValidating,
+		Message: phase.GetMessage(phase.OperatorSourceValidating),
+	}
+
+	datastore := mocks.NewDatastoreWriter(controller)
+	client := mocks.NewKubeClient(controller)
+	reconciler := operatorsource.NewUpdatedEventReconciler(helperGetContextLogger(), datastore, client)
+
+	// We expect the operator source to be removed from the datastore.
+	csc := helperNewCatalogSourceConfig(opsrcIn.Namespace, getExpectedCatalogSourceConfigName(opsrcIn.Name))
+	datastore.EXPECT().RemoveOperatorSource(opsrcIn.GetUID()).Times(1)
+
+	// We expect the associated CatalogConfigSource object to be deleted.
+	client.EXPECT().Delete(ctx, csc)
+
+	opsrcGot, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
+
+	assert.NoError(t, errGot)
+	assert.Equal(t, opsrcWant, opsrcGot)
+	assert.Equal(t, nextPhaseWant, nextPhaseGot)
+}
+
+// Use Case: The associated CatalogSourceConfig object is not found while purging.
+// Expected Result: NotFound error is ignored and the next phase should be set
+// to "Validating" so that reconciliation is triggered.
+func TestReconcile_CatalogSourceConfigNotFound_ErrorExpected(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	ctx := context.TODO()
+
+	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.Succeeded)
+	opsrcWant := opsrcIn.DeepCopy()
+	opsrcWant.Status = v1alpha1.OperatorSourceStatus{}
+
+	nextPhaseWant := &v1alpha1.Phase{
+		Name:    phase.OperatorSourceValidating,
+		Message: phase.GetMessage(phase.OperatorSourceValidating),
+	}
+
+	datastore := mocks.NewDatastoreWriter(controller)
+	client := mocks.NewKubeClient(controller)
+	reconciler := operatorsource.NewUpdatedEventReconciler(helperGetContextLogger(), datastore, client)
+
+	// We expect the operator source to be removed from the datastore.
+	csc := helperNewCatalogSourceConfig(opsrcIn.Namespace, getExpectedCatalogSourceConfigName(opsrcIn.Name))
+	datastore.EXPECT().RemoveOperatorSource(opsrcIn.GetUID())
+
+	// We expect kube client to throw a NotFound error.
+	notFoundErr := k8s_errors.NewNotFound(schema.GroupResource{}, "CatalogSourceConfig not found")
+	client.EXPECT().Delete(ctx, csc).Return(notFoundErr)
+
+	opsrcGot, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
+
+	assert.Error(t, errGot)
+	assert.Equal(t, opsrcGot, opsrcWant)
+	assert.Equal(t, nextPhaseWant, nextPhaseGot)
+}

--- a/pkg/operatorsource/validating.go
+++ b/pkg/operatorsource/validating.go
@@ -6,22 +6,25 @@ import (
 	"net/url"
 
 	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
 	log "github.com/sirupsen/logrus"
 )
 
 // NewValidatingReconciler returns a Reconciler that reconciles
 // an OperatorSource object in "Validating" phase
-func NewValidatingReconciler(logger *log.Entry) Reconciler {
+func NewValidatingReconciler(logger *log.Entry, datastore datastore.Writer) Reconciler {
 	return &validatingReconciler{
-		logger: logger,
+		logger:    logger,
+		datastore: datastore,
 	}
 }
 
 // validatingReconciler is an implementation of Reconciler interface that
 // reconciles an OperatorSource object in "Validating" phase.
 type validatingReconciler struct {
-	logger *log.Entry
+	logger    *log.Entry
+	datastore datastore.Writer
 }
 
 // Reconcile reconciles an OperatorSource object that is in "Validating" phase.
@@ -55,6 +58,8 @@ func (r *validatingReconciler) Reconcile(ctx context.Context, in *v1alpha1.Opera
 			fmt.Sprintf("Invalid operator source endpoint - %s", err.Error()))
 		return
 	}
+
+	r.datastore.AddOperatorSource(in)
 
 	r.logger.Info("Scheduling for download")
 


### PR DESCRIPTION
When an admin updates the spec of an OperatorSource object we need to reconcile so that the new spec takes effect.

What needs to be done:
* Save OperatorSource spec to datastore. 
* Determine if the Spec has been changed, we will consider change in spec as an update event.
* Reconcile update event appropriately.
