### PR TITLE
[deploy] Add liveness and readiness probes

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -3,6 +3,7 @@ package main
 import (
 	"flag"
 	"log"
+	"net/http"
 	"runtime"
 
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -59,6 +60,12 @@ func main() {
 	if err := controller.AddToManager(mgr); err != nil {
 		log.Fatal(err)
 	}
+
+	// Serve a health check.
+	http.HandleFunc("/healthz", func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusOK)
+	})
+	go http.ListenAndServe(":8080", nil)
 
 	log.Print("Starting the Cmd.")
 

--- a/deploy/marketplace.csv.yaml
+++ b/deploy/marketplace.csv.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: marketplace-operator.v0.0.1
-  namespace: marketplace
+  namespace: openshift-marketplace
 spec:
   displayName: marketplace
   description: |-
@@ -27,7 +27,7 @@ spec:
     strategy: deployment
     spec:
       clusterPermissions:
-      - serviceAccountName: default
+      - serviceAccountName: marketplace-operator
         rules:
         - apiGroups:
           - marketplace.redhat.com
@@ -61,15 +61,26 @@ spec:
               labels:
                 name: marketplace-operator
             spec:
+              serviceAccountName: marketplace-operator
               containers:
                 - name: marketplace-operator
                   image: quay.io/openshift/origin-operator-marketplace
                   ports:
                   - containerPort: 60000
                     name: metrics
+                  - containerPort: 8080
+                    name: healthz
                   command:
                   - marketplace-operator
                   imagePullPolicy: Always
+                  livenessProbe:
+                    httpGet:
+                      path: /healthz
+                      port: 8080
+                  readinessProbe:
+                    httpGet:
+                      path: /healthz
+                      port: 8080
                   env:
                     - name: WATCH_NAMESPACE
                       valueFrom:

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -19,9 +19,19 @@ spec:
           ports:
           - containerPort: 60000
             name: metrics
+          - containerPort: 8080
+            name: healthz
           command:
           - marketplace-operator
           imagePullPolicy: Always
+          livenessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
+          readinessProbe:
+            httpGet:
+              path: /healthz
+              port: 8080
           env:
             - name: WATCH_NAMESPACE
               valueFrom:


### PR DESCRIPTION
Updated main.go to include an http endpoint that returns a 200 status when pinged for use in readiness and liveness probes.
Updated the operator.yaml to include a readiness and liveness probe.