### PR TITLE
Keep datastore in sync with registry update(s)

### DIFF
--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -106,6 +106,10 @@ type Writer interface {
 	// to each repository. The lack of granular (per repository) information
 	// will force us to reload the entire namespace.
 	OperatorSourceHasUpdate(opsrcUID types.UID, metadata []*RegistryMetadata) (bool, error)
+
+	// GetAllOperatorSources returns a list of all OperatorSource objecs(s) that
+	// datastore is aware of.
+	GetAllOperatorSources() []*OperatorSourceKey
 }
 
 // memoryDatastore is an in-memory implementation of operator manifest datastore.
@@ -223,6 +227,10 @@ func (ds *memoryDatastore) OperatorSourceHasUpdate(opsrcUID types.UID, metadata 
 	}
 
 	return false, nil
+}
+
+func (ds *memoryDatastore) GetAllOperatorSources() []*OperatorSourceKey {
+	return ds.rows.GetAllRows()
 }
 
 // validate ensures that no package is mentioned more than once in the list.

--- a/pkg/operatorsource/poller.go
+++ b/pkg/operatorsource/poller.go
@@ -1,0 +1,81 @@
+package operatorsource
+
+import (
+	"fmt"
+
+	"github.com/operator-framework/operator-marketplace/pkg/appregistry"
+	"github.com/operator-framework/operator-marketplace/pkg/datastore"
+	"github.com/operator-framework/operator-marketplace/pkg/phase"
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewPoller returns a new instance of Poller interface.
+func NewPoller(client client.Client) Poller {
+	poller := &poller{
+		datastore: datastore.Cache,
+		helper: &pollHelper{
+			factory:      appregistry.NewClientFactory(),
+			datastore:    datastore.Cache,
+			client:       client,
+			transitioner: phase.NewTransitioner(),
+		},
+	}
+
+	return poller
+}
+
+// Poller is an interface that wraps the Poll method.
+//
+// Poll iterates through all available operator source(s) that are in the
+// underlying datastore and performs the following action(s):
+//   a) It polls the remote registry namespace to check if there are any
+//      update(s) available.
+//
+//   b) If there is an update available then it triggers a purge and rebuild
+//      operation for the specified OperatorSource object.
+//
+// On any error during each iteration it logs the error encountered and moves
+// on to the next OperatorSource object.
+type Poller interface {
+	Poll()
+}
+
+// poller implements the Poller interface.
+type poller struct {
+	helper    PollHelper
+	datastore datastore.Writer
+}
+
+func (p *poller) Poll() {
+	sources := p.datastore.GetAllOperatorSources()
+
+	for _, source := range sources {
+		if err := p.pollSource(source); err != nil {
+			log.Errorf("%v", err)
+		}
+	}
+}
+
+func (p *poller) pollSource(source *datastore.OperatorSourceKey) error {
+	updated, err := p.helper.HasUpdate(source)
+	if err != nil {
+		return fmt.Errorf("[sync] error checking for updates [%s] - %v", source.Name, err)
+	}
+
+	if !updated {
+		return nil
+	}
+
+	log.Infof("[sync] remote registry has update(s) - purging OperatorSource [%s]", source.Name)
+	deleted, err := p.helper.TriggerPurge(source)
+	if err != nil {
+		return fmt.Errorf("[sync] error updating object [%s] - %v", source.Name, err)
+	}
+
+	if deleted {
+		log.Infof("[sync] object deleted [%s] - no action taken", source.Name)
+	}
+
+	return nil
+}

--- a/pkg/operatorsource/pollhelper.go
+++ b/pkg/operatorsource/pollhelper.go
@@ -1,0 +1,109 @@
+package operatorsource
+
+import (
+	"context"
+	"errors"
+
+	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/appregistry"
+	"github.com/operator-framework/operator-marketplace/pkg/datastore"
+	"github.com/operator-framework/operator-marketplace/pkg/phase"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// PollHelper is an interface that can be used to check whether a remote registry
+// has any update(s) and trigger a rebuild of in-cluster OperatorSource cache.
+type PollHelper interface {
+	// HasUpdate contacts the remote registry associated with the specified
+	// OperatorSource object, fetches release metadata and determines whether
+	// the remote registry has new update(s).
+	//
+	// It returns true if the remote registry has update(s), otherwise it
+	// returns false.
+	// If the function encounters any error then it returns (false, err).
+	HasUpdate(source *datastore.OperatorSourceKey) (bool, error)
+
+	// TriggerPurge triggers a rebuild of the cache associated with the
+	// specified OperatorSource object.
+	//
+	// It fetches the latest copy of the specified OperatorSource object and
+	// then sets the phase to 'Purging' so that the cache is invalidated and
+	// reconciliation can start new.
+	//
+	// On return, deleted is set to true if the object has already been deleted.
+	// updateErr is set to the error the function encounters while it tries
+	// to update the OperatorSource object.
+	TriggerPurge(source *datastore.OperatorSourceKey) (deleted bool, updateErr error)
+}
+
+// pollHelper implements the PollHelper interface.
+type pollHelper struct {
+	factory      appregistry.ClientFactory
+	datastore    datastore.Writer
+	client       client.Client
+	transitioner phase.Transitioner
+}
+
+func (h *pollHelper) HasUpdate(source *datastore.OperatorSourceKey) (bool, error) {
+	// Get the latest version of the operator source from underlying datastore.
+	source, exists := h.datastore.GetOperatorSource(source.UID)
+	if !exists {
+		return false, errors.New("The given OperatorSource object does not exist in datastore")
+	}
+
+	registry, err := h.factory.New(source.Spec.Type, source.Spec.Endpoint)
+	if err != nil {
+		return false, err
+	}
+
+	metadata, err := registry.ListPackages(source.Spec.RegistryNamespace)
+	if err != nil {
+		return false, err
+	}
+
+	updated, err := h.datastore.OperatorSourceHasUpdate(source.UID, metadata)
+	if err != nil {
+		return false, err
+	}
+
+	return updated, nil
+}
+
+func (h *pollHelper) TriggerPurge(source *datastore.OperatorSourceKey) (deleted bool, updateErr error) {
+	instance := &v1alpha1.OperatorSource{}
+
+	// Get the current state of the given object before we make any decision.
+	if err := h.client.Get(context.TODO(), source.Name, instance); err != nil {
+		// Not found, the given OperatorSource object could have been deleted.
+		// Treat it as no error and indicate that the object has been deleted.
+		if k8s_errors.IsNotFound(err) {
+			deleted = true
+			return
+		}
+
+		// Otherwise, it is an error.
+		updateErr = err
+		return
+	}
+
+	// Needed because sdk does not get the gvk.
+	instance.EnsureGVK()
+
+	// We want to purge the OperatorSource object so that the cache can rebuild.
+	nextPhase := &v1alpha1.Phase{
+		Name:    phase.OperatorSourcePurging,
+		Message: "Remote registry has been updated",
+	}
+	if !h.transitioner.TransitionInto(&instance.Status.CurrentPhase, nextPhase) {
+		// No need to update since the object is already in purging phase.
+		return
+	}
+
+	if err := h.client.Update(context.TODO(), instance); err != nil {
+		updateErr = err
+		return
+	}
+
+	return
+}

--- a/pkg/operatorsource/syncer.go
+++ b/pkg/operatorsource/syncer.go
@@ -1,0 +1,54 @@
+package operatorsource
+
+import (
+	"time"
+
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewRegistrySyncer returns a new instance of RegistrySyncer interface.
+func NewRegistrySyncer(client client.Client, initialWait time.Duration, resyncInterval time.Duration) RegistrySyncer {
+	return &registrySyncer{
+		initialWait:    initialWait,
+		resyncInterval: resyncInterval,
+		poller:         NewPoller(client),
+	}
+}
+
+// RegistrySyncer is an interface that wraps the Sync method.
+//
+// Sync kicks off the registry sync operation every N (resync wait time)
+// minutes. Sync will stop running once the stop channel is closed.
+type RegistrySyncer interface {
+	Sync(stop <-chan struct{})
+}
+
+// registrySyncer implements RegistrySyncer interface.
+type registrySyncer struct {
+	initialWait    time.Duration
+	resyncInterval time.Duration
+	poller         Poller
+}
+
+func (s *registrySyncer) Sync(stop <-chan struct{}) {
+	log.Infof("[sync] Operator source sync loop will start after %d minutes", s.initialWait)
+
+	// Immediately after the operator process starts, it will spend time in
+	// reconciling existing OperatorSource CR(s). Let's give the process a
+	// grace period to reconcile and rebuild the local cache from existing CR(s).
+	<-time.After(s.initialWait * time.Minute)
+
+	log.Info("[sync] Operator source sync loop has started")
+	for {
+		select {
+		case <-time.After(s.resyncInterval * time.Minute):
+			log.Debug("[sync] Checking for operator source update(s) in remote registry")
+			s.poller.Poll()
+
+		case <-stop:
+			log.Info("[sync] Ending operator source watch loop")
+			return
+		}
+	}
+}


### PR DESCRIPTION
Keep in-memory OperatorSource cache of datastore in sync with remote registry update(s). Rebuild the local cache when any of the following happens:
- A new repository has been added to the given namespace in remote registry associated with the OperatorSource object.
- An existing repository has been removed from the given namespace in remote registry associate with the OperatorSource object.
- A new release has been pushed for an existing repository in remote registry associate with the OperatorSource object.

Implement the following to accomplish the above goal:
* Add a new function 'ListPackages' in appregistry that returns latest metadata (with release information) for all repositories under the given namespace.
* Add 'Poller' that polls for changes to the underlying namespace associated with each OperatorSource object that datastore is aware of.
* Compare local metadata with remote and determine if there is any update. If an OperatorSource has update(s) available in remote registry then trigger a rebuild of datastore cache for the given OperatorSource object.
* Implement a 'RegistrySyncer' loop that checks every N minute(s) and kicks off the 'Polling' operation.
* Kick off the 'RegistrySyncer.Sync' method in a dedicated goroutine when the operator process starts.