### PR TITLE
Bug 1680070: Allow specifying spaces in between packages

### DIFF
--- a/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
+++ b/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
@@ -99,7 +99,7 @@ func (csc *CatalogSourceConfig) EnsurePublisher() {
 
 // GetPackageIDs returns the list of package(s) specified.
 func (csc *CatalogSourceConfig) GetPackageIDs() []string {
-	return strings.Split(csc.Spec.Packages, ",")
+	return strings.Split(strings.Replace(csc.Spec.Packages, " ", "", -1), ",")
 }
 
 // GetTargetNamespace returns the TargetNamespace where the OLM resources will
@@ -122,4 +122,9 @@ func (csc *CatalogSourceConfig) RemoveOwner(ownerUID types.UID) {
 	}
 
 	csc.SetOwnerReferences(owners)
+}
+
+// GetPackageIDs returns the list of package(s) specified.
+func (spec *CatalogSourceConfigSpec) GetPackageIDs() []string {
+	return strings.Split(strings.Replace(spec.Packages, " ", "", -1), ",")
 }

--- a/pkg/catalogsourceconfig/cache.go
+++ b/pkg/catalogsourceconfig/cache.go
@@ -56,8 +56,8 @@ func (c *cache) IsEntryStale(csc *v1alpha1.CatalogSourceConfig) (bool, bool) {
 		return true, true
 	}
 
-	cachedPackages := GetPackageIDs(spec.Packages)
-	inPackageIDs := GetPackageIDs(csc.Spec.Packages)
+	cachedPackages := spec.GetPackageIDs()
+	inPackageIDs := csc.GetPackageIDs()
 
 	if len(cachedPackages) != len(inPackageIDs) {
 		return true, false

--- a/pkg/catalogsourceconfig/cache_test.go
+++ b/pkg/catalogsourceconfig/cache_test.go
@@ -32,7 +32,7 @@ func TestMain(m *testing.M) {
 // TestGet tests if an CatalogSourceConfig object inserted into the cache is found.
 func TestGet(t *testing.T) {
 	spec, found := cache.Get(csc)
-	outPackages := catalogsourceconfig.GetPackageIDs(spec.Packages)
+	outPackages := spec.GetPackageIDs()
 	assert.ElementsMatch(t, inPackages, outPackages)
 	assert.True(t, found)
 }

--- a/pkg/catalogsourceconfig/configuring.go
+++ b/pkg/catalogsourceconfig/configuring.go
@@ -128,7 +128,7 @@ func (r *configuringReconciler) reconcileCatalogSource(csc *v1alpha1.CatalogSour
 // datastore but listed in the spec.
 func (r *configuringReconciler) checkPackages(csc *v1alpha1.CatalogSourceConfig) error {
 	missingPackages := []string{}
-	packageIDs := GetPackageIDs(csc.Spec.Packages)
+	packageIDs := csc.GetPackageIDs()
 	for _, packageID := range packageIDs {
 		if _, err := r.reader.Read(packageID); err != nil {
 			missingPackages = append(missingPackages, packageID)
@@ -143,11 +143,6 @@ func (r *configuringReconciler) checkPackages(csc *v1alpha1.CatalogSourceConfig)
 		)
 	}
 	return nil
-}
-
-// GetPackageIDs returns a list of IDs from a comma separated string of IDs.
-func GetPackageIDs(csIDs string) []string {
-	return strings.Split(csIDs, ",")
 }
 
 // newCatalogSource returns a CatalogSource object.

--- a/pkg/catalogsourceconfig/registry.go
+++ b/pkg/catalogsourceconfig/registry.go
@@ -241,7 +241,7 @@ func (r *registry) getLabel() map[string]string {
 func (r *registry) getOperatorSources() (string, []string) {
 	var opsrcString string
 	var opsrcList []string
-	for _, packageID := range GetPackageIDs(r.csc.Spec.Packages) {
+	for _, packageID := range r.csc.Spec.GetPackageIDs() {
 		opsrcMeta, err := r.reader.Read(packageID)
 		if err != nil {
 			r.log.Errorf("Error %v reading package %s", err, packageID)
@@ -402,7 +402,7 @@ func (r *registry) waitForDeploymentScaleDown(retryInterval, timeout time.Durati
 
 // getCommand returns the command used to launch the registry server
 func getCommand(packages string, sources string) []string {
-	return []string{"appregistry-server", "-s", sources, "-o", packages}
+	return []string{"appregistry-server", "-s", sources, "-o", strings.Replace(packages, " ", "", -1)}
 }
 
 // getRules returns the PolicyRule needed to access the given operatorSources and secrets


### PR DESCRIPTION
A CatalogSourceConfig spec should allow a valid set of packages to be specified with spaces in between them. For example: foo, bar, jazz