### PR TITLE
[csc] Add retry logic to csc reconciliation

### DIFF
--- a/pkg/catalogsourceconfig/configuring.go
+++ b/pkg/catalogsourceconfig/configuring.go
@@ -67,7 +67,7 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Cata
 
 	err = r.reconcileCatalogSource(in)
 	if err != nil {
-		nextPhase = phase.GetNextWithMessage(phase.Failed, err.Error())
+		nextPhase = phase.GetNextWithMessage(phase.Configuring, err.Error())
 		return
 	}
 

--- a/pkg/catalogsourceconfig/update.go
+++ b/pkg/catalogsourceconfig/update.go
@@ -40,7 +40,8 @@ func (r *updateReconciler) Reconcile(ctx context.Context, in *v1alpha1.CatalogSo
 		// Delete the objects in the old TargetNamespace
 		err = r.deleteObjects(in)
 		if err != nil {
-			nextPhase = phase.GetNextWithMessage(phase.Failed, err.Error())
+			// Next retry should resume from the current phase.
+			nextPhase = phase.GetNextWithMessage(in.Status.CurrentPhase.Name, err.Error())
 			return
 		}
 	}


### PR DESCRIPTION
On any reconciliation error we set the current phase to 'Failed'. The reconciliation of a Failed CatalogSourceConfig object is currently a no op. In order to retry a failed reconciliation, do the following:

- On error, make sure the object retains its current phase so that the next retry can resume from the current phase.
- Set 'CurrentPhase.Message' to the last error encountered so that the object reflects the most recent error encountered.