### PR TITLE
[opsrc] Add support to filter operator offering(s)

### DIFF
--- a/pkg/catalogsourceconfig/catalogsourcebuilder.go
+++ b/pkg/catalogsourceconfig/catalogsourcebuilder.go
@@ -37,14 +37,24 @@ func (b *CatalogSourceBuilder) WithMeta(name, namespace string) *CatalogSourceBu
 	return b
 }
 
-// WithOLMLabels adds "olm-visibility" and "openshift-marketplace" labels to ObjectMeta.
-func (b *CatalogSourceBuilder) WithOLMLabels() *CatalogSourceBuilder {
+// WithOLMLabels adds "olm-visibility", "openshift-marketplace" and and all
+// label(s) associated with the CatalogSource object specified in cscLabels.
+func (b *CatalogSourceBuilder) WithOLMLabels(cscLabels map[string]string) *CatalogSourceBuilder {
+	labels := map[string]string{
+		"olm-visibility":        "hidden",
+		"openshift-marketplace": "true",
+	}
+
+	for key, value := range cscLabels {
+		labels[key] = value
+	}
+
 	b.WithTypeMeta()
 	objectMeta := b.cs.GetObjectMeta()
 	if objectMeta == nil {
 		b.cs.ObjectMeta = metav1.ObjectMeta{}
 	}
-	b.cs.SetLabels(map[string]string{"olm-visibility": "hidden", "openshift-marketplace": "true"})
+	b.cs.SetLabels(labels)
 	return b
 }
 

--- a/pkg/catalogsourceconfig/configuring.go
+++ b/pkg/catalogsourceconfig/configuring.go
@@ -3,8 +3,9 @@ package catalogsourceconfig
 import (
 	"context"
 	"fmt"
-	"github.com/operator-framework/operator-marketplace/pkg/operatorsource"
 	"strings"
+
+	"github.com/operator-framework/operator-marketplace/pkg/operatorsource"
 
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
@@ -217,9 +218,11 @@ func newCatalogSource(csc *v1alpha1.CatalogSourceConfig, configMapName string) *
 	// is not visible in the OLM Packages UI. In addition we will set the
 	// "openshift-marketplace" label which will be used by the Marketplace UI
 	// to filter out global CatalogSources.
-	datastoreLabel, found := csc.ObjectMeta.GetLabels()[operatorsource.DatastoreLabel]
+	cscLabels := csc.ObjectMeta.GetLabels()
+	datastoreLabel, found := cscLabels[operatorsource.DatastoreLabel]
 	if found && strings.ToLower(datastoreLabel) == "true" {
-		builder.WithOLMLabels()
+		builder.WithOLMLabels(cscLabels)
 	}
+
 	return builder.CatalogSource()
 }

--- a/pkg/operatorsource/catalogsourceconfigbuilder.go
+++ b/pkg/operatorsource/catalogsourceconfigbuilder.go
@@ -22,19 +22,38 @@ func (b *CatalogSourceConfigBuilder) CatalogSourceConfig() *v1alpha1.CatalogSour
 	return &b.object
 }
 
