### PR TITLE
[bug] Update csv to use the expected service account and namespace

### DIFF
--- a/deploy/marketplace.csv.yaml
+++ b/deploy/marketplace.csv.yaml
@@ -2,7 +2,7 @@ apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: marketplace-operator.v0.0.1
-  namespace: marketplace
+  namespace: openshift-marketplace
 spec:
   displayName: marketplace
   description: |-
@@ -27,7 +27,7 @@ spec:
     strategy: deployment
     spec:
       clusterPermissions:
-      - serviceAccountName: default
+      - serviceAccountName: marketplace-operator
         rules:
         - apiGroups:
           - marketplace.redhat.com
@@ -61,6 +61,7 @@ spec:
               labels:
                 name: marketplace-operator
             spec:
+              serviceAccountName: marketplace-operator
               containers:
                 - name: marketplace-operator
                   image: quay.io/openshift/origin-operator-marketplace


### PR DESCRIPTION
This bug came as a result of the changes that were introduced when the project was rebuilt using version 0.1.1 of the operator sdk.
In this update, the service account changed from default to marketplace-operator. The csv has been updated to use the marketplace-operator service account.