### PR TITLE
Improve naming of CRs

### DIFF
--- a/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
+++ b/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
@@ -5,13 +5,6 @@ import (
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
 
-const (
-	// ConfigMapPrefix is the prefix used for the ConfigMap created by the handler
-	ConfigMapPrefix = "csc-cm-"
-	// CatalogSourcePrefix is the prefix used for the CatalogSource created by the handler
-	CatalogSourcePrefix = "csc-cs-"
-)
-
 // +k8s:deepcopy-gen:interfaces=k8s.io/apimachinery/pkg/runtime.Object
 
 // CatalogSourceConfigList contains a list of CatalogSourceConfig

--- a/pkg/catalogsourceconfig/configuring.go
+++ b/pkg/catalogsourceconfig/configuring.go
@@ -110,13 +110,13 @@ func (r *configuringReconciler) reconcileCatalogSource(csc *v1alpha1.CatalogSour
 	// Check if the CatalogSource already exists
 	catalogSourceGet := new(CatalogSourceBuilder).WithTypeMeta().CatalogSource()
 	key := client.ObjectKey{
-		Name:      v1alpha1.CatalogSourcePrefix + csc.Name,
+		Name:      csc.Name,
 		Namespace: csc.Spec.TargetNamespace,
 	}
 	err = r.client.Get(context.TODO(), key, catalogSourceGet)
 
 	// Update the CatalogSource if it exists else create one.
-	configMapName := v1alpha1.ConfigMapPrefix + csc.Name
+	configMapName := csc.Name
 	if err == nil {
 		if catalogSourceGet.Spec.ConfigMap != configMapName {
 			catalogSourceGet.Spec.ConfigMap = configMapName
@@ -157,7 +157,7 @@ func (r *configuringReconciler) reconcileConfigMap(csc *v1alpha1.CatalogSourceCo
 	}
 
 	// Check if the ConfigMap already exists
-	configMapName := v1alpha1.ConfigMapPrefix + csc.Name
+	configMapName := csc.Name
 	configMapGet := new(ConfigMapBuilder).WithTypeMeta().ConfigMap()
 	key := client.ObjectKey{
 		Name:      configMapName,
@@ -197,7 +197,7 @@ func GetPackageIDs(csIDs string) []string {
 // newConfigMap returns a new ConfigMap object.
 func newConfigMap(csc *v1alpha1.CatalogSourceConfig, data map[string]string) *corev1.ConfigMap {
 	return new(ConfigMapBuilder).
-		WithMeta(v1alpha1.ConfigMapPrefix+csc.Name, csc.Spec.TargetNamespace).
+		WithMeta(csc.Name, csc.Spec.TargetNamespace).
 		WithOwner(csc).
 		WithData(data).
 		ConfigMap()
@@ -207,9 +207,9 @@ func newConfigMap(csc *v1alpha1.CatalogSourceConfig, data map[string]string) *co
 func newCatalogSource(csc *v1alpha1.CatalogSourceConfig, configMapName string) *olm.CatalogSource {
 	builder := new(CatalogSourceBuilder).
 		WithOwner(csc).
-		WithMeta(v1alpha1.CatalogSourcePrefix+csc.Name, csc.Spec.TargetNamespace).
+		WithMeta(csc.Name, csc.Spec.TargetNamespace).
 		// TBD: where do we get display name and publisher from?
-		WithSpec("internal", configMapName, csc.Name, csc.Name)
+		WithSpec("internal", configMapName, "Marketplace Operators", "Red Hat")
 
 	// Check if the operatorsource.DatastoreLabel is "true" which indicates that
 	// the CatalogSource is the datastore for an OperatorSource. This is a hint

--- a/pkg/catalogsourceconfig/update.go
+++ b/pkg/catalogsourceconfig/update.go
@@ -68,7 +68,7 @@ func (r *updateReconciler) deleteObjects(in *v1alpha1.CatalogSourceConfig) error
 	}
 
 	// Delete the ConfigMap
-	name := v1alpha1.ConfigMapPrefix + in.Name
+	name := in.Name
 	configMap := new(ConfigMapBuilder).
 		WithMeta(name, cachedCSCSpec.TargetNamespace).
 		ConfigMap()
@@ -79,7 +79,7 @@ func (r *updateReconciler) deleteObjects(in *v1alpha1.CatalogSourceConfig) error
 	r.log.Infof("Deleted ConfigMap %s/%s", cachedCSCSpec.TargetNamespace, name)
 
 	// Delete the CatalogSource
-	name = v1alpha1.CatalogSourcePrefix + in.Name
+	name = in.Name
 	catalogSource := new(CatalogSourceBuilder).
 		WithMeta(name, cachedCSCSpec.TargetNamespace).
 		CatalogSource()

--- a/pkg/operatorsource/configuring.go
+++ b/pkg/operatorsource/configuring.go
@@ -2,8 +2,6 @@ package operatorsource
 
 import (
 	"context"
-	"fmt"
-
 	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
@@ -11,11 +9,6 @@ import (
 	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/types"
 	"sigs.k8s.io/controller-runtime/pkg/client"
-)
-
-const (
-	// The prefix to a name we use to create CatalogSourceConfig object.
-	catalogSourceConfigPrefix = "opsrc"
 )
 
 // NewConfiguringReconciler returns a Reconciler that reconciles
@@ -65,7 +58,7 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 
 	out = in
 
-	cscName := getCatalogSourceConfigName(in.Name)
+	cscName := in.Name
 	cscNamespacedName := types.NamespacedName{Name: cscName, Namespace: in.Namespace}
 	cscRetrievedInto := r.builder.WithMeta(in.Namespace, cscName).CatalogSourceConfig()
 
@@ -100,10 +93,4 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 	r.logger.Info("The object has been successfully reconciled")
 
 	return
-}
-
-// Given a name of OperatorSource object, this function returns the name
-// of the corresponding CatalogSourceConfig type object.
-func getCatalogSourceConfigName(operatorsourceName string) string {
-	return fmt.Sprintf("%s-%s", catalogSourceConfigPrefix, operatorsourceName)
 }

--- a/pkg/operatorsource/configuring_test.go
+++ b/pkg/operatorsource/configuring_test.go
@@ -2,7 +2,6 @@ package operatorsource_test
 
 import (
 	"context"
-	"fmt"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,10 +16,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
-
-func getExpectedCatalogSourceConfigName(opsrcName string) string {
-	return fmt.Sprintf("opsrc-%s", opsrcName)
-}
 
 // Use Case: Not configured, CatalogSourceConfig object has not been created yet.
 // Expected Result: A properly populated CatalogSourceConfig should get created
@@ -41,10 +36,10 @@ func TestReconcile_NotConfigured_NewCatalogConfigSourceObjectCreated(t *testing.
 
 	ctx := context.TODO()
 	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.Configuring)
-	namespacedName := types.NamespacedName{Name: "opsrc-foo", Namespace: "marketplace"}
+	namespacedName := types.NamespacedName{Name: "foo", Namespace: "marketplace"}
 
 	// We expect that the given CatalogConfigSource object does not exist.
-	cscGet := helperNewCatalogSourceConfig(opsrcIn.Namespace, getExpectedCatalogSourceConfigName(opsrcIn.Name))
+	cscGet := helperNewCatalogSourceConfig(opsrcIn.Namespace, opsrcIn.Name)
 	kubeClientErr := k8s_errors.NewNotFound(schema.GroupResource{}, "CatalogSourceConfig not found")
 	kubeclient.EXPECT().Get(context.TODO(), namespacedName, cscGet).Return(kubeClientErr)
 
@@ -93,8 +88,8 @@ func TestReconcile_AlreadyConfigured_NoActionTaken(t *testing.T) {
 
 	ctx := context.TODO()
 	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.Configuring)
-	namespacedName := types.NamespacedName{Name: "opsrc-foo", Namespace: "marketplace"}
-	cscGet := helperNewCatalogSourceConfig(opsrcIn.Namespace, getExpectedCatalogSourceConfigName(opsrcIn.Name))
+	namespacedName := types.NamespacedName{Name: "foo", Namespace: "marketplace"}
+	cscGet := helperNewCatalogSourceConfig(opsrcIn.Namespace, opsrcIn.Name)
 
 	// We expect that the given CatalogConfigSource object already exists.
 	kubeclient.EXPECT().Get(context.TODO(), namespacedName, cscGet).Return(nil).Times(1)

--- a/pkg/operatorsource/purging.go
+++ b/pkg/operatorsource/purging.go
@@ -57,7 +57,7 @@ func (r *purgingReconciler) Reconcile(ctx context.Context, in *v1alpha1.Operator
 	r.datastore.RemoveOperatorSource(in.GetUID())
 
 	builder := &CatalogSourceConfigBuilder{}
-	csc := builder.WithMeta(in.Namespace, getCatalogSourceConfigName(in.Name)).CatalogSourceConfig()
+	csc := builder.WithMeta(in.Namespace, in.Name).CatalogSourceConfig()
 
 	if err = r.client.Delete(ctx, csc); err != nil && !k8s_errors.IsNotFound(err) {
 		nextPhase = phase.GetNextWithMessage(phase.Failed, err.Error())

--- a/pkg/operatorsource/purging_test.go
+++ b/pkg/operatorsource/purging_test.go
@@ -37,7 +37,7 @@ func TestReconcileWithPurging(t *testing.T) {
 	reconciler := operatorsource.NewPurgingReconciler(helperGetContextLogger(), datastore, client)
 
 	// We expect the operator source to be removed from the datastore.
-	csc := helperNewCatalogSourceConfig(opsrcIn.Namespace, getExpectedCatalogSourceConfigName(opsrcIn.Name))
+	csc := helperNewCatalogSourceConfig(opsrcIn.Namespace, opsrcIn.Name)
 	datastore.EXPECT().RemoveOperatorSource(opsrcIn.GetUID()).Times(1)
 
 	// We expect the associated CatalogConfigSource object to be deleted.
@@ -72,7 +72,7 @@ func TestReconcileWithPurgingWithCatalogSourceConfigNotFound(t *testing.T) {
 	reconciler := operatorsource.NewPurgingReconciler(helperGetContextLogger(), datastore, client)
 
 	// We expect the operator source to be removed from the datastore.
-	csc := helperNewCatalogSourceConfig(opsrcIn.Namespace, getExpectedCatalogSourceConfigName(opsrcIn.Name))
+	csc := helperNewCatalogSourceConfig(opsrcIn.Namespace, opsrcIn.Name)
 	datastore.EXPECT().RemoveOperatorSource(opsrcIn.GetUID())
 
 	// We expect kube client to throw a NotFound error.

--- a/test/e2e/marketplace_test.go
+++ b/test/e2e/marketplace_test.go
@@ -96,7 +96,7 @@ func defaultCreateTest(t *testing.T, f *test.Framework, ctx *test.TestCtx) error
 			Kind: operator.OperatorSourceKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      "global-operators",
+			Name:      "test-operators",
 			Namespace: namespace,
 		},
 		Spec: operator.OperatorSourceSpec{
@@ -106,9 +106,9 @@ func defaultCreateTest(t *testing.T, f *test.Framework, ctx *test.TestCtx) error
 		},
 	}
 
-	catalogSourceConfigName := "opsrc-global-operators"
-	configMapName := "csc-cm-opsrc-global-operators"
-	catalogSourceName := "csc-cs-opsrc-global-operators"
+	catalogSourceConfigName := "test-operators"
+	configMapName := "test-operators"
+	catalogSourceName := "test-operators"
 
 	// Create the operatorsource to download the manifests.
 	err = f.Client.Create(


### PR DESCRIPTION
- Remove the prefixes of the created CatalogSourceConfigs, CatalogSources and ConfigMaps. This has been done to make the naming more consistent.
- Hard code the display name to "Marketplace Operators" and publisher to "Red Hat" in the CatalogSource. This has been done to make the OLM package UI display look nice.