### PR TITLE
[opsrc] Add retry logic to opsrc reconciliation

### DIFF
--- a/pkg/operatorsource/configuring.go
+++ b/pkg/operatorsource/configuring.go
@@ -71,7 +71,7 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 	err = r.client.Create(ctx, cscCreate)
 	if err != nil && !k8s_errors.IsAlreadyExists(err) {
 		r.logger.Errorf("Unexpected error while creating CatalogSourceConfig: %s", err.Error())
-		nextPhase = phase.GetNextWithMessage(phase.Failed, err.Error())
+		nextPhase = phase.GetNextWithMessage(phase.Configuring, err.Error())
 
 		return
 	}
@@ -89,7 +89,7 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 	err = r.client.Get(ctx, cscNamespacedName, &cscExisting)
 	if err != nil {
 		r.logger.Errorf("Unexpected error while getting CatalogSourceConfig: %s", err.Error())
-		nextPhase = phase.GetNextWithMessage(phase.Failed, err.Error())
+		nextPhase = phase.GetNextWithMessage(phase.Configuring, err.Error())
 
 		return
 	}
@@ -104,7 +104,7 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 	err = r.client.Update(ctx, cscUpdate)
 	if err != nil {
 		r.logger.Errorf("Unexpected error while updating CatalogSourceConfig: %s", err.Error())
-		nextPhase = phase.GetNextWithMessage(phase.Failed, err.Error())
+		nextPhase = phase.GetNextWithMessage(phase.Configuring, err.Error())
 
 		return
 	}

--- a/pkg/operatorsource/configuring_test.go
+++ b/pkg/operatorsource/configuring_test.go
@@ -141,7 +141,7 @@ func TestReconcile_UpdateError_MovedToFailedPhase(t *testing.T) {
 
 	updateError := k8s_errors.NewServerTimeout(schema.GroupResource{}, "operation", 1)
 	nextPhaseWant := &v1alpha1.Phase{
-		Name:    phase.Failed,
+		Name:    phase.Configuring,
 		Message: updateError.Error(),
 	}
 

--- a/pkg/operatorsource/purging.go
+++ b/pkg/operatorsource/purging.go
@@ -62,7 +62,7 @@ func (r *purgingReconciler) Reconcile(ctx context.Context, in *v1alpha1.Operator
 		CatalogSourceConfig()
 
 	if err = r.client.Delete(ctx, csc); err != nil && !k8s_errors.IsNotFound(err) {
-		nextPhase = phase.GetNextWithMessage(phase.Failed, err.Error())
+		nextPhase = phase.GetNextWithMessage(phase.OperatorSourcePurging, err.Error())
 		return
 	}
 

--- a/pkg/operatorsource/validating.go
+++ b/pkg/operatorsource/validating.go
@@ -54,6 +54,7 @@ func (r *validatingReconciler) Reconcile(ctx context.Context, in *v1alpha1.Opera
 	// Validate that operator source endpoint is a valid URL.
 	_, err = url.ParseRequestURI(in.Spec.Endpoint)
 	if err != nil {
+		// This needs manual intervention. So flag it as 'Failed'.
 		nextPhase = phase.GetNextWithMessage(phase.Failed,
 			fmt.Sprintf("Invalid operator source endpoint - %s", err.Error()))
 		return


### PR DESCRIPTION
On any reconciliation error we set the current phase to 'Failed'. The reconciliation of a Failed OperatorSource object is currently a no op. In order to retry a failed reconciliation, do the following:

- On error, make sure the object retains its current phase so that the next retry can resume from the current phase.
- Set 'CurrentPhase.Message' to the last error encountered so that  the object reflects the most recent error encountered.