### PR TITLE
Update catalog when a new version is available

### DIFF
--- a/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
+++ b/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
@@ -1,6 +1,8 @@
 package v1alpha1
 
 import (
+	"strings"
+
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 )
@@ -90,4 +92,9 @@ func (csc *CatalogSourceConfig) EnsurePublisher() {
 	if csc.Spec.Publisher == "" {
 		csc.Spec.Publisher = "Custom"
 	}
+}
+
+// GetPackageIDs returns the list of package(s) specified.
+func (csc *CatalogSourceConfig) GetPackageIDs() []string {
+	return strings.Split(csc.Spec.Packages, ",")
 }

--- a/pkg/catalogsourceconfig/syncer.go
+++ b/pkg/catalogsourceconfig/syncer.go
@@ -1,0 +1,71 @@
+package catalogsourceconfig
+
+import (
+	"time"
+
+	"github.com/operator-framework/operator-marketplace/pkg/datastore"
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewCatalogSyncer returns a new instance of CatalogSyncer interface.
+func NewCatalogSyncer(client client.Client, initialWait time.Duration) *catalogSyncer {
+	return &catalogSyncer{
+		initialWait:    initialWait,
+		triggerer:      NewTriggerer(client),
+		notificationCh: make(chan datastore.PackageUpdateNotification),
+	}
+}
+
+// CatalogSyncer is an interface that wraps the Sync method.
+//
+// Sync is a loop that waits on a specified channel for package update
+// notification. Once notification is received it triggers reconciliation of
+// CatalogSourceConfig object(s) that needs to update catalog source(s).
+type CatalogSyncer interface {
+	Sync(stop <-chan struct{})
+}
+
+// catalogSyncer implements CatalogSyncer interface.
+type catalogSyncer struct {
+	initialWait    time.Duration
+	triggerer      Triggerer
+	notificationCh chan datastore.PackageUpdateNotification
+}
+
+func (s *catalogSyncer) Sync(stop <-chan struct{}) {
+	log.Infof("[sync] CatalogSourceConfig sync loop will start after %s", s.initialWait)
+
+	// Immediately after the operator process starts, it will spend time in
+	// reconciling existing CR(s). Let's give the process a grace period to
+	// reconcile and rebuild the local cache from existing CR(s).
+	<-time.After(s.initialWait)
+
+	log.Info("[sync] CatalogSourceConfig sync loop has started")
+	for {
+		select {
+		case notification := <-s.notificationCh:
+			if notification == nil {
+				log.Error("[sync] package update notification cannot be <nil>")
+				break
+			}
+
+			log.Info("[sync] received list of package(s) with new version, syncing CatalogSourceConfig object(s)")
+			if err := s.triggerer.Trigger(notification); err != nil {
+				log.Errorf("[sync] CatalogSourceConfig sync error- %v", err)
+			}
+
+		case <-stop:
+			log.Info("[sync] Ending CatalogSourceConfig sync loop")
+			return
+		}
+	}
+}
+
+// Send sends the specified update notification to the underlying channel.
+func (s *catalogSyncer) Send(notification datastore.PackageUpdateNotification) {
+	go func() {
+		log.Info("[sync] sending list of package(s) with new version")
+		s.notificationCh <- notification
+	}()
+}

--- a/pkg/catalogsourceconfig/triggerer.go
+++ b/pkg/catalogsourceconfig/triggerer.go
@@ -1,0 +1,115 @@
+package catalogsourceconfig
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/datastore"
+	"github.com/operator-framework/operator-marketplace/pkg/operatorsource"
+	"github.com/operator-framework/operator-marketplace/pkg/phase"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewTriggerer returns a new instance of Triggerer interface.
+func NewTriggerer(client client.Client) Triggerer {
+	return &triggerer{
+		client:       client,
+		transitioner: phase.NewTransitioner(),
+	}
+}
+
+// Triggerer is an interface that wraps the Trigger method.
+//
+// Trigger iterates through the list of all CatalogSourceConfig object(s) and
+// applies the following logic:
+//
+// a. Compare the list of package(s) specified in Spec.Packages with the update
+//    notification list and determine if the given CatalogSourceConfig specifies
+//    a package that has either been removed or has a new version available.
+//
+// b. If the above is true then update the given CatalogSourceConfig object in
+//    order to kick off a new reconciliation. This way it will get the latest
+//    package manifest from datastore.
+//
+// The list call applies the label selector [opsrc-datastore!=true] to exclude
+// CatalogSourceConfig object which is used as datastore for marketplace.
+type Triggerer interface {
+	Trigger(notification datastore.PackageUpdateNotification) error
+}
+
+// triggerer implements the Triggerer interface.
+type triggerer struct {
+	client       client.Client
+	transitioner phase.Transitioner
+}
+
+func (t *triggerer) Trigger(notification datastore.PackageUpdateNotification) error {
+	options := &client.ListOptions{}
+	options.SetLabelSelector(fmt.Sprintf("%s!=true", operatorsource.DatastoreLabel))
+
+	cscs := &v1alpha1.CatalogSourceConfigList{}
+	if err := t.client.List(context.TODO(), options, cscs); err != nil {
+		return err
+	}
+
+	allErrors := []error{}
+	for _, instance := range cscs.Items {
+		// Needed because sdk does not get the gvk.
+		instance.EnsureGVK()
+
+		packages, updateNeeded := t.setPackages(&instance, notification)
+		if !updateNeeded {
+			continue
+		}
+
+		if err := t.update(&instance, packages); err != nil {
+			allErrors = append(allErrors, err)
+		}
+	}
+
+	return utilerrors.NewAggregate(allErrors)
+}
+
+func (t *triggerer) setPackages(instance *v1alpha1.CatalogSourceConfig, notification datastore.PackageUpdateNotification) (packages string, updateNeeded bool) {
+	packageList := make([]string, 0)
+	for _, pkg := range instance.GetPackageIDs() {
+		if notification.IsRemoved(pkg) {
+			updateNeeded = true
+
+			// The package specified has been removed from the registry. We will
+			// remove it from the spec.
+			continue
+		}
+
+		packageList = append(packageList, pkg)
+
+		if notification.IsUpdated(pkg) {
+			updateNeeded = true
+		}
+	}
+
+	packages = strings.Join(packageList, ",")
+	return
+}
+
+func (t *triggerer) update(instance *v1alpha1.CatalogSourceConfig, packages string) error {
+	out := instance.DeepCopy()
+
+	// We want to Set the phase to Initial to kick off reconciliation anew.
+	nextPhase := &v1alpha1.Phase{
+		Name:    phase.Initial,
+		Message: "Package(s) have update(s), scheduling for reconciliation",
+	}
+	t.transitioner.TransitionInto(&out.Status.CurrentPhase, nextPhase)
+
+	out.Spec.Packages = packages
+
+	if err := t.client.Update(context.TODO(), out); err != nil {
+		return err
+	}
+
+	return nil
+}

--- a/pkg/datastore/metadata.go
+++ b/pkg/datastore/metadata.go
@@ -19,6 +19,20 @@ type OperatorMetadata struct {
 	RawYAML []byte
 }
 
+// Repository holds metadata associated with a repository in remote registry and
+// the list of operator package name(s) associated with the repository.
+//
+// We need this object to relate operator package(s) that user subscribes to a
+// given repository in remote registry.
+type Repository struct {
+	// Metadata that uniquely identifies the given operator manifest in registry.
+	Metadata RegistryMetadata
+
+	// Packages is the list of operator package name(s) associated with the
+	// given repository.
+	Packages []string
+}
+
 // RegistryMetadata encapsulates metadata that uniquely describes the source of
 // the given operator manifest in registry.
 type RegistryMetadata struct {

--- a/pkg/datastore/row.go
+++ b/pkg/datastore/row.go
@@ -46,9 +46,9 @@ type operatorSourceRow struct {
 	// The package name is used to uniquely identify the operator manifest(s).
 	Operators map[string]*SingleOperatorManifest
 
-	// Metadata is the metadata associated with each repository under the given
+	// Repositories is the metadata associated with each repository under the given
 	// namespace.
-	Metadata map[string]*RegistryMetadata
+	Repositories map[string]*Repository
 }
 
 // GetPackages returns the list of available package(s) associated with an
@@ -81,19 +81,19 @@ func (m *operatorSourceRowMap) AddEmpty(opsrc *v1alpha1.OperatorSource) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	m.add(opsrc, map[string]*RegistryMetadata{}, map[string]*SingleOperatorManifest{})
+	m.add(opsrc, map[string]*Repository{}, map[string]*SingleOperatorManifest{})
 }
 
 // Add adds a new operator source to the map with an the specified set of
 // registry metadata and operator manifest(s).
-func (m *operatorSourceRowMap) Add(opsrc *v1alpha1.OperatorSource, metadata map[string]*RegistryMetadata, operators map[string]*SingleOperatorManifest) {
+func (m *operatorSourceRowMap) Add(opsrc *v1alpha1.OperatorSource, repositories map[string]*Repository, operators map[string]*SingleOperatorManifest) {
 	m.lock.Lock()
 	defer m.lock.Unlock()
 
-	m.add(opsrc, metadata, operators)
+	m.add(opsrc, repositories, operators)
 }
 
-func (m *operatorSourceRowMap) add(opsrc *v1alpha1.OperatorSource, metadata map[string]*RegistryMetadata, operators map[string]*SingleOperatorManifest) {
+func (m *operatorSourceRowMap) add(opsrc *v1alpha1.OperatorSource, repositories map[string]*Repository, operators map[string]*SingleOperatorManifest) {
 	m.Sources[opsrc.GetUID()] = &operatorSourceRow{
 		OperatorSourceKey: OperatorSourceKey{
 			UID: opsrc.GetUID(),
@@ -103,8 +103,8 @@ func (m *operatorSourceRowMap) add(opsrc *v1alpha1.OperatorSource, metadata map[
 			},
 			Spec: &opsrc.Spec,
 		},
-		Operators: operators,
-		Metadata:  metadata,
+		Operators:    operators,
+		Repositories: repositories,
 	}
 }
 

--- a/pkg/datastore/update_result.go
+++ b/pkg/datastore/update_result.go
@@ -1,0 +1,102 @@
+package datastore
+
+import (
+	"fmt"
+)
+
+func newUpdateResult() *UpdateResult {
+	return &UpdateResult{
+		Updated: make([]string, 0),
+		Removed: make([]string, 0),
+	}
+}
+
+func NewPackageUpdateAggregator() *PackageUpdateAggregator {
+	return &PackageUpdateAggregator{
+		updated: map[string]bool{},
+		removed: map[string]bool{},
+	}
+}
+
+// UpdateResult holds information related to what has changed in the remote
+// registry associated with an operator source.
+type UpdateResult struct {
+	// RegistryHasUpdate indicates whether the remote registry associated with
+	// the operatour source has any change. It is set to true if any of the
+	// following is true:
+	// a. A new repository has been pushed.
+	// b. An existing repository has been removed.
+	// c. An existing repository has a new version.
+	RegistryHasUpdate bool
+
+	// Updated is the list of operator name(s) that potentially have new
+	// version(s) because the corresponding repositories have new version(s).
+	Updated []string
+
+	// Removed is the list of operator name(s) that are no longer available
+	// because the corresponding repositories have been removed.
+	Removed []string
+}
+
+func (a *UpdateResult) String() string {
+	return fmt.Sprintf("operator(s) updated=%s, operator(s) removed=%s", a.Updated, a.Removed)
+}
+
+// PackageUpdateNotification is an interface used to determine whether a
+// specified operator has a new version or has been removed.
+type PackageUpdateNotification interface {
+	// IsRemoved returns true if the specified package has been removed.
+	IsRemoved(pkg string) bool
+
+	// IsUpdated returns true if the specified package has a new version.
+	IsUpdated(pkg string) bool
+}
+
+// PackageUpdateAggregator is used to aggregate update information from across
+// all operator source(s).
+// PackageUpdateAggregator also implements PackageUpdateNotification interface.
+type PackageUpdateAggregator struct {
+	updated map[string]bool
+	removed map[string]bool
+}
+
+// Add accepts an UpdateResult for a given operator source and aggregates it.
+func (a *PackageUpdateAggregator) Add(result *UpdateResult) {
+	for _, pkg := range result.Updated {
+		a.updated[pkg] = true
+	}
+
+	for _, pkg := range result.Removed {
+		a.removed[pkg] = true
+	}
+}
+
+// IsUpdatedOrRemoved returns true whether any operator has a new version or has
+// been removed from the remote registry.
+func (a *PackageUpdateAggregator) IsUpdatedOrRemoved() bool {
+	return len(a.removed) > 0 || len(a.updated) > 0
+}
+
+func (a *PackageUpdateAggregator) String() string {
+	ulist := make([]string, 0)
+	for k, _ := range a.updated {
+		ulist = append(ulist, k)
+	}
+
+	rlist := make([]string, 0)
+	for k, _ := range a.removed {
+		rlist = append(rlist, k)
+	}
+
+	return fmt.Sprintf("operator(s) updated=%s, operator(s) removed=%s", ulist, rlist)
+}
+
+func (a *PackageUpdateAggregator) IsRemoved(pkg string) bool {
+	_, exists := a.removed[pkg]
+	return exists
+}
+
+func (a *PackageUpdateAggregator) IsUpdated(pkg string) bool {
+	_, exists := a.updated[pkg]
+	return exists
+}

--- a/pkg/operatorsource/syncer.go
+++ b/pkg/operatorsource/syncer.go
@@ -3,17 +3,27 @@ package operatorsource
 import (
 	"time"
 
+	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewRegistrySyncer returns a new instance of RegistrySyncer interface.
-func NewRegistrySyncer(client client.Client, initialWait time.Duration, resyncInterval time.Duration) RegistrySyncer {
+func NewRegistrySyncer(client client.Client, initialWait time.Duration, resyncInterval time.Duration, updateNotificationSendWait time.Duration, sender PackageUpdateNotificationSender) RegistrySyncer {
 	return &registrySyncer{
 		initialWait:    initialWait,
 		resyncInterval: resyncInterval,
-		poller:         NewPoller(client),
+		poller:         NewPoller(client, updateNotificationSendWait, sender),
 	}
+}
+
+// PackageUpdateNotificationSender is an interface that wraps the Send method.
+//
+// Send sends package update notification to the underlying channel that
+// CatalogSourceConfig is waiting on. This method is expected to be a non
+// blocking operation.
+type PackageUpdateNotificationSender interface {
+	Send(notification datastore.PackageUpdateNotification)
 }
 
 // RegistrySyncer is an interface that wraps the Sync method.
@@ -32,17 +42,17 @@ type registrySyncer struct {
 }
 
 func (s *registrySyncer) Sync(stop <-chan struct{}) {
-	log.Infof("[sync] Operator source sync loop will start after %d minutes", s.initialWait)
+	log.Infof("[sync] Operator source sync loop will start after %s", s.initialWait)
 
 	// Immediately after the operator process starts, it will spend time in
 	// reconciling existing OperatorSource CR(s). Let's give the process a
 	// grace period to reconcile and rebuild the local cache from existing CR(s).
-	<-time.After(s.initialWait * time.Minute)
+	<-time.After(s.initialWait)
 
 	log.Info("[sync] Operator source sync loop has started")
 	for {
 		select {
-		case <-time.After(s.resyncInterval * time.Minute):
+		case <-time.After(s.resyncInterval):
 			log.Debug("[sync] Checking for operator source update(s) in remote registry")
 			s.poller.Poll()
 


### PR DESCRIPTION
When a new version of an operator is pushed to quay.io, we want to
make the new version available to existing CatalogSource object(s)
so that user can upgrade to the new version.

Make the following change(s) to achieve this goal:

- Extend datastore to maintain a list of package(s) associated with
  each repository so that when a repository has a new version we
  can relate to the package(s)involved.
- Extend datastore to return more fine grained information on update:
    -- Return a list of repositories that have new versions.
    -- Return a list of repositories that have been removed
       from the registry namespace.
- Implement a sync loop that waits on a channel for package update
  notification. Once activated, it lists all existing
  CatalogSourceConfig object(s) [label: opsrc-datastore!=true]. for
  each CatalogSourceConfig listed it executes the following:
    --  Determine if any package specified in Spec.Packages has a
        new version.
    -- Determine if any package specified in Spec.Packages has been
       removed from registry.
    -- If any of the above is true, update the CatalogSourceConfig
       object accordingly to trigger a new reconciliation.
  Once reconciliation kicks off the corresponding CatalogSource and
  ConfigMap object(s) will have the latest package information.
  - Extend OperatorSource registry sync to notify the above sync loop
    with the new package update information.

TODO#
This approach has the following limitations:
- Once an update is detected OperatorSource and CatalogSourceConfig
  reconciliation take place concurrently. This may cause CatalogSourceConfig
  to ask for a package for which OperatorSource has not finished downloading
  and processing the new version yet. So CatalogSourceConfig will get the
  older version of the package and call it a day. Right now, we have a
  hard coded wait time before we before we send update notification to
  CatalogSourceConfig sync loop.
- If the update operation of CatalogSourceConfig object that needs to get
  the new version of a package fails, we don't retry and hence the object
  is left stale.

One way we can resolve this is by keeping track of the version of the
repository in spec of CatalogSourceConfig object. This way it
can eventually get the new version from datastore when it is
available by retrying.

-- Add e2e test(s).