### PR TITLE
Format configuring.go imports correctly

### DIFF
--- a/pkg/catalogsourceconfig/configuring.go
+++ b/pkg/catalogsourceconfig/configuring.go
@@ -3,8 +3,9 @@ package catalogsourceconfig
 import (
 	"context"
 	"fmt"
-	"github.com/operator-framework/operator-marketplace/pkg/operatorsource"
 	"strings"
+
+	"github.com/operator-framework/operator-marketplace/pkg/operatorsource"
 
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"


### PR DESCRIPTION
-Reorder imports in /pkg/catalogsourceconfig/configuring.go to standard