### PR TITLE
Updated OperaorSource unit tests using fake client

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -37,7 +37,6 @@ generate-mocks:
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_datastore.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=Reader=DatastoreReader,Writer=DatastoreWriter $(PKG)/datastore Reader,Writer
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_phase_reconciler.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=Reconciler=PhaseReconciler $(PKG)/operatorsource Reconciler
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_phase_tansitioner.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=Transitioner=PhaseTransitioner $(PKG)/phase Transitioner
-	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_kubeclient.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=Client=KubeClient $(CONTROLLER_RUNTIME_PKG)/client Client
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_phase_reconciler_strategy.go -package=$(OPERATORSOURCE_MOCK_PKG) $(PKG)/operatorsource PhaseReconcilerFactory
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_appregistry.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=ClientFactory=AppRegistryClientFactory,Client=AppRegistryClient $(PKG)/appregistry ClientFactory,Client
 

--- a/pkg/operatorsource/configuring_test.go
+++ b/pkg/operatorsource/configuring_test.go
@@ -5,16 +5,17 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	gomock "github.com/golang/mock/gomock"
+	"github.com/operator-framework/operator-marketplace/pkg/apis"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
 	mocks "github.com/operator-framework/operator-marketplace/pkg/mocks/operatorsource_mocks"
 	"github.com/operator-framework/operator-marketplace/pkg/operatorsource"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 // Use Case: Not configured, CatalogSourceConfig object has not been created yet.
@@ -24,18 +25,22 @@ func TestReconcile_NotConfigured_NewCatalogConfigSourceObjectCreated(t *testing.
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 
+	namespace, name := "marketplace", "foo"
 	nextPhaseWant := &v1alpha1.Phase{
 		Name:    phase.Succeeded,
 		Message: phase.GetMessage(phase.Succeeded),
 	}
 
-	datastore := mocks.NewDatastoreWriter(controller)
-	kubeclient := mocks.NewKubeClient(controller)
+	scheme := runtime.NewScheme()
+	apis.AddToScheme(scheme)
 
-	reconciler := operatorsource.NewConfiguringReconciler(helperGetContextLogger(), datastore, kubeclient)
+	datastore := mocks.NewDatastoreWriter(controller)
+	fakeclient := fake.NewFakeClientWithScheme(scheme)
+
+	reconciler := operatorsource.NewConfiguringReconciler(helperGetContextLogger(), datastore, fakeclient)
 
 	ctx := context.TODO()
-	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.Configuring)
+	opsrcIn := helperNewOperatorSourceWithPhase(namespace, name, phase.Configuring)
 
 	labelsWant := map[string]string{
 		"opsrc-group": "Community",
@@ -44,6 +49,70 @@ func TestReconcile_NotConfigured_NewCatalogConfigSourceObjectCreated(t *testing.
 
 	packages := "a,b,c"
 	datastore.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return(packages)
+
+	opsrcGot, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
+
+	assert.NoError(t, errGot)
+	assert.Equal(t, opsrcIn, opsrcGot)
+	assert.Equal(t, nextPhaseWant, nextPhaseGot)
+
+	// Verify reconciler passed expected CatalogSourceConfig to fakeclient
+	trueVar := true
+	cscWant := helperNewCatalogSourceConfigWithLabels(opsrcIn.Namespace, opsrcIn.Name, labelsWant)
+	cscWant.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+		metav1.OwnerReference{
+			APIVersion: opsrcIn.APIVersion,
+			Kind:       opsrcIn.Kind,
+			Name:       opsrcIn.Name,
+			UID:        opsrcIn.UID,
+			Controller: &trueVar,
+		},
+	}
+	cscWant.Spec = v1alpha1.CatalogSourceConfigSpec{
+		TargetNamespace: opsrcIn.Namespace,
+		Packages:        packages,
+	}
+
+	cscNamespacedName := types.NamespacedName{Name: name, Namespace: namespace}
+	cscGot := &v1alpha1.CatalogSourceConfig{}
+	fakeclient.Get(ctx, cscNamespacedName, cscGot)
+
+	assert.Equal(t, cscWant, cscGot)
+}
+
+// Use Case: Not configured, CatalogSourceConfig object already exists due to
+// past errors.
+// Expected Result: The existing CatalogSourceConfig object should be updated
+// accordingly and the next phase should be set to "Succeeded".
+func TestReconcile_CatalogSourceConfigAlreadyExists_Updated(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	namespace, name := "marketplace", "foo"
+	nextPhaseWant := &v1alpha1.Phase{
+		Name:    phase.Succeeded,
+		Message: phase.GetMessage(phase.Succeeded),
+	}
+	scheme := runtime.NewScheme()
+	apis.AddToScheme(scheme)
+
+	datastore := mocks.NewDatastoreWriter(controller)
+	fakeclient := fake.NewFakeClientWithScheme(scheme)
+
+	ctx := context.TODO()
+	opsrcIn := helperNewOperatorSourceWithPhase(namespace, name, phase.Configuring)
+
+	labelsWant := map[string]string{
+		"opsrc-group": "Community",
+	}
+	opsrcIn.SetLabels(labelsWant)
+
+	packages := "a,b,c"
+	datastore.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return(packages)
+
+	// The given CatalogConfigSource object already exists.
+	cscIn := helperNewCatalogSourceConfig(opsrcIn.Namespace, opsrcIn.Name)
+	fakeclient.Create(ctx, cscIn)
 
 	trueVar := true
 	cscWant := helperNewCatalogSourceConfigWithLabels(opsrcIn.Namespace, opsrcIn.Name, labelsWant)
@@ -60,110 +129,18 @@ func TestReconcile_NotConfigured_NewCatalogConfigSourceObjectCreated(t *testing.
 		TargetNamespace: opsrcIn.Namespace,
 		Packages:        packages,
 	}
-	kubeclient.EXPECT().Create(context.TODO(), cscWant).Return(nil)
+
+	reconciler := operatorsource.NewConfiguringReconciler(helperGetContextLogger(), datastore, fakeclient)
 
 	opsrcGot, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
 
 	assert.NoError(t, errGot)
 	assert.Equal(t, opsrcIn, opsrcGot)
 	assert.Equal(t, nextPhaseWant, nextPhaseGot)
-}
 
