### PR TITLE
[csc+opsrc] Introduce datastore label

### DIFF
--- a/pkg/catalogsourceconfig/catalogsourcebuilder.go
+++ b/pkg/catalogsourceconfig/catalogsourcebuilder.go
@@ -28,10 +28,23 @@ func (b *CatalogSourceBuilder) WithTypeMeta() *CatalogSourceBuilder {
 // WithMeta sets basic TypeMeta and ObjectMeta.
 func (b *CatalogSourceBuilder) WithMeta(name, namespace string) *CatalogSourceBuilder {
 	b.WithTypeMeta()
-	b.cs.ObjectMeta = metav1.ObjectMeta{
-		Name:      name,
-		Namespace: namespace,
+	objectMeta := b.cs.GetObjectMeta()
+	if objectMeta == nil {
+		b.cs.ObjectMeta = metav1.ObjectMeta{}
 	}
+	b.cs.SetName(name)
+	b.cs.SetNamespace(namespace)
+	return b
+}
+
+// WithOLMLabels adds "olm-visibility" and "openshift-marketplace" labels to ObjectMeta.
+func (b *CatalogSourceBuilder) WithOLMLabels() *CatalogSourceBuilder {
+	b.WithTypeMeta()
+	objectMeta := b.cs.GetObjectMeta()
+	if objectMeta == nil {
+		b.cs.ObjectMeta = metav1.ObjectMeta{}
+	}
+	b.cs.SetLabels(map[string]string{"olm-visibility": "hidden", "openshift-marketplace": "true"})
 	return b
 }
 

--- a/pkg/operatorsource/catalogsourceconfigbuilder.go
+++ b/pkg/operatorsource/catalogsourceconfigbuilder.go
@@ -7,6 +7,11 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+// DatastoreLabel is the label used in a CatalogSourceConfig to indicate that
+// the resulting CatalogSource acts as the datastore for the OperatorSource
+// if it is set to "true".
+const DatastoreLabel string = "opsrc-datastore"
+
 // CatalogSourceConfigBuilder builds a new CatalogSourceConfig type object.
 type CatalogSourceConfigBuilder struct {
 	object v1alpha1.CatalogSourceConfig
@@ -28,6 +33,7 @@ func (b *CatalogSourceConfigBuilder) WithMeta(namespace, name string) *CatalogSo
 	b.object.ObjectMeta = metav1.ObjectMeta{
 		Name:      name,
 		Namespace: namespace,
+		Labels:    map[string]string{DatastoreLabel: "true"},
 	}
 
 	return b

--- a/pkg/operatorsource/helper_test.go
+++ b/pkg/operatorsource/helper_test.go
@@ -68,6 +68,7 @@ func helperNewCatalogSourceConfig(namespace, name string) *v1alpha1.CatalogSourc
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
+			Labels:    map[string]string{"opsrc-datastore": "true"},
 		},
 	}
 }


### PR DESCRIPTION
- Update the CatalogSourceConfigBuilder` to add a datastore label.
- The CatalogSourceConfig's configuring reconciler will check for this datastore label. If present it will add the _olm-visibility: hidden_ and _openshift-marketplace: true_ labels to the CatalogSource. 
_olm-visibility: hidden_ will cause the CatalogSource to be hidden in the OLM Package Manifest UI. 
_openshift-marketplace: true_ will be used to filter out the global CatalogSources in the Marketplace UI.
- Add the datastore label to the ObjectMeta in helperNewCatalogSourceConfig()