### PR TITLE
[opsrc] Handle faulty operator manifest(s)

### DIFF
--- a/Gopkg.lock
+++ b/Gopkg.lock
@@ -978,6 +978,7 @@
     "k8s.io/apimachinery/pkg/runtime/schema",
     "k8s.io/apimachinery/pkg/types",
     "k8s.io/apimachinery/pkg/util/clock",
+    "k8s.io/apimachinery/pkg/util/errors",
     "k8s.io/apimachinery/pkg/util/wait",
     "k8s.io/client-go/plugin/pkg/client/auth/gcp",
     "k8s.io/code-generator/cmd/client-gen",

--- a/pkg/datastore/testdata/source-3-faulty.yaml
+++ b/pkg/datastore/testdata/source-3-faulty.yaml
@@ -1,0 +1,12 @@
+data:
+  customResourceDefinitions: |-      
+    - apiVersion: apiextensions.k8s.io/v1beta1
+      kind: CustomResourceDefinition
+      metadata:
+        name: faulty.foo.redhat.com
+  clusterServiceVersions: |-
+  packages: |-
+    - packageName: faulty
+      channels:
+      - name: alpha
+        currentCSV: where-is-my-csvs

--- a/pkg/operatorsource/downloading_test.go
+++ b/pkg/operatorsource/downloading_test.go
@@ -2,6 +2,7 @@ package operatorsource_test
 
 import (
 	"context"
+	"errors"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -54,7 +55,7 @@ func TestReconcile_ScheduledForDownload_Success(t *testing.T) {
 	registryClient.EXPECT().RetrieveAll(opsrcIn.Spec.RegistryNamespace).Return(manifestExpected, nil).Times(1)
 
 	// We expect the datastore to save downloaded manifest(s) returned by the registry.
-	writer.EXPECT().Write(opsrcIn, manifestExpected).Return(nil)
+	writer.EXPECT().Write(opsrcIn, manifestExpected).Return(1, nil)
 
 	// We expect datastore to return the specified list of packages.
 	writer.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return(opsrcWant.Status.Packages)
@@ -62,6 +63,59 @@ func TestReconcile_ScheduledForDownload_Success(t *testing.T) {
 	opsrcGot, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
 
 	assert.NoError(t, errGot)
+	assert.Equal(t, opsrcWant, opsrcGot)
+	assert.Equal(t, nextPhaseWant, nextPhaseGot)
+}
+
+// Use Case: Some raw operator manifest(s) downloaded are faulty.
+// Expected Result: Faulty manifest(s) are ignored and the next phase
+// set to "Configuring".
+func TestReconcile_HaveFaultyPackages_Success(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	nextPhaseWant := &v1alpha1.Phase{
+		Name:    phase.Configuring,
+		Message: phase.GetMessage(phase.Configuring),
+	}
+
+	writer := mocks.NewDatastoreWriter(controller)
+	factory := mocks.NewAppRegistryClientFactory(controller)
+
+	reconciler := operatorsource.NewDownloadingReconciler(helperGetContextLogger(), factory, writer)
+
+	ctx := context.TODO()
+	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.OperatorSourceDownloading)
+
+	opsrcWant := opsrcIn.DeepCopy()
+	opsrcWant.Status.Packages = "etcd,prometheus,amqp"
+
+	registryClient := mocks.NewAppRegistryClient(controller)
+	factory.EXPECT().New(opsrcIn.Spec.Type, opsrcIn.Spec.Endpoint).Return(registryClient, nil).Times(1)
+
+	// We expect the remote registry to return a non-empty list of manifest(s).
+	manifestExpected := []*datastore.OperatorMetadata{
+		&datastore.OperatorMetadata{
+			RegistryMetadata: datastore.RegistryMetadata{
+				Namespace:  "redhat",
+				Repository: "myapp",
+				Release:    "1.0.0",
+				Digest:     "abcdefgh",
+			},
+		},
+	}
+	registryClient.EXPECT().RetrieveAll(opsrcIn.Spec.RegistryNamespace).Return(manifestExpected, nil).Times(1)
+
+	// We expect the datastore to save downloaded manifest(s) returned by the registry.
+	writeErrorExpected := errors.New("faulty packages")
+	writer.EXPECT().Write(opsrcIn, manifestExpected).Return(1, writeErrorExpected)
+
+	// We expect datastore to return the specified list of packages.
+	writer.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return(opsrcWant.Status.Packages)
+
+	opsrcGot, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
+
+	assert.Nil(t, errGot)
 	assert.Equal(t, opsrcWant, opsrcGot)
 	assert.Equal(t, nextPhaseWant, nextPhaseGot)
 }


### PR DESCRIPTION
Handle faulty operator manifest(s) in remote registry associated
with an OperatorSource object in a graceful manner:

- Log error(s) encountered for faulty manifest(s).
- If a faulty package manifest is encountered move on to the next
  repository in the namespace as opposed to aborting the entire
  operation.