-// WithMeta sets TypeMeta and ObjectMeta accordingly.
-func (b *CatalogSourceConfigBuilder) WithMeta(namespace, name string) *CatalogSourceConfigBuilder {
+// WithTypeMeta sets TypeMeta of the CatalogSourceConfig object.
+func (b *CatalogSourceConfigBuilder) WithTypeMeta() *CatalogSourceConfigBuilder {
 	b.object.TypeMeta = metav1.TypeMeta{
 		APIVersion: fmt.Sprintf("%s/%s",
 			v1alpha1.SchemeGroupVersion.Group, v1alpha1.SchemeGroupVersion.Version),
 		Kind: v1alpha1.CatalogSourceConfigKind,
 	}
 
-	b.object.ObjectMeta = metav1.ObjectMeta{
-		Name:      name,
-		Namespace: namespace,
-		Labels:    map[string]string{DatastoreLabel: "true"},
+	return b
+}
+
+// WithNamespacedName sets name and namespace of the CatalogSourceConfig object.
+func (b *CatalogSourceConfigBuilder) WithNamespacedName(namespace, name string) *CatalogSourceConfigBuilder {
+	b.object.SetNamespace(namespace)
+	b.object.SetName(name)
+
+	return b
+}
+
+// WithLabels sets appropriate labels for the CatalogSourceConfig object. It
+// applies all labels associated with an OperatorSource object specified in
+// opsrcLabels.
+func (b *CatalogSourceConfigBuilder) WithLabels(opsrcLabels map[string]string) *CatalogSourceConfigBuilder {
+	labels := map[string]string{
+		DatastoreLabel: "true",
 	}
+
+	for key, value := range opsrcLabels {
+		labels[key] = value
+	}
+
+	b.object.SetLabels(labels)
 
 	return b
 }

--- a/pkg/operatorsource/configuring.go
+++ b/pkg/operatorsource/configuring.go
@@ -61,7 +61,9 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 
 	cscName := in.Name
 	cscNamespacedName := types.NamespacedName{Name: cscName, Namespace: in.Namespace}
-	cscRetrievedInto := r.builder.WithMeta(in.Namespace, cscName).CatalogSourceConfig()
+	cscRetrievedInto := r.builder.WithTypeMeta().
+		WithNamespacedName(in.Namespace, cscName).
+		CatalogSourceConfig()
 
 	err = r.client.Get(ctx, cscNamespacedName, cscRetrievedInto)
 
@@ -78,7 +80,9 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 
 	manifests := r.datastore.GetPackageIDsByOperatorSource(in.GetUID())
 
-	csc := r.builder.WithMeta(in.Namespace, cscName).
+	csc := r.builder.WithTypeMeta().
+		WithNamespacedName(in.Namespace, cscName).
+		WithLabels(in.GetLabels()).
 		WithSpec(in.Namespace, manifests).
 		WithOwner(in).
 		CatalogSourceConfig()

--- a/pkg/operatorsource/configuring_test.go
+++ b/pkg/operatorsource/configuring_test.go
@@ -36,6 +36,12 @@ func TestReconcile_NotConfigured_NewCatalogConfigSourceObjectCreated(t *testing.
 
 	ctx := context.TODO()
 	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.Configuring)
+
+	labelsWant := map[string]string{
+		"opsrc-group": "Community",
+	}
+	opsrcIn.SetLabels(labelsWant)
+
 	namespacedName := types.NamespacedName{Name: "foo", Namespace: "marketplace"}
 
 	// We expect that the given CatalogConfigSource object does not exist.
@@ -47,7 +53,7 @@ func TestReconcile_NotConfigured_NewCatalogConfigSourceObjectCreated(t *testing.
 	datastore.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return(packages)
 
 	trueVar := true
-	cscWant := cscGet.DeepCopy()
+	cscWant := helperNewCatalogSourceConfigWithLabels(opsrcIn.Namespace, opsrcIn.Name, labelsWant)
 	cscWant.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
 		metav1.OwnerReference{
 			APIVersion: opsrcIn.APIVersion,

--- a/pkg/operatorsource/helper_test.go
+++ b/pkg/operatorsource/helper_test.go
@@ -68,7 +68,23 @@ func helperNewCatalogSourceConfig(namespace, name string) *v1alpha1.CatalogSourc
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      name,
 			Namespace: namespace,
-			Labels:    map[string]string{"opsrc-datastore": "true"},
 		},
 	}
+}
+
+func helperNewCatalogSourceConfigWithLabels(namespace, name string, opsrcLabels map[string]string) *v1alpha1.CatalogSourceConfig {
+	csc := helperNewCatalogSourceConfig(namespace, name)
+
+	// This is the default label that should get added to CatalogSourceConfig.
+	labels := map[string]string{
+		"opsrc-datastore": "true",
+	}
+
+	for key, value := range opsrcLabels {
+		labels[key] = value
+	}
+
+	csc.SetLabels(labels)
+
+	return csc
 }

--- a/pkg/operatorsource/purging.go
+++ b/pkg/operatorsource/purging.go
@@ -57,7 +57,9 @@ func (r *purgingReconciler) Reconcile(ctx context.Context, in *v1alpha1.Operator
 	r.datastore.RemoveOperatorSource(in.GetUID())
 
 	builder := &CatalogSourceConfigBuilder{}
-	csc := builder.WithMeta(in.Namespace, in.Name).CatalogSourceConfig()
+	csc := builder.WithTypeMeta().
+		WithNamespacedName(in.Namespace, in.Name).
+		CatalogSourceConfig()
 
 	if err = r.client.Delete(ctx, csc); err != nil && !k8s_errors.IsNotFound(err) {
 		nextPhase = phase.GetNextWithMessage(phase.Failed, err.Error())

--- a/test/e2e/marketplace_test.go
+++ b/test/e2e/marketplace_test.go
@@ -20,6 +20,8 @@ import (
 const (
 	cleanupRetryInterval = time.Second * 1
 	cleanupTimeout       = time.Second * 5
+
+	GroupLabel string = "opsrc-group"
 )
 
 // Test marketplace is the root function that triggers the set of e2e tests
@@ -91,6 +93,7 @@ func defaultCreateTest(t *testing.T, f *test.Framework, ctx *test.TestCtx) error
 		return fmt.Errorf("could not get namespace: %v", err)
 	}
 
+	groupWant := "Community"
 	testOperatorSource := &operator.OperatorSource{
 		TypeMeta: metav1.TypeMeta{
 			Kind: operator.OperatorSourceKind,
@@ -98,6 +101,9 @@ func defaultCreateTest(t *testing.T, f *test.Framework, ctx *test.TestCtx) error
 		ObjectMeta: metav1.ObjectMeta{
 			Name:      "test-operators",
 			Namespace: namespace,
+			Labels: map[string]string{
+				GroupLabel: groupWant,
+			},
 		},
 		Spec: operator.OperatorSourceSpec{
 			Type:              "appregistry",
@@ -150,6 +156,19 @@ func defaultCreateTest(t *testing.T, f *test.Framework, ctx *test.TestCtx) error
 			"The created catalogsource %s was not properly associated with the created configmap %s",
 			resultCatalogSource.Name,
 			resultConfigMap.Name,
+		)
+	}
+
+	labels := resultCatalogSource.GetLabels()
+	groupGot, ok := labels[GroupLabel]
+
+	if !ok || groupGot != groupWant {
+		t.Errorf(
+			"The created catalogsource %s does not have the right label[%s] - want=%s got=%s",
+			resultCatalogSource.Name,
+			GroupLabel,
+			groupWant,
+			groupGot,
 		)
 	}
 


### PR DESCRIPTION
Allow the admin to filter operator offering(s) by Operator Type.
With multiple operator source(s) an admin needs the ability to filter
operator offering(s) by group. For example, we want to list operator
offering(s) from "Community" or "ISV" etc.

Make the following change(s) to achieve this goal:
- Apply all label(s) associated with an OperatorSource to its
  corresponding CatalogSourceConfig object.

This will ensure that the corresponding CatalogSource object
has all the label(s) from the OperatorSource object.

This will cause Package API server to return the same label(s) for
all PackageManifest object(s) related to the CatalogSource
in question.

We can use a specific label `opsrc-group` that reflects the group
name of an operator source. The UI can utilize this label to
filter operator offering(s) from multiple source(s).