### PR TITLE
Make datastore access concurrent

### DIFF
--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -84,69 +84,6 @@ type Writer interface {
 	GetOperatorSource(opsrcUID types.UID) (spec *v1alpha1.OperatorSourceSpec, ok bool)
 }
 
-// operatorSourceRow is what gets stored in datastore after an OperatorSource CR
-// is reconciled.
-//
-// Every reconciled OperatorSource object has a corresponding operatorSourceRow
-// in datastore. The Writer interface accepts a raw operator manifest and
-// marshals it into this type before writing it to the underlying storage.
-type operatorSourceRow struct {
-	// We store the Spec associated with a given OperatorSource object. This is
-	// so that we can determine whether Spec for an existing operator source
-	// has been updated.
-	//
-	// We compare the Spec of the received OperatorSource object to the one
-	// in datastore.
-	Spec *v1alpha1.OperatorSourceSpec
-
-	// Operators is the collection of all single-operator manifest(s) associated
-	// with the underlying operator source.
-	// The package name is used to uniquely identify the operator manifest(s).
-	Operators map[string]*SingleOperatorManifest
-}
-
-// GetPackages returns the list of available package(s) associated with an
-// operator source.
-// An empty list is returned if there are no package(s).
-func (r *operatorSourceRow) GetPackages() []string {
-	packages := make([]string, 0)
-	for packageID, _ := range r.Operators {
-		packages = append(packages, packageID)
-	}
-
-	return packages
-}
-
-// operatorSourceRowMap is a map that holds a collection of operator source(s)
-// represented by operatorSourceRow.
-// The UID of an OperatorSource object is used as the key to uniquely identify
-// an operator source.
-type operatorSourceRowMap map[types.UID]*operatorSourceRow
-
-// GetAllPackages return a list of all package(s) available across all
-// operator source(s).
-func (m operatorSourceRowMap) GetAllPackages() []string {
-	packages := make([]string, 0)
-	for _, row := range m {
-		packages = append(packages, row.GetPackages()...)
-	}
-
-	return packages
-}
-
-// GetAllPackagesMap returns a collection of all available package(s) across all
-// operator sources in a map. Package name is used as the key to this map.
-func (m operatorSourceRowMap) GetAllPackagesMap() map[string]*SingleOperatorManifest {
-	packages := map[string]*SingleOperatorManifest{}
-	for _, row := range m {
-		for packageID, manifest := range row.Operators {
-			packages[packageID] = manifest
-		}
-	}
-
-	return packages
-}
-
 // memoryDatastore is an in-memory implementation of operator manifest datastore.
 // TODO: In future, it will be replaced by an indexable persistent datastore.
 type memoryDatastore struct {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -22,7 +22,7 @@ func init() {
 // New returns an instance of memoryDatastore.
 func New() *memoryDatastore {
 	return &memoryDatastore{
-		rows:    operatorSourceRowMap{},
+		rows:    newOperatorSourceRowMap(),
 		parser:  &manifestYAMLParser{},
 		walker:  &walker{},
 		bundler: &bundler{},
@@ -111,7 +111,7 @@ type Writer interface {
 // memoryDatastore is an in-memory implementation of operator manifest datastore.
 // TODO: In future, it will be replaced by an indexable persistent datastore.
 type memoryDatastore struct {
-	rows    operatorSourceRowMap
+	rows    *operatorSourceRowMap
 	parser  ManifestYAMLParser
 	walker  ManifestWalker
 	bundler Bundler
@@ -158,19 +158,7 @@ func (ds *memoryDatastore) Write(opsrc *v1alpha1.OperatorSource, rawManifests []
 		metadata[rawManifest.RegistryMetadata.Repository] = &rawManifest.RegistryMetadata
 	}
 
-	row := &operatorSourceRow{
-		OperatorSourceKey: OperatorSourceKey{
-			Name: types.NamespacedName{
-				Namespace: opsrc.GetNamespace(),
-				Name:      opsrc.GetName(),
-			},
-			Spec: &opsrc.Spec,
-		},
-		Operators: operators,
-		Metadata:  metadata,
-	}
-
-	ds.rows[opsrc.GetUID()] = row
+	ds.rows.Add(opsrc, metadata, operators)
 
 	return nil
 }
@@ -181,7 +169,7 @@ func (ds *memoryDatastore) GetPackageIDs() string {
 }
 
 func (ds *memoryDatastore) GetPackageIDsByOperatorSource(opsrcUID types.UID) string {
-	row, exists := ds.rows[opsrcUID]
+	row, exists := ds.rows.GetRow(opsrcUID)
 	if !exists {
 		return ""
 	}
@@ -191,24 +179,15 @@ func (ds *memoryDatastore) GetPackageIDsByOperatorSource(opsrcUID types.UID) str
 }
 
 func (ds *memoryDatastore) AddOperatorSource(opsrc *v1alpha1.OperatorSource) {
-	ds.rows[opsrc.GetUID()] = &operatorSourceRow{
-		OperatorSourceKey: OperatorSourceKey{
-			Name: types.NamespacedName{
-				Namespace: opsrc.GetNamespace(),
-				Name:      opsrc.GetName(),
-			},
-			Spec: &opsrc.Spec,
-		},
-		Operators: map[string]*SingleOperatorManifest{},
-	}
+	ds.rows.AddEmpty(opsrc)
 }
 
 func (ds *memoryDatastore) RemoveOperatorSource(uid types.UID) {
-	delete(ds.rows, uid)
+	ds.rows.Remove(uid)
 }
 
 func (ds *memoryDatastore) GetOperatorSource(opsrcUID types.UID) (*OperatorSourceKey, bool) {
-	row, exists := ds.rows[opsrcUID]
+	row, exists := ds.rows.GetRow(opsrcUID)
 	if !exists {
 		return nil, false
 	}
@@ -219,7 +198,7 @@ func (ds *memoryDatastore) GetOperatorSource(opsrcUID types.UID) (*OperatorSourc
 func (ds *memoryDatastore) OperatorSourceHasUpdate(opsrcUID types.UID, metadata []*RegistryMetadata) (bool, error) {
 	// TODO: Return fine grained information that describes repository that
 	// was removed, added or has a new release.
-	row, exists := ds.rows[opsrcUID]
+	row, exists := ds.rows.GetRow(opsrcUID)
 	if !exists {
 		return false, fmt.Errorf("datastore has no record of the specified OperatorSource [%s]", opsrcUID)
 	}

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -81,7 +81,31 @@ type Writer interface {
 	// datastore uses the UID of the given OperatorSource object to check if
 	// a Spec already exists. If no Spec is found then the function
 	// returns (nil, false).
-	GetOperatorSource(opsrcUID types.UID) (spec *v1alpha1.OperatorSourceSpec, ok bool)
+	GetOperatorSource(opsrcUID types.UID) (key *OperatorSourceKey, ok bool)
+
+	// OperatorSourceHasUpdate returns true if the operator source in remote
+	// registry specified in metadata has update(s) that need to be pulled.
+	//
+	// The function returns true if the remote registry has any update(s). The
+	// following event(s) indicate that a remote registry has been updated.
+	//   - New repositories have been added to the remote registry associated
+	//     with the operator source.
+	//   - Existing repositories have been removed from the remote registry
+	//     associated with the operator source.
+	//   - A new release for an existing repository has been pushed to
+	//     the registry.
+	//
+	// Right now we consider remote and local operator source to be same only
+	// when the following conditions are true:
+	//
+	// - Number of repositories in both local and remote are exactly the same.
+	// - Each repository in remote has a corresponding local repository with
+	//   exactly the same release.
+	//
+	// The current implementation does not return update information specific
+	// to each repository. The lack of granular (per repository) information
+	// will force us to reload the entire namespace.
+	OperatorSourceHasUpdate(opsrcUID types.UID, metadata []*RegistryMetadata) (bool, error)
 }
 
 // memoryDatastore is an in-memory implementation of operator manifest datastore.
@@ -112,6 +136,7 @@ func (ds *memoryDatastore) Write(opsrc *v1alpha1.OperatorSource, rawManifests []
 		return errors.New("invalid argument")
 	}
 
+	metadata := map[string]*RegistryMetadata{}
 	operators := map[string]*SingleOperatorManifest{}
 	for _, rawManifest := range rawManifests {
 		data, err := ds.parser.Unmarshal(rawManifest.RawYAML)
@@ -128,11 +153,21 @@ func (ds *memoryDatastore) Write(opsrc *v1alpha1.OperatorSource, rawManifests []
 		for i, operatorPackage := range packages {
 			operators[operatorPackage.GetPackageID()] = packages[i]
 		}
+
+		// For each repository store the associated registry metadata.
+		metadata[rawManifest.RegistryMetadata.Repository] = &rawManifest.RegistryMetadata
 	}
 
 	row := &operatorSourceRow{
-		Spec:      &opsrc.Spec,
+		OperatorSourceKey: OperatorSourceKey{
+			Name: types.NamespacedName{
+				Namespace: opsrc.GetNamespace(),
+				Name:      opsrc.GetName(),
+			},
+			Spec: &opsrc.Spec,
+		},
 		Operators: operators,
+		Metadata:  metadata,
 	}
 
 	ds.rows[opsrc.GetUID()] = row
@@ -157,7 +192,13 @@ func (ds *memoryDatastore) GetPackageIDsByOperatorSource(opsrcUID types.UID) str
 
 func (ds *memoryDatastore) AddOperatorSource(opsrc *v1alpha1.OperatorSource) {
 	ds.rows[opsrc.GetUID()] = &operatorSourceRow{
-		Spec:      &opsrc.Spec,
+		OperatorSourceKey: OperatorSourceKey{
+			Name: types.NamespacedName{
+				Namespace: opsrc.GetNamespace(),
+				Name:      opsrc.GetName(),
+			},
+			Spec: &opsrc.Spec,
+		},
 		Operators: map[string]*SingleOperatorManifest{},
 	}
 }
@@ -166,13 +207,43 @@ func (ds *memoryDatastore) RemoveOperatorSource(uid types.UID) {
 	delete(ds.rows, uid)
 }
 
-func (ds *memoryDatastore) GetOperatorSource(opsrcUID types.UID) (opsrc *v1alpha1.OperatorSourceSpec, ok bool) {
+func (ds *memoryDatastore) GetOperatorSource(opsrcUID types.UID) (*OperatorSourceKey, bool) {
 	row, exists := ds.rows[opsrcUID]
 	if !exists {
 		return nil, false
 	}
 
-	return row.Spec, true
+	return &row.OperatorSourceKey, true
+}
+
+func (ds *memoryDatastore) OperatorSourceHasUpdate(opsrcUID types.UID, metadata []*RegistryMetadata) (bool, error) {
+	// TODO: Return fine grained information that describes repository that
+	// was removed, added or has a new release.
+	row, exists := ds.rows[opsrcUID]
+	if !exists {
+		return false, fmt.Errorf("datastore has no record of the specified OperatorSource [%s]", opsrcUID)
+	}
+
+	if len(row.Metadata) != len(metadata) {
+		return true, nil
+	}
+
+	for _, remote := range metadata {
+		if remote.Release == "" {
+			return false, fmt.Errorf("Release not specified for repository [%s]", remote.ID())
+		}
+
+		local, exists := row.Metadata[remote.Repository]
+		if !exists {
+			return true, nil
+		}
+
+		if local.Release != remote.Release {
+			return true, nil
+		}
+	}
+
+	return false, nil
 }
 
 // validate ensures that no package is mentioned more than once in the list.

--- a/pkg/datastore/metadata.go
+++ b/pkg/datastore/metadata.go
@@ -40,6 +40,6 @@ type RegistryMetadata struct {
 }
 
 // ID returns the unique identifier associated with this operator manifest.
-func (om *OperatorMetadata) ID() string {
-	return fmt.Sprintf("%s/%s", om.RegistryMetadata.Namespace, om.RegistryMetadata.Repository)
+func (rm *RegistryMetadata) ID() string {
+	return fmt.Sprintf("%s/%s", rm.Namespace, rm.Repository)
 }

--- a/pkg/datastore/row.go
+++ b/pkg/datastore/row.go
@@ -1,0 +1,73 @@
+package datastore
+
+import (
+	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// operatorSourceRow is what gets stored in datastore after an OperatorSource CR
+// is reconciled.
+//
+// Every reconciled OperatorSource object has a corresponding operatorSourceRow
+// in datastore. The Writer interface accepts a raw operator manifest and
+// marshals it into this type before writing it to the underlying storage.
+type operatorSourceRow struct {
+	// We store the Spec associated with a given OperatorSource object. This is
+	// so that we can determine whether Spec for an existing operator source
+	// has been updated.
+	//
+	// We compare the Spec of the received OperatorSource object to the one
+	// in datastore.
+	Spec *v1alpha1.OperatorSourceSpec
+
+	// Operators is the collection of all single-operator manifest(s) associated
+	// with the underlying operator source.
+	// The package name is used to uniquely identify the operator manifest(s).
+	Operators map[string]*SingleOperatorManifest
+
+	// Metadata is the metadata associated with each repository under the given
+	// namespace.
+	Metadata map[string]*RegistryMetadata
+}
+
+// GetPackages returns the list of available package(s) associated with an
+// operator source.
+// An empty list is returned if there are no package(s).
+func (r *operatorSourceRow) GetPackages() []string {
+	packages := make([]string, 0)
+	for packageID, _ := range r.Operators {
+		packages = append(packages, packageID)
+	}
+
+	return packages
+}
+
+// operatorSourceRowMap is a map that holds a collection of operator source(s)
+// represented by operatorSourceRow.
+// The UID of an OperatorSource object is used as the key to uniquely identify
+// an operator source.
+type operatorSourceRowMap map[types.UID]*operatorSourceRow
+
+// GetAllPackages return a list of all package(s) available across all
+// operator source(s).
+func (m operatorSourceRowMap) GetAllPackages() []string {
+	packages := make([]string, 0)
+	for _, row := range m {
+		packages = append(packages, row.GetPackages()...)
+	}
+
+	return packages
+}
+
+// GetAllPackagesMap returns a collection of all available package(s) across all
+// operator sources in a map. Package name is used as the key to this map.
+func (m operatorSourceRowMap) GetAllPackagesMap() map[string]*SingleOperatorManifest {
+	packages := map[string]*SingleOperatorManifest{}
+	for _, row := range m {
+		for packageID, manifest := range row.Operators {
+			packages[packageID] = manifest
+		}
+	}
+
+	return packages
+}

--- a/pkg/datastore/row.go
+++ b/pkg/datastore/row.go
@@ -5,13 +5,13 @@ import (
 	"k8s.io/apimachinery/pkg/types"
 )
 
-// operatorSourceRow is what gets stored in datastore after an OperatorSource CR
-// is reconciled.
-//
-// Every reconciled OperatorSource object has a corresponding operatorSourceRow
-// in datastore. The Writer interface accepts a raw operator manifest and
-// marshals it into this type before writing it to the underlying storage.
-type operatorSourceRow struct {
+// OperatorSourceKey is what datastore uses to relate to an OperatorSource
+// object.
+type OperatorSourceKey struct {
+	// Name is the namespaced name of the given OperatorSource object that
+	// uniquely identifies it and can be used to query the k8s API server.
+	Name types.NamespacedName
+
 	// We store the Spec associated with a given OperatorSource object. This is
 	// so that we can determine whether Spec for an existing operator source
 	// has been updated.
@@ -19,6 +19,16 @@ type operatorSourceRow struct {
 	// We compare the Spec of the received OperatorSource object to the one
 	// in datastore.
 	Spec *v1alpha1.OperatorSourceSpec
+}
+
+// operatorSourceRow is what gets stored in datastore after an OperatorSource CR
+// is reconciled.
+//
+// Every reconciled OperatorSource object has a corresponding operatorSourceRow
+// in datastore. The Writer interface accepts a raw operator manifest and
+// marshals it into this type before writing it to the underlying storage.
+type operatorSourceRow struct {
+	OperatorSourceKey
 
 	// Operators is the collection of all single-operator manifest(s) associated
 	// with the underlying operator source.

--- a/pkg/datastore/row.go
+++ b/pkg/datastore/row.go
@@ -1,9 +1,17 @@
 package datastore
 
 import (
+	"sync"
+
 	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
 	"k8s.io/apimachinery/pkg/types"
 )
+
+func newOperatorSourceRowMap() *operatorSourceRowMap {
+	return &operatorSourceRowMap{
+		Sources: map[types.UID]*operatorSourceRow{},
+	}
+}
 
 // OperatorSourceKey is what datastore uses to relate to an OperatorSource
 // object.
@@ -56,13 +64,69 @@ func (r *operatorSourceRow) GetPackages() []string {
 // represented by operatorSourceRow.
 // The UID of an OperatorSource object is used as the key to uniquely identify
 // an operator source.
-type operatorSourceRowMap map[types.UID]*operatorSourceRow
+type operatorSourceRowMap struct {
+	lock sync.RWMutex
+
+	// Sources is a map of operatorSourceRow where UID of the given
+	// OperatorSource object is used as key.
+	Sources map[types.UID]*operatorSourceRow
+}
+
+// AddEmpty adds a new operator source to the map with an empty set of
+// registry metadata and operator manifest(s).
+func (m *operatorSourceRowMap) AddEmpty(opsrc *v1alpha1.OperatorSource) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.add(opsrc, map[string]*RegistryMetadata{}, map[string]*SingleOperatorManifest{})
+}
+
+// Add adds a new operator source to the map with an the specified set of
+// registry metadata and operator manifest(s).
+func (m *operatorSourceRowMap) Add(opsrc *v1alpha1.OperatorSource, metadata map[string]*RegistryMetadata, operators map[string]*SingleOperatorManifest) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	m.add(opsrc, metadata, operators)
+}
+
+func (m *operatorSourceRowMap) add(opsrc *v1alpha1.OperatorSource, metadata map[string]*RegistryMetadata, operators map[string]*SingleOperatorManifest) {
+	m.Sources[opsrc.GetUID()] = &operatorSourceRow{
+		OperatorSourceKey: OperatorSourceKey{
+			Name: types.NamespacedName{
+				Namespace: opsrc.GetNamespace(),
+				Name:      opsrc.GetName(),
+			},
+			Spec: &opsrc.Spec,
+		},
+		Operators: operators,
+		Metadata:  metadata,
+	}
+}
+
+func (m *operatorSourceRowMap) Remove(opsrcUID types.UID) {
+	m.lock.Lock()
+	defer m.lock.Unlock()
+
+	delete(m.Sources, opsrcUID)
+}
+
+func (m *operatorSourceRowMap) GetRow(opsrcUID types.UID) (*operatorSourceRow, bool) {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
+	row, ok := m.Sources[opsrcUID]
+	return row, ok
+}
 
 // GetAllPackages return a list of all package(s) available across all
 // operator source(s).
-func (m operatorSourceRowMap) GetAllPackages() []string {
+func (m *operatorSourceRowMap) GetAllPackages() []string {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
 	packages := make([]string, 0)
-	for _, row := range m {
+	for _, row := range m.Sources {
 		packages = append(packages, row.GetPackages()...)
 	}
 
@@ -72,8 +136,11 @@ func (m operatorSourceRowMap) GetAllPackages() []string {
 // GetAllPackagesMap returns a collection of all available package(s) across all
 // operator sources in a map. Package name is used as the key to this map.
 func (m operatorSourceRowMap) GetAllPackagesMap() map[string]*SingleOperatorManifest {
+	m.lock.RLock()
+	defer m.lock.RUnlock()
+
 	packages := map[string]*SingleOperatorManifest{}
-	for _, row := range m {
+	for _, row := range m.Sources {
 		for packageID, manifest := range row.Operators {
 			packages[packageID] = manifest
 		}

--- a/pkg/operatorsource/outofsync.go
+++ b/pkg/operatorsource/outofsync.go
@@ -63,8 +63,8 @@ func (r *outOfSyncCacheReconciler) Reconcile(ctx context.Context, in *v1alpha1.O
 
 	// If we are here, the object is in a particular phase. Now is the time to
 	// determine if Spec of the OperatorSource object has been updated.
-	oldSpec, exists := r.datastore.GetOperatorSource(in.GetUID())
-	if exists && oldSpec.IsEqual(&in.Spec) {
+	source, exists := r.datastore.GetOperatorSource(in.GetUID())
+	if exists && source.Spec.IsEqual(&in.Spec) {
 		// Underlying datastore is aware of the OperatorSource object and
 		// Spec has not been modified.
 		// Let the regular phased reconciler handle the OperatorSource object.


### PR DESCRIPTION
* Make `datastore` access concurrent since there will be concurrent reader(s) and writer(s) of the underlying datastore.
* Store registry metadata that includes release information associated with each repository in remote registry so that we can determine if there is a new release.
* Add a new function 'OperatorSourceHasUpdate' that returns true if the operator source in remote registry has any update(s).

The above feature(s) are going to pave the way for `sync in cluster datastore cache with remote registry update(s)`.