### PR TITLE
[opsrc] Add downloaded manifest list to Status

### DIFF
--- a/pkg/apis/marketplace/v1alpha1/operatorsource_types.go
+++ b/pkg/apis/marketplace/v1alpha1/operatorsource_types.go
@@ -20,6 +20,7 @@ type OperatorSourceList struct {
 	Items           []OperatorSource `json:"items"`
 }
 
+// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 // OperatorSource is the Schema for the operatorsources API
 // +k8s:openapi-gen=true
 type OperatorSource struct {
@@ -28,8 +29,6 @@ type OperatorSource struct {
 	Spec              OperatorSourceSpec   `json:"spec,omitempty"`
 	Status            OperatorSourceStatus `json:"status,omitempty"`
 }
-
-// +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // OperatorSourceSpec defines the desired state of OperatorSource
 type OperatorSourceSpec struct {
@@ -50,6 +49,11 @@ type OperatorSourceSpec struct {
 type OperatorSourceStatus struct {
 	// Current phase of the OperatorSource object
 	CurrentPhase ObjectPhase `json:"currentPhase,omitempty"`
+
+	// Packages is a comma separated list of package(s) each of which has been
+	// downloaded and processed by Marketplace operator from the specified
+	// endpoint.
+	Packages string `json:"packages,omitempty"`
 }
 
 // Set group, version, and kind strings

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -45,10 +45,17 @@ type Reader interface {
 // Writer is an interface that is used to manage the underlying datastore
 // for operator manifest.
 type Writer interface {
-	// GetPackageIDs returns a comma separated list of operator ID(s). Each ID
+	// GetPackageIDs returns a comma separated list of operator ID(s). This list
+	// includes operator(s) across all OperatorSource object(s). Each ID
 	// returned can be used to retrieve the manifest associated with the
 	// operator from underlying datastore.
 	GetPackageIDs() string
+
+	// GetPackageIDsByOperatorSource returns a comma separated list of operator
+	// ID(s) associated with a given OperatorSource object.
+	// Each ID returned can be used to retrieve the manifest associated with the
+	// operator from underlying datastore.
+	GetPackageIDsByOperatorSource(opsrcUID types.UID) string
 
 	// Write saves the Spec associated with a given OperatorSource object and
 	// the downloaded operator manifest(s) into datastore.
@@ -201,6 +208,16 @@ func (ds *memoryDatastore) Write(opsrc *v1alpha1.OperatorSource, rawManifests []
 func (ds *memoryDatastore) GetPackageIDs() string {
 	keys := ds.rows.GetAllPackages()
 	return strings.Join(keys, ",")
+}
+
+func (ds *memoryDatastore) GetPackageIDsByOperatorSource(opsrcUID types.UID) string {
+	row, exists := ds.rows[opsrcUID]
+	if !exists {
+		return ""
+	}
+
+	packages := row.GetPackages()
+	return strings.Join(packages, ",")
 }
 
 func (ds *memoryDatastore) AddOperatorSource(opsrc *v1alpha1.OperatorSource) {

--- a/pkg/operatorsource/downloading.go
+++ b/pkg/operatorsource/downloading.go
@@ -83,6 +83,9 @@ func (r *downloadingReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 		return
 	}
 
+	packages := r.datastore.GetPackageIDsByOperatorSource(out.GetUID())
+	out.Status.Packages = packages
+
 	r.logger.Info("Download complete, scheduling for configuration")
 
 	nextPhase = phase.GetNext(phase.Configuring)


### PR DESCRIPTION
Add a new field called 'Packages' to OperatorSourceStatus. This is a
comma separated list of operator manifest(s) downloaded by
marketplace operator from the registry specified by the OperatorSource
object.

When an OperatorSource object is reconciled this field allows us to see
the list of manifest(s) processed.