### PR TITLE
[opsrc] Fix OperatorSource reconciliation error

### DIFF
--- a/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
+++ b/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
@@ -5,6 +5,7 @@ import (
 
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 const (
@@ -97,4 +98,20 @@ func (csc *CatalogSourceConfig) EnsurePublisher() {
 // GetPackageIDs returns the list of package(s) specified.
 func (csc *CatalogSourceConfig) GetPackageIDs() []string {
 	return strings.Split(csc.Spec.Packages, ",")
+}
+
+// RemoveOwner removes the owner specified in ownerUID from OwnerReference of
+// the CatalogSourceConfig object.
+func (csc *CatalogSourceConfig) RemoveOwner(ownerUID types.UID) {
+	owners := make([]metav1.OwnerReference, 0)
+
+	for _, owner := range csc.GetOwnerReferences() {
+		if owner.UID == ownerUID {
+			continue
+		}
+
+		owners = append(owners, owner)
+	}
+
+	csc.SetOwnerReferences(owners)
 }

--- a/pkg/operatorsource/configuring.go
+++ b/pkg/operatorsource/configuring.go
@@ -95,6 +95,12 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 	}
 
 	cscExisting.EnsureGVK()
+
+	// The existing CatalogSourceConfig might already be owned by this
+	// OperatorSource object. Let's remove the owner reference, otherwise we
+	// will be adding it twice.
+	cscExisting.RemoveOwner(in.GetUID())
+
 	builder := CatalogSourceConfigBuilder{object: cscExisting}
 	cscUpdate := builder.WithSpec(in.Namespace, manifests, in.Spec.DisplayName, in.Spec.Publisher).
 		WithLabels(in.GetLabels()).


### PR DESCRIPTION
OperatorSource reconciler fails in 'Configuring' phase if the
following conditions are true:
 - The CatalogSourceConfig object already exists.
 - It is already owned by the OperatorSource object.

The reconciler appends the OperatorSource object to the
OwnerReference list of the CatalogSourceConfig without checking
whether it is already owned by the same OperatorSource. This causes
the Update API to throw an error.

Solution: Remove the given OperatorSource object from the
OwnerReference list to ensure it is not specified more than once.

Bugzilla link: https://bugzilla.redhat.com/show_bug.cgi?id=1672701.