### PR TITLE
[deploy] Fix image-references for OCP build

### DIFF
--- a/manifests/image-references
+++ b/manifests/image-references
@@ -2,7 +2,7 @@ kind: ImageStream
 apiVersion: image.openshift.io/v1
 spec:
   tags:
-  - name: operator-marketplace
+  - name: marketplace-operator
     from:
       kind: DockerImage
       name:  quay.io/openshift/origin-operator-marketplace:latest


### PR DESCRIPTION
Change tag name to "marketplace-operator" to match what the release build expects.