### PR TITLE
[e2e] Stop creating Marketplace resources

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -1,21 +1,8 @@
 #!/bin/bash
 set -e
 
-TEST_NAMESPACE="openshift-operators"
-MANIFEST_FOLDER="./test/e2e/environment/"
-NAMESPACED_MANIFEST="./${MANIFEST_FOLDER}/namespaced-manifest.yaml"
-GLOBAL_MANIFEST="./${MANIFEST_FOLDER}/global-manifest.yaml"
-OPERATOR_SOURCE_CRD="./deploy/crds/operatorsource.crd.yaml"
-CATALOG_SOURCE_CONFIG_CRD="./deploy/crds/catalogsourceconfig.crd.yaml"
-
-# Create openshift resources if they don't exist
-echo "Creating openshift resources"
-kubectl apply -f $OPERATOR_SOURCE_CRD
-kubectl apply -f $CATALOG_SOURCE_CONFIG_CRD
-if ! kubectl get namespace $TEST_NAMESPACE; then
-    kubectl create namespace $TEST_NAMESPACE
-fi
+TEST_NAMESPACE="openshift-marketplace"
 
 # Run the tests through the operator-sdk
 echo "Running operator-sdk test"
-operator-sdk test local ./test/e2e --up-local --kubeconfig=$KUBECONFIG --namespace $TEST_NAMESPACE
+operator-sdk test local ./test/e2e/ --no-setup --namespace $TEST_NAMESPACE

--- a/scripts/run-e2e-job.sh
+++ b/scripts/run-e2e-job.sh
@@ -4,11 +4,10 @@ set -o pipefail
 
 MARKETPLACE_OPERATOR_ROOT=$(dirname "${BASH_SOURCE}")/..
 SDK_VERSION=v0.3.0
-KUBE_VERSION=v1.12.3
 
 # Get operator-sdk binary.
 wget -O /tmp/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/${SDK_VERSION}/operator-sdk-${SDK_VERSION}-x86_64-linux-gnu && chmod +x /tmp/operator-sdk
-wget -O /tmp/kubectl https://storage.googleapis.com/kubernetes-release/release/${KUBE_VERSION}/bin/linux/amd64/kubectl && chmod +x /tmp/kubectl
+
 PATH=$PATH:/tmp
 cd $MARKETPLACE_OPERATOR_ROOT
 . ./scripts/e2e-tests.sh

--- a/test/e2e/marketplace_test.go
+++ b/test/e2e/marketplace_test.go
@@ -70,15 +70,11 @@ func TestMarketplace(t *testing.T) {
 func MarketplaceCluster(t *testing.T) {
 	ctx := test.NewTestCtx(t)
 	defer ctx.Cleanup()
-	err := ctx.InitializeClusterResources(&test.CleanupOptions{TestContext: ctx, Timeout: cleanupTimeout, RetryInterval: cleanupRetryInterval})
-	if err != nil {
-		t.Fatalf("failed to initialize cluster resources: %v", err)
-	}
-	t.Log("Initialized cluster resources")
+
 	// get global framework variables
 	f := test.Global
 
-	if err = defaultCreateTest(t, f, ctx); err != nil {
+	if err := defaultCreateTest(t, f, ctx); err != nil {
 		t.Fatal(err)
 	}
 }


### PR DESCRIPTION
Now that we are managed by CVO, all the required Marketplace resources will be present in a cluster by default. This patch removes code that was creating these resources. Also removed downloading kubectl as that is not needed anymore.