### PR TITLE
[opsrc] support for multiple operator source CR(s)

### DIFF
--- a/pkg/operatorsource/configuring.go
+++ b/pkg/operatorsource/configuring.go
@@ -2,6 +2,7 @@ package operatorsource
 
 import (
 	"context"
+
 	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
@@ -75,7 +76,7 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 		return
 	}
 
-	manifests := r.datastore.GetPackageIDs()
+	manifests := r.datastore.GetPackageIDsByOperatorSource(in.GetUID())
 
 	csc := r.builder.WithMeta(in.Namespace, cscName).
 		WithSpec(in.Namespace, manifests).

--- a/pkg/operatorsource/configuring_test.go
+++ b/pkg/operatorsource/configuring_test.go
@@ -44,7 +44,7 @@ func TestReconcile_NotConfigured_NewCatalogConfigSourceObjectCreated(t *testing.
 	kubeclient.EXPECT().Get(context.TODO(), namespacedName, cscGet).Return(kubeClientErr)
 
 	packages := "a,b,c"
-	datastore.EXPECT().GetPackageIDs().Return(packages)
+	datastore.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return(packages)
 
 	trueVar := true
 	cscWant := cscGet.DeepCopy()


### PR DESCRIPTION
- The list of package(s) specified in `Spec.Packages` of the `CatalogSourceConfig` should include the package(s) from the associated `OperatorSource` only.