-// Use Case: Not configured, CatalogSourceConfig object already exists due to
-// past errors.
-// Expected Result: The existing CatalogSourceConfig object should be updated
-// accordingly and the next phase should be set to "Succeeded".
-func TestReconcile_CatalogSourceConfigAlreadyExists_Updated(t *testing.T) {
-	controller := gomock.NewController(t)
-	defer controller.Finish()
+	cscNamespacedName := types.NamespacedName{Name: name, Namespace: namespace}
+	cscGot := &v1alpha1.CatalogSourceConfig{}
+	fakeclient.Get(ctx, cscNamespacedName, cscGot)
 
-	namespace, name := "marketplace", "foo"
-	nextPhaseWant := &v1alpha1.Phase{
-		Name:    phase.Succeeded,
-		Message: phase.GetMessage(phase.Succeeded),
-	}
-
-	datastore := mocks.NewDatastoreWriter(controller)
-	kubeclient := mocks.NewKubeClient(controller)
-
-	reconciler := operatorsource.NewConfiguringReconciler(helperGetContextLogger(), datastore, kubeclient)
-
-	ctx := context.TODO()
-	opsrcIn := helperNewOperatorSourceWithPhase(namespace, name, phase.Configuring)
-
-	labelsWant := map[string]string{
-		"opsrc-group": "Community",
-	}
-	opsrcIn.SetLabels(labelsWant)
-
-	packages := "a,b,c"
-	datastore.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return(packages)
-
-	createErr := k8s_errors.NewAlreadyExists(schema.GroupResource{}, "CatalogSourceConfig already exists")
-	kubeclient.EXPECT().Create(context.TODO(), gomock.Any()).Return(createErr)
-
-	// We expect Get to return the given CatalogSourceConfig successfully.
-	namespacedName := types.NamespacedName{Name: name, Namespace: namespace}
-	cscGet := v1alpha1.CatalogSourceConfig{}
-	kubeclient.EXPECT().Get(context.TODO(), namespacedName, &cscGet).Return(nil)
-
-	trueVar := true
-	cscWant := helperNewCatalogSourceConfigWithLabels("", "", labelsWant)
-	cscWant.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
-		metav1.OwnerReference{
-			APIVersion: opsrcIn.APIVersion,
-			Kind:       opsrcIn.Kind,
-			Name:       opsrcIn.Name,
-			UID:        opsrcIn.UID,
-			Controller: &trueVar,
-		},
-	}
-	cscWant.Spec = v1alpha1.CatalogSourceConfigSpec{
-		TargetNamespace: opsrcIn.Namespace,
-		Packages:        packages,
-	}
-	kubeclient.EXPECT().Update(context.TODO(), cscWant).Return(nil)
-
-	opsrcGot, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
-
-	assert.NoError(t, errGot)
-	assert.Equal(t, opsrcIn, opsrcGot)
-	assert.Equal(t, nextPhaseWant, nextPhaseGot)
-}
-
-// Use Case: Update of existing CatalogSourceConfig object fails.
-// Expected Result: The object is moved to "Failed" phase.
-func TestReconcile_UpdateError_MovedToFailedPhase(t *testing.T) {
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
-	namespace, name := "marketplace", "foo"
-
-	updateError := k8s_errors.NewServerTimeout(schema.GroupResource{}, "operation", 1)
-	nextPhaseWant := &v1alpha1.Phase{
-		Name:    phase.Configuring,
-		Message: updateError.Error(),
-	}
-
-	datastore := mocks.NewDatastoreWriter(controller)
-	kubeclient := mocks.NewKubeClient(controller)
-
-	reconciler := operatorsource.NewConfiguringReconciler(helperGetContextLogger(), datastore, kubeclient)
-
-	ctx := context.TODO()
-	opsrcIn := helperNewOperatorSourceWithPhase(namespace, name, phase.Configuring)
-
-	datastore.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return("a,b,c")
-
-	createErr := k8s_errors.NewAlreadyExists(schema.GroupResource{}, "CatalogSourceConfig already exists")
-	kubeclient.EXPECT().Create(context.TODO(), gomock.Any()).Return(createErr)
-
-	kubeclient.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).Return(nil)
-	kubeclient.EXPECT().Update(context.TODO(), gomock.Any()).Return(updateError)
-
-	_, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
-
-	assert.Error(t, errGot)
-	assert.Equal(t, updateError, errGot)
-	assert.Equal(t, nextPhaseWant, nextPhaseGot)
+	assert.Equal(t, cscWant, cscGot)
 }


### PR DESCRIPTION
Use the `controller-runtime`'s fake client in unit tests for `operatorsource` package.

`operator-sdk` should include an up-to-date fake client with custom scheme support built-in by this week.
I've applied the minimum changes needed to get fake client to work with Marketplace's custom CRDs in the meantime.

**UPDATE**
With PR #69 merged, fake client should be good to go.