### PR TITLE
[opsrc] Make configuring reconciler idempotent

### DIFF
--- a/pkg/operatorsource/configuring_test.go
+++ b/pkg/operatorsource/configuring_test.go
@@ -42,13 +42,6 @@ func TestReconcile_NotConfigured_NewCatalogConfigSourceObjectCreated(t *testing.
 	}
 	opsrcIn.SetLabels(labelsWant)
 
-	namespacedName := types.NamespacedName{Name: "foo", Namespace: "marketplace"}
-
-	// We expect that the given CatalogConfigSource object does not exist.
-	cscGet := helperNewCatalogSourceConfig(opsrcIn.Namespace, opsrcIn.Name)
-	kubeClientErr := k8s_errors.NewNotFound(schema.GroupResource{}, "CatalogSourceConfig not found")
-	kubeclient.EXPECT().Get(context.TODO(), namespacedName, cscGet).Return(kubeClientErr)
-
 	packages := "a,b,c"
 	datastore.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return(packages)
 
@@ -76,12 +69,15 @@ func TestReconcile_NotConfigured_NewCatalogConfigSourceObjectCreated(t *testing.
 	assert.Equal(t, nextPhaseWant, nextPhaseGot)
 }
 
-// Use Case: Already configured, CatalogSourceConfig object already exists.
-// Expected Result: No action is taken and the next phase is set to "Succeeded".
-func TestReconcile_AlreadyConfigured_NoActionTaken(t *testing.T) {
+// Use Case: Not configured, CatalogSourceConfig object already exists due to
+// past errors.
+// Expected Result: The existing CatalogSourceConfig object should be updated
+// accordingly and the next phase should be set to "Succeeded".
+func TestReconcile_CatalogSourceConfigAlreadyExists_Updated(t *testing.T) {
 	controller := gomock.NewController(t)
 	defer controller.Finish()
 
+	namespace, name := "marketplace", "foo"
 	nextPhaseWant := &v1alpha1.Phase{
 		Name:    phase.Succeeded,
 		Message: phase.GetMessage(phase.Succeeded),
@@ -93,16 +89,81 @@ func TestReconcile_AlreadyConfigured_NoActionTaken(t *testing.T) {
 	reconciler := operatorsource.NewConfiguringReconciler(helperGetContextLogger(), datastore, kubeclient)
 
 	ctx := context.TODO()
-	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.Configuring)
-	namespacedName := types.NamespacedName{Name: "foo", Namespace: "marketplace"}
-	cscGet := helperNewCatalogSourceConfig(opsrcIn.Namespace, opsrcIn.Name)
+	opsrcIn := helperNewOperatorSourceWithPhase(namespace, name, phase.Configuring)
 
-	// We expect that the given CatalogConfigSource object already exists.
-	kubeclient.EXPECT().Get(context.TODO(), namespacedName, cscGet).Return(nil).Times(1)
+	labelsWant := map[string]string{
+		"opsrc-group": "Community",
+	}
+	opsrcIn.SetLabels(labelsWant)
+
+	packages := "a,b,c"
+	datastore.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return(packages)
+
+	createErr := k8s_errors.NewAlreadyExists(schema.GroupResource{}, "CatalogSourceConfig already exists")
+	kubeclient.EXPECT().Create(context.TODO(), gomock.Any()).Return(createErr)
+
+	// We expect Get to return the given CatalogSourceConfig successfully.
+	namespacedName := types.NamespacedName{Name: name, Namespace: namespace}
+	cscGet := v1alpha1.CatalogSourceConfig{}
+	kubeclient.EXPECT().Get(context.TODO(), namespacedName, &cscGet).Return(nil)
+
+	trueVar := true
+	cscWant := helperNewCatalogSourceConfigWithLabels("", "", labelsWant)
+	cscWant.ObjectMeta.OwnerReferences = []metav1.OwnerReference{
+		metav1.OwnerReference{
+			APIVersion: opsrcIn.APIVersion,
+			Kind:       opsrcIn.Kind,
+			Name:       opsrcIn.Name,
+			UID:        opsrcIn.UID,
+			Controller: &trueVar,
+		},
+	}
+	cscWant.Spec = v1alpha1.CatalogSourceConfigSpec{
+		TargetNamespace: opsrcIn.Namespace,
+		Packages:        packages,
+	}
+	kubeclient.EXPECT().Update(context.TODO(), cscWant).Return(nil)
 
 	opsrcGot, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
 
 	assert.NoError(t, errGot)
 	assert.Equal(t, opsrcIn, opsrcGot)
+	assert.Equal(t, nextPhaseWant, nextPhaseGot)
+}
+
+// Use Case: Update of existing CatalogSourceConfig object fails.
+// Expected Result: The object is moved to "Failed" phase.
+func TestReconcile_UpdateError_MovedToFailedPhase(t *testing.T) {
+	controller := gomock.NewController(t)
+	defer controller.Finish()
+
+	namespace, name := "marketplace", "foo"
+
+	updateError := k8s_errors.NewServerTimeout(schema.GroupResource{}, "operation", 1)
+	nextPhaseWant := &v1alpha1.Phase{
+		Name:    phase.Failed,
+		Message: updateError.Error(),
+	}
+
+	datastore := mocks.NewDatastoreWriter(controller)
+	kubeclient := mocks.NewKubeClient(controller)
+
+	reconciler := operatorsource.NewConfiguringReconciler(helperGetContextLogger(), datastore, kubeclient)
+
+	ctx := context.TODO()
+	opsrcIn := helperNewOperatorSourceWithPhase(namespace, name, phase.Configuring)
+
+	datastore.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return("a,b,c")
+
+	createErr := k8s_errors.NewAlreadyExists(schema.GroupResource{}, "CatalogSourceConfig already exists")
+	kubeclient.EXPECT().Create(context.TODO(), gomock.Any()).Return(createErr)
+
+	kubeclient.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).Return(nil)
+	kubeclient.EXPECT().Update(context.TODO(), gomock.Any()).Return(updateError)
+
+	_, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
+
+	assert.Error(t, errGot)
+	assert.Equal(t, updateError, errGot)
 	assert.Equal(t, nextPhaseWant, nextPhaseGot)
 }


### PR DESCRIPTION
Make configuring reconciler for OperatorSource object idempotent.
Right now, if the given CatalogSourceConfig object already exists
then the reconciler assumes that it is already properly configured
and moves on. This may not be true, due to unexpected error we might
have stale CatalogSourceConfig object. Making the configuring
reconciler idempotent helps us work around these issue(s).

Do the following to make it idempotent:
- Call Create to cretae the CatalogSourceConfig object.
- If we get an AlreadyExists error, then get the latest version
  of the object.
- Set the fields appropriately and then Call Update.