### PR TITLE
Remove Dependency on Owner References

### DIFF
--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -28,6 +28,7 @@ rules:
   - create
   - delete
   - update
+  - list
 - apiGroups:
   - operators.coreos.com
   resources:
@@ -37,6 +38,7 @@ rules:
   - create
   - delete
   - update
+  - list
 - apiGroups:
   - apps
   resources:
@@ -46,6 +48,7 @@ rules:
   - create
   - delete
   - update
+  - list
 - apiGroups:
   - config.openshift.io
   resources:
@@ -71,3 +74,4 @@ rules:
   - create
   - delete
   - update
+  - list

--- a/pkg/catalogsourceconfig/configuring.go
+++ b/pkg/catalogsourceconfig/configuring.go
@@ -153,7 +153,7 @@ func GetPackageIDs(csIDs string) []string {
 // newCatalogSource returns a CatalogSource object.
 func newCatalogSource(csc *v1alpha1.CatalogSourceConfig, address string) *olm.CatalogSource {
 	builder := new(CatalogSourceBuilder).
-		WithOwner(csc).
+		WithOwnerLabel(csc).
 		WithMeta(csc.Name, csc.Spec.TargetNamespace).
 		WithSpec(olm.SourceTypeGrpc, address, csc.Spec.DisplayName, csc.Spec.Publisher)
 

--- a/pkg/catalogsourceconfig/deleted.go
+++ b/pkg/catalogsourceconfig/deleted.go
@@ -3,8 +3,14 @@ package catalogsourceconfig
 import (
 	"context"
 
+	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
 	log "github.com/sirupsen/logrus"
+	apps "k8s.io/api/apps/v1"
+	core "k8s.io/api/core/v1"
+	rbac "k8s.io/api/rbac/v1"
+	"k8s.io/apimachinery/pkg/labels"
+	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
@@ -47,6 +53,12 @@ func (r *deletedReconciler) Reconcile(ctx context.Context, in *v1alpha1.CatalogS
 	// Evict the catalogsourceconfig data from the cache.
 	r.cache.Evict(out)
 
+	// Delete all created resources
+	err = r.deleteCreatedResources(ctx, in.Name, in.Namespace)
+	if err != nil {
+		return nil, nil, err
+	}
+
 	// Remove the csc finalizer from the object.
 	out.RemoveFinalizer()
 
@@ -60,4 +72,107 @@ func (r *deletedReconciler) Reconcile(ctx context.Context, in *v1alpha1.CatalogS
 	r.logger.Info("Finalizer removed, now garbage collector will clean it up.")
 
 	return out, nil, nil
+}
+
+// Delete all resources owned by the catalog source config
+func (r *deletedReconciler) deleteCreatedResources(ctx context.Context, name, namespace string) error {
+	allErrors := []error{}
+	labelMap := map[string]string{
+		CscOwnerNameLabel:      name,
+		CscOwnerNamespaceLabel: namespace,
+	}
+	labelSelector := labels.SelectorFromSet(labelMap)
+	options := &client.ListOptions{LabelSelector: labelSelector}
+
+	// Delete Catalog Sources
+	catalogSources := &olm.CatalogSourceList{}
+	err := r.client.List(ctx, options, catalogSources)
+	if err != nil {
+		allErrors = append(allErrors, err)
+	}
+
+	for _, catalogSource := range catalogSources.Items {
+		r.logger.Infof("Removing catalogSource %s from namespace %s", catalogSource.Name, catalogSource.Namespace)
+		err := r.client.Delete(ctx, &catalogSource)
+		if err != nil {
+			allErrors = append(allErrors, err)
+		}
+	}
+
+	// Delete Services
+	services := &core.ServiceList{}
+	err = r.client.List(ctx, options, services)
+	if err != nil {
+		allErrors = append(allErrors, err)
+	}
+
+	for _, service := range services.Items {
+		r.logger.Infof("Removing service %s from namespace %s", service.Name, service.Namespace)
+		err := r.client.Delete(ctx, &service)
+		if err != nil {
+			allErrors = append(allErrors, err)
+		}
+	}
+
+	// Delete Deployments
+	deployments := &apps.DeploymentList{}
+	err = r.client.List(ctx, options, deployments)
+	if err != nil {
+		allErrors = append(allErrors, err)
+	}
+
+	for _, deployment := range deployments.Items {
+		r.logger.Infof("Removing deployment %s from namespace %s", deployment.Name, deployment.Namespace)
+		err := r.client.Delete(ctx, &deployment)
+		if err != nil {
+			allErrors = append(allErrors, err)
+		}
+	}
+
+	// Delete Role Bindings
+	roleBindings := &rbac.RoleBindingList{}
+	err = r.client.List(ctx, options, roleBindings)
+	if err != nil {
+		allErrors = append(allErrors, err)
+	}
+
+	for _, roleBinding := range roleBindings.Items {
+		r.logger.Infof("Removing roleBinding %s from namespace %s", roleBinding.Name, roleBinding.Namespace)
+		err := r.client.Delete(ctx, &roleBinding)
+		if err != nil {
+			allErrors = append(allErrors, err)
+		}
+	}
+
+	// Delete Roles
+	roles := &rbac.RoleList{}
+	err = r.client.List(ctx, options, roles)
+	if err != nil {
+		allErrors = append(allErrors, err)
+	}
+
+	for _, role := range roles.Items {
+		r.logger.Infof("Removing role %s from namespace %s", role.Name, role.Namespace)
+		err := r.client.Delete(ctx, &role)
+		if err != nil {
+			allErrors = append(allErrors, err)
+		}
+	}
+
+	// Delete Service Accounts
+	serviceAccounts := &core.ServiceAccountList{}
+	err = r.client.List(ctx, options, serviceAccounts)
+	if err != nil {
+		allErrors = append(allErrors, err)
+	}
+
+	for _, serviceAccount := range serviceAccounts.Items {
+		r.logger.Infof("Removing serviceAccount %s from namespace %s", serviceAccount.Name, serviceAccount.Namespace)
+		err := r.client.Delete(ctx, &serviceAccount)
+		if err != nil {
+			allErrors = append(allErrors, err)
+		}
+	}
+
+	return utilerrors.NewAggregate(allErrors)
 }

--- a/pkg/catalogsourceconfig/deploymentbuilder.go
+++ b/pkg/catalogsourceconfig/deploymentbuilder.go
@@ -37,12 +37,18 @@ func (b *DeploymentBuilder) WithMeta(name, namespace string) *DeploymentBuilder 
 	return b
 }
 
-// WithOwner sets the owner of the Deployment object to the given owner.
-func (b *DeploymentBuilder) WithOwner(owner *v1alpha1.CatalogSourceConfig) *DeploymentBuilder {
-	b.deployment.SetOwnerReferences(append(b.deployment.GetOwnerReferences(),
-		[]meta.OwnerReference{
-			*meta.NewControllerRef(owner, owner.GroupVersionKind()),
-		}[0]))
+// WithOwnerLabel sets the owner label of the Deployment object to the given owner.
+func (b *DeploymentBuilder) WithOwnerLabel(owner *v1alpha1.CatalogSourceConfig) *DeploymentBuilder {
+	labels := map[string]string{
+		CscOwnerNameLabel:      owner.Name,
+		CscOwnerNamespaceLabel: owner.Namespace,
+	}
+
+	for key, value := range b.deployment.GetLabels() {
+		labels[key] = value
+	}
+
+	b.deployment.SetLabels(labels)
 	return b
 }
 

--- a/pkg/catalogsourceconfig/podtemplatebuilder.go
+++ b/pkg/catalogsourceconfig/podtemplatebuilder.go
@@ -25,12 +25,18 @@ func (b *PodTemplateBuilder) WithObjectMeta(name, namespace string) *PodTemplate
 	return b
 }
 
-// WithOwner sets the owner of the PodTemplate object to the given owner.
-func (b *PodTemplateBuilder) WithOwner(owner *v1alpha1.CatalogSourceConfig) *PodTemplateBuilder {
-	b.pt.SetOwnerReferences(append(b.pt.GetOwnerReferences(),
-		[]meta.OwnerReference{
-			*meta.NewControllerRef(owner, owner.GroupVersionKind()),
-		}[0]))
+// WithOwnerLabel sets the owner label of the PodTemplate object to the given owner.
+func (b *PodTemplateBuilder) WithOwnerLabel(owner *v1alpha1.CatalogSourceConfig) *PodTemplateBuilder {
+	labels := map[string]string{
+		CscOwnerNameLabel:      owner.Name,
+		CscOwnerNamespaceLabel: owner.Namespace,
+	}
+
+	for key, value := range b.pt.GetLabels() {
+		labels[key] = value
+	}
+
+	b.pt.SetLabels(labels)
 	return b
 }
 

--- a/pkg/catalogsourceconfig/registry.go
+++ b/pkg/catalogsourceconfig/registry.go
@@ -273,7 +273,7 @@ func (r *registry) getSubjects() []rbac.Subject {
 func (r *registry) newDeployment(registryCommand []string) *apps.Deployment {
 	return new(DeploymentBuilder).
 		WithMeta(r.csc.GetName(), r.csc.GetNamespace()).
-		WithOwner(r.csc.CatalogSourceConfig).
+		WithOwnerLabel(r.csc.CatalogSourceConfig).
 		WithSpec(1, r.getLabel(), r.newPodTemplateSpec(registryCommand)).
 		Deployment()
 }
@@ -329,7 +329,7 @@ func (r *registry) newPodTemplateSpec(registryCommand []string) core.PodTemplate
 func (r *registry) newRole(operatorSources []string) *rbac.Role {
 	return new(RoleBuilder).
 		WithMeta(r.csc.GetName(), r.csc.GetNamespace()).
-		WithOwner(r.csc.CatalogSourceConfig).
+		WithOwnerLabel(r.csc.CatalogSourceConfig).
 		WithRules(getRules(operatorSources)).
 		Role()
 }
@@ -338,7 +338,7 @@ func (r *registry) newRole(operatorSources []string) *rbac.Role {
 func (r *registry) newRoleBinding(roleName string) *rbac.RoleBinding {
 	return new(RoleBindingBuilder).
 		WithMeta(r.csc.GetName(), r.csc.GetNamespace()).
-		WithOwner(r.csc.CatalogSourceConfig).
+		WithOwnerLabel(r.csc.CatalogSourceConfig).
 		WithSubjects(r.getSubjects()).
 		WithRoleRef(roleName).
 		RoleBinding()
@@ -348,7 +348,7 @@ func (r *registry) newRoleBinding(roleName string) *rbac.RoleBinding {
 func (r *registry) newService() *core.Service {
 	return new(ServiceBuilder).
 		WithMeta(r.csc.GetName(), r.csc.GetNamespace()).
-		WithOwner(r.csc.CatalogSourceConfig).
+		WithOwnerLabel(r.csc.CatalogSourceConfig).
 		WithSpec(r.newServiceSpec()).
 		Service()
 }
@@ -357,7 +357,7 @@ func (r *registry) newService() *core.Service {
 func (r *registry) newServiceAccount() *core.ServiceAccount {
 	return new(ServiceAccountBuilder).
 		WithMeta(r.csc.GetName(), r.csc.GetNamespace()).
-		WithOwner(r.csc.CatalogSourceConfig).
+		WithOwnerLabel(r.csc.CatalogSourceConfig).
 		ServiceAccount()
 }
 

--- a/pkg/catalogsourceconfig/rolebindingbuilder.go
+++ b/pkg/catalogsourceconfig/rolebindingbuilder.go
@@ -36,12 +36,18 @@ func (b *RoleBindingBuilder) WithMeta(name, namespace string) *RoleBindingBuilde
 	return b
 }
 
-// WithOwner sets the owner of the RoleBinding object to the given owner.
-func (b *RoleBindingBuilder) WithOwner(owner *v1alpha1.CatalogSourceConfig) *RoleBindingBuilder {
-	b.rb.SetOwnerReferences(append(b.rb.GetOwnerReferences(),
-		[]meta.OwnerReference{
-			*meta.NewControllerRef(owner, owner.GroupVersionKind()),
-		}[0]))
+// WithOwnerLabel sets the owner label of the RoleBinding object to the given owner.
+func (b *RoleBindingBuilder) WithOwnerLabel(owner *v1alpha1.CatalogSourceConfig) *RoleBindingBuilder {
+	labels := map[string]string{
+		CscOwnerNameLabel:      owner.Name,
+		CscOwnerNamespaceLabel: owner.Namespace,
+	}
+
+	for key, value := range b.rb.GetLabels() {
+		labels[key] = value
+	}
+
+	b.rb.SetLabels(labels)
 	return b
 }
 

--- a/pkg/catalogsourceconfig/rolebuilder.go
+++ b/pkg/catalogsourceconfig/rolebuilder.go
@@ -36,12 +36,18 @@ func (b *RoleBuilder) WithMeta(name, namespace string) *RoleBuilder {
 	return b
 }
 
-// WithOwner sets the owner of the Role object to the given owner.
-func (b *RoleBuilder) WithOwner(owner *v1alpha1.CatalogSourceConfig) *RoleBuilder {
-	b.role.SetOwnerReferences(append(b.role.GetOwnerReferences(),
-		[]meta.OwnerReference{
-			*meta.NewControllerRef(owner, owner.GroupVersionKind()),
-		}[0]))
+// WithOwnerLabel sets the owner label of the Role object to the given owner.
+func (b *RoleBuilder) WithOwnerLabel(owner *v1alpha1.CatalogSourceConfig) *RoleBuilder {
+	labels := map[string]string{
+		CscOwnerNameLabel:      owner.Name,
+		CscOwnerNamespaceLabel: owner.Namespace,
+	}
+
+	for key, value := range b.role.GetLabels() {
+		labels[key] = value
+	}
+
+	b.role.SetLabels(labels)
 	return b
 }
 

--- a/pkg/catalogsourceconfig/serviceaccountbuilder.go
+++ b/pkg/catalogsourceconfig/serviceaccountbuilder.go
@@ -36,11 +36,17 @@ func (b *ServiceAccountBuilder) WithMeta(name, namespace string) *ServiceAccount
 	return b
 }
 
-// WithOwner sets the owner of the ServiceAccount object to the given owner.
-func (b *ServiceAccountBuilder) WithOwner(owner *v1alpha1.CatalogSourceConfig) *ServiceAccountBuilder {
-	b.sa.SetOwnerReferences(append(b.sa.GetOwnerReferences(),
-		[]meta.OwnerReference{
-			*meta.NewControllerRef(owner, owner.GroupVersionKind()),
-		}[0]))
+// WithOwnerLabel sets the owner label of the ServiceAccount object to the given owner.
+func (b *ServiceAccountBuilder) WithOwnerLabel(owner *v1alpha1.CatalogSourceConfig) *ServiceAccountBuilder {
+	labels := map[string]string{
+		CscOwnerNameLabel:      owner.Name,
+		CscOwnerNamespaceLabel: owner.Namespace,
+	}
+
+	for key, value := range b.sa.GetLabels() {
+		labels[key] = value
+	}
+
+	b.sa.SetLabels(labels)
 	return b
 }

--- a/pkg/catalogsourceconfig/servicebuilder.go
+++ b/pkg/catalogsourceconfig/servicebuilder.go
@@ -35,12 +35,18 @@ func (b *ServiceBuilder) WithMeta(name, namespace string) *ServiceBuilder {
 	return b
 }
 
-// WithOwner sets the owner of the CatalogSource object to the given owner.
-func (b *ServiceBuilder) WithOwner(owner *v1alpha1.CatalogSourceConfig) *ServiceBuilder {
-	b.service.SetOwnerReferences(append(b.service.GetOwnerReferences(),
-		[]metav1.OwnerReference{
-			*metav1.NewControllerRef(owner, owner.GroupVersionKind()),
-		}[0]))
+// WithOwnerLabel sets the owner label of the CatalogSource object to the given owner.
+func (b *ServiceBuilder) WithOwnerLabel(owner *v1alpha1.CatalogSourceConfig) *ServiceBuilder {
+	labels := map[string]string{
+		CscOwnerNameLabel:      owner.Name,
+		CscOwnerNamespaceLabel: owner.Namespace,
+	}
+
+	for key, value := range b.service.GetLabels() {
+		labels[key] = value
+	}
+
+	b.service.SetLabels(labels)
 	return b
 }
 

--- a/pkg/operatorsource/catalogsourceconfigbuilder.go
+++ b/pkg/operatorsource/catalogsourceconfigbuilder.go
@@ -12,6 +12,16 @@ import (
 // if it is set to "true".
 const DatastoreLabel string = "opsrc-datastore"
 
+// OpsrcOwnerNameLabel is the label used to mark ownership over resources
+// that are owned by the OperatorSource. When this label is set, the reconciler
+// should handle these resources when the OperatorSource is deleted.
+const OpsrcOwnerNameLabel string = "opsrc-owner-name"
+
+// OpsrcOwnerNamespaceLabel is the label used to mark ownership over resources
+// that are owned by the OperatorSource. When this label is set, the reconciler
+// should handle these resources when the OperatorSource is deleted.
+const OpsrcOwnerNamespaceLabel string = "opsrc-owner-namespace"
+
 // CatalogSourceConfigBuilder builds a new CatalogSourceConfig type object.
 type CatalogSourceConfigBuilder struct {
 	object v1alpha1.CatalogSourceConfig
@@ -53,24 +63,27 @@ func (b *CatalogSourceConfigBuilder) WithLabels(opsrcLabels map[string]string) *
 		labels[key] = value
 	}
 
+	for key, value := range b.object.GetLabels() {
+		labels[key] = value
+	}
+
 	b.object.SetLabels(labels)
 
 	return b
 }
 
-// WithOwner sets the owner of the CatalogSourceConfig object to the given owner.
-func (b *CatalogSourceConfigBuilder) WithOwner(owner *v1alpha1.OperatorSource) *CatalogSourceConfigBuilder {
-	trueVar := true
-	ownerReference := metav1.OwnerReference{
-		APIVersion: owner.APIVersion,
-		Kind:       owner.Kind,
-		Name:       owner.Name,
-		UID:        owner.UID,
-		Controller: &trueVar,
+// WithOwnerLabel sets the owner label of the CatalogSourceConfig object to the given owner.
+func (b *CatalogSourceConfigBuilder) WithOwnerLabel(owner *v1alpha1.OperatorSource) *CatalogSourceConfigBuilder {
+	labels := map[string]string{
+		OpsrcOwnerNameLabel:      owner.Name,
+		OpsrcOwnerNamespaceLabel: owner.Namespace,
 	}
-	ownerReferences := append(b.object.GetOwnerReferences(), ownerReference)
-	b.object.SetOwnerReferences(ownerReferences)
 
+	for key, value := range b.object.GetLabels() {
+		labels[key] = value
+	}
+
+	b.object.SetLabels(labels)
 	return b
 }
 

--- a/pkg/operatorsource/configuring.go
+++ b/pkg/operatorsource/configuring.go
@@ -65,7 +65,7 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 		WithNamespacedName(in.Namespace, in.Name).
 		WithLabels(in.GetLabels()).
 		WithSpec(in.Namespace, manifests, in.Spec.DisplayName, in.Spec.Publisher).
-		WithOwner(in).
+		WithOwnerLabel(in).
 		CatalogSourceConfig()
 
 	err = r.client.Create(ctx, cscCreate)
@@ -96,15 +96,10 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 
 	cscExisting.EnsureGVK()
 
-	// The existing CatalogSourceConfig might already be owned by this
-	// OperatorSource object. Let's remove the owner reference, otherwise we
-	// will be adding it twice.
-	cscExisting.RemoveOwner(in.GetUID())
-
 	builder := CatalogSourceConfigBuilder{object: cscExisting}
 	cscUpdate := builder.WithSpec(in.Namespace, manifests, in.Spec.DisplayName, in.Spec.Publisher).
 		WithLabels(in.GetLabels()).
-		WithOwner(in).
+		WithOwnerLabel(in).
 		CatalogSourceConfig()
 
 	err = r.client.Update(ctx, cscUpdate)


### PR DESCRIPTION
-Since owner references across namespaces are unreliable, remove them
-Stop adding owner references to created resources
-Track resources that need to be deleted with labels
-Delete all created resources in finalizer of respective custom resource