### PR TITLE
[deploy] Update the marketplace csv for use with OLM.

### DIFF
--- a/README.md
+++ b/README.md
@@ -26,7 +26,7 @@ $ export REGISTRY=<SOME_REGISTRY> \
 
 ### Description
 
-The marketplace operator manages two CRDs: [OperatorSource](./deploy/crd/operatorsource.crd.yaml) and [CatalogSourceConfig](./deploy/crd/catalogsourceconfig.crd.yaml). When an OperatorSource CR is created in the same namespace as where the marketplace operator is running (we recommend the namespace be called "marketplace"), the operator will download artifacts stored in the registry specified in this OperatorSource CR (for now, please see documentation about using [quay](https://quay.io)'s appregistry API). For an example of this OperatorSource CR please see the [examples](./deploy/examples/) folder.
+The marketplace operator manages two CRDs: [OperatorSource](./deploy/crd/operatorsource.crd.yaml) and [CatalogSourceConfig](./deploy/crd/catalogsourceconfig.crd.yaml). When an OperatorSource CR is created in the same namespace as where the marketplace operator is running (we recommend the namespace be called "openshift-operators"), the operator will download artifacts stored in the registry specified in this OperatorSource CR (for now, please see documentation about using [quay](https://quay.io)'s appregistry API). For an example of this OperatorSource CR please see the [examples](./deploy/examples/) folder.
 
 The operator will then create a CatalogSourceConfig CR which will, for the time being, trigger the marketplace operator to create a ConfigMap CR and CatalogSource CR. The package-server, managed by [OLM](https://github.com/operator-framework/operator-lifecycle-manager), will then respond to the creation of these CRs and allow the external operators to be visible in the [marketplace UI](https://github.com/openshift/console/tree/master/frontend/public/components/marketplace).
 
@@ -36,7 +36,7 @@ It is important to note that the order in which you apply the deployment files m
 #### Deploying the Marketplace Operator
 ```bash
 $ oc apply -f deploy/marketplace.ns.yaml
-$ oc project openshift-marketplace
+$ oc project openshift-operators
 $ oc apply -f deploy/crd/catalogsourceconfig.crd.yaml
 $ oc apply -f deploy/crd/operatorsource.crd.yaml
 $ oc apply -f deploy/service_account.yaml
@@ -48,13 +48,13 @@ $ oc apply -f deploy/operator.yaml
 #### Deploying the Marketplace Operator with OLM
 ```bash
 $ oc apply -f deploy/marketplace.ns.yaml
-$ oc project openshift-marketplace
+$ oc project openshift-operators
 $ oc apply -f deploy/crd/catalogsourceconfig.crd.yaml
 $ oc apply -f deploy/crd/operatorsource.crd.yaml
 $ oc apply -f deploy/service_account.yaml
 $ oc apply -f deploy/role.yaml
 $ oc apply -f deploy/role_binding.yaml
-$ oc apply -f deploy/marketplace.csv.yaml
+$ oc apply -f deploy/marketplace.v0.0.1.clusterserviceversion.yaml
 ```
 
 ### Deploying the Marketplace Operator with Kubernetes

--- a/deploy/crds/catalogsourceconfig.crd.yaml
+++ b/deploy/crds/catalogsourceconfig.crd.yaml
@@ -41,10 +41,6 @@ spec:
       properties:
         spec:
           type: object
-          description: Represents the configuration of a CatalogSourceConfig
-          required:
-          - spec
-          type: object
           description: Spec for a CatalogSourceConfig
           required:
           - targetNamespace

--- a/deploy/crds/operatorsource.crd.yaml
+++ b/deploy/crds/operatorsource.crd.yaml
@@ -45,10 +45,6 @@ spec:
       properties:
         spec:
           type: object
-          description: Represents the configuration of an OperatorSource
-          required:
-          - spec
-          type: object
           description: Spec for an OperatorSource.
           required:
           - type
@@ -61,7 +57,10 @@ spec:
               pattern: 'appregistry'
             endpoint:
               type: string
-              description: The endpoint of the OperatorSource
+              description: Points to the remote app registry server from where operator manifests can be fetched.
             registryNamespace:
               type: string
-              description:  App registry namespace
+              description: |-
+                The namespace in app registry.
+                Only operator manifests under this namespace will be visible.
+                Please note that this is not a k8s namespace.

--- a/deploy/examples/catalogsourceconfig.cr.yaml
+++ b/deploy/examples/catalogsourceconfig.cr.yaml
@@ -2,7 +2,7 @@ apiVersion: "marketplace.redhat.com/v1alpha1"
 kind: "CatalogSourceConfig"
 metadata:
   name: "example"
-  namespace: "openshift-marketplace"
+  namespace: "openshift-operators"
 spec:
   targetNamespace: "global"
   packages: "operators/marketplace-operators"

--- a/deploy/examples/operatorsource.cr.yaml
+++ b/deploy/examples/operatorsource.cr.yaml
@@ -2,7 +2,7 @@ apiVersion: "marketplace.redhat.com/v1alpha1"
 kind: "OperatorSource"
 metadata:
   name: "global-operators"
-  namespace: "openshift-marketplace"
+  namespace: "openshift-operators"
 spec:
   type: appregistry
   endpoint: "https://quay.io/cnr"

--- a/deploy/marketplace.ns.yaml
+++ b/deploy/marketplace.ns.yaml
@@ -1,4 +1,4 @@
 apiVersion: v1
 kind: Namespace
 metadata:
-    name: "openshift-marketplace"
+    name: "openshift-operators"

--- a/deploy/marketplace.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/marketplace.v0.0.1.clusterserviceversion.yaml
@@ -1,10 +1,12 @@
+#! validate-crd: deploy/chart/templates/0000_30_02-clusterserviceversion.crd.yaml
+#! parse-kind: ClusterServiceVersion
 apiVersion: operators.coreos.com/v1alpha1
 kind: ClusterServiceVersion
 metadata:
   name: marketplace-operator.v0.0.1
-  namespace: openshift-marketplace
+  namespace: openshift-operators
 spec:
-  displayName: marketplace
+  displayName: marketplace-operator
   description: |-
     Marketplace is a gateway for users to consume off-cluster Operators which will include Red Hat, ISV, optional OpenShift and community content.
   keywords: ['marketplace', 'catalog', 'olm', 'admin']
@@ -64,7 +66,7 @@ spec:
               serviceAccountName: marketplace-operator
               containers:
                 - name: marketplace-operator
-                  image: quay.io/openshift/origin-operator-marketplace
+                  image: quay.io/openshift/origin-operator-marketplace:latest
                   ports:
                   - containerPort: 60000
                     name: metrics
@@ -88,7 +90,7 @@ spec:
                           fieldPath: metadata.namespace
                     - name: OPERATOR_NAME
                       value: "marketplace-operator"
-customresourcedefinitions:
+  customresourcedefinitions:
     owned:
     - name: operatorsources.marketplace.redhat.com
       version: v1alpha1
@@ -109,11 +111,12 @@ customresourcedefinitions:
           displayName: Registry Namespace
           path: registryNamespace
       statusDescriptors:
-      - description: The Current phase of the OperatorSource object.
-        displayName: Current Phase
-        path: currentPhase
-        x-descriptors:
-          - 'urn:alm:descriptor:io.kubernetes.phase'
+        - description: Current status of the CatalogSourceConfig
+          displayName: Current Phase Name
+          path: currentPhase.phase.name
+        - description: Message associated with the current status
+          displayName: Current Phase Message
+          path: currentPhase.phase.message
     - name: catalogsourceconfigs.marketplace.redhat.com
       version: v1alpha1
       kind: CatalogSourceConfig
@@ -123,12 +126,13 @@ customresourcedefinitions:
         - description: The namespace where the operators will be enabled.
           displayName: Target Namespace
           path: targetNamespace
-        - description: Represents a list of operator(s) which will be enabled in the target namespace.
+        - description: List of operator(s) which will be enabled in the target namespace
           displayName: Packages
           path: packages
       statusDescriptors:
-      - description: The Current phase of the CatalogSourceConfig object.
-        displayName: Current Phase
-        path: currentPhase
-        x-descriptors:
-          - 'urn:alm:descriptor:io.kubernetes.phase'
+        - description: Current status of the CatalogSourceConfig
+          displayName: Current Phase Name
+          path: currentPhase.phase.name
+        - description: Message associated with the current status
+          displayName: Current Phase Message
+          path: currentPhase.phase.message

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -15,7 +15,7 @@ spec:
       serviceAccountName: marketplace-operator
       containers:
         - name: marketplace-operator
-          image: quay.io/openshift/origin-operator-marketplace
+          image: quay.io/openshift/origin-operator-marketplace:latest
           ports:
           - containerPort: 60000
             name: metrics

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -5,7 +5,7 @@ metadata:
 subjects:
 - kind: ServiceAccount
   name: marketplace-operator
-  namespace: openshift-marketplace
+  namespace: openshift-operators
 roleRef:
   kind: ClusterRole
   name: marketplace-operator

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -e
 
-TEST_NAMESPACE="openshift-marketplace"
+TEST_NAMESPACE="openshift-operators"
 MANIFEST_FOLDER="./test/e2e/environment/"
 NAMESPACED_MANIFEST="./${MANIFEST_FOLDER}/namespaced-manifest.yaml"
 GLOBAL_MANIFEST="./${MANIFEST_FOLDER}/global-manifest.yaml"


### PR DESCRIPTION
The changes introduced in this PR:
* Rename the marketplace csv so the OLM provided `make release` command includes Marketplace in it's configMap.
* Clearly shows that the latest marketplace image is used
* Removes incorrect x-descriptorsi
* Update the operators display name
* Updates the Readme to reflect these changes