### PR TITLE
[deploy] Deploy operator to master node

### DIFF
--- a/deploy/marketplace.v0.0.1.clusterserviceversion.yaml
+++ b/deploy/marketplace.v0.0.1.clusterserviceversion.yaml
@@ -64,6 +64,10 @@ spec:
                 name: marketplace-operator
             spec:
               serviceAccountName: marketplace-operator
+              nodeSelector:
+                node-role.kubernetes.io/master: ""
+              tolerations:
+              - operator: Exists
               containers:
                 - name: marketplace-operator
                   image: quay.io/openshift/origin-operator-marketplace:latest

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -14,6 +14,10 @@ spec:
         name: marketplace-operator
     spec:
       serviceAccountName: marketplace-operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - operator: Exists
       containers:
         - name: marketplace-operator
           image: quay.io/openshift/origin-operator-marketplace:latest

--- a/manifests/10_operator.yaml
+++ b/manifests/10_operator.yaml
@@ -14,6 +14,10 @@ spec:
         name: marketplace-operator
     spec:
       serviceAccountName: marketplace-operator
+      nodeSelector:
+        node-role.kubernetes.io/master: ""
+      tolerations:
+      - operator: Exists
       containers:
         - name: marketplace-operator
           image: quay.io/openshift/origin-operator-marketplace:latest


### PR DESCRIPTION
As per CVO guidelines, all the operators it manages must be deployed to the master node. The toleration is added to allow the pod onto any node with any taint.