### PR TITLE
Bug 1683422: [csc] Make CLI output less verbose

### DIFF
--- a/deploy/crds/catalogsourceconfig.crd.yaml
+++ b/deploy/crds/catalogsourceconfig.crd.yaml
@@ -17,26 +17,10 @@ spec:
   scope: Namespaced
   version: v1alpha1
   additionalPrinterColumns:
-  - name: TargetNamespace
-    type: string
-    description: The namespace where the operators will be enabled
-    JSONPath: .spec.targetNamespace
-  - name: Packages
-    type: string
-    description: List of operator(s) which will be enabled in the target namespace
-    JSONPath: .spec.packages
   - name: Status
     type: string
     description: Current status of the CatalogSourceConfig
     JSONPath: .status.currentPhase.phase.name
-  - name: DisplayName
-    type: string
-    description: Display Name for resulting CatalogSource
-    JSONPath: .spec.csDisplayName
-  - name: Publisher
-    type: string
-    description: Publisher for resulting CatalogSource
-    JSONPath: .spec.csPublisher
   - name: Message
     type: string
     description: Message associated with the current status

--- a/deploy/upstream/02_catalogsourceconfig.crd.yaml
+++ b/deploy/upstream/02_catalogsourceconfig.crd.yaml
@@ -17,14 +17,6 @@ spec:
   scope: Namespaced
   version: v1alpha1
   additionalPrinterColumns:
-  - name: TargetNamespace
-    type: string
-    description: The namespace where the operators will be enabled
-    JSONPath: .spec.targetNamespace
-  - name: Packages
-    type: string
-    description: List of operator(s) which will be enabled in the target namespace
-    JSONPath: .spec.packages
   - name: Status
     type: string
     description: Current status of the CatalogSourceConfig

--- a/manifests/02_catalogsourceconfig.crd.yaml
+++ b/manifests/02_catalogsourceconfig.crd.yaml
@@ -17,26 +17,10 @@ spec:
   scope: Namespaced
   version: v1alpha1
   additionalPrinterColumns:
-  - name: TargetNamespace
-    type: string
-    description: The namespace where the operators will be enabled
-    JSONPath: .spec.targetNamespace
-  - name: Packages
-    type: string
-    description: List of operator(s) which will be enabled in the target namespace
-    JSONPath: .spec.packages
   - name: Status
     type: string
     description: Current status of the CatalogSourceConfig
     JSONPath: .status.currentPhase.phase.name
-  - name: DisplayName
-    type: string
-    description: Display Name for resulting CatalogSource
-    JSONPath: .spec.csDisplayName
-  - name: Publisher
-    type: string
-    description: Publisher for resulting CatalogSource
-    JSONPath: .spec.csPublisher
   - name: Message
     type: string
     description: Message associated with the current status


### PR DESCRIPTION
- Fixes #116
- Removed `TARGETNAMESPACE`, `PACKAGES`, `DISPLAYNAME` and `PUBLISHER` fields from output
- Modified catalogsourceconfig.crd to remove fields from `additionalPrinterColumns`