### PR TITLE
Bug 1685066: Fix OperatorSource sync

### DIFF
--- a/pkg/catalogsourceconfig/cache.go
+++ b/pkg/catalogsourceconfig/cache.go
@@ -12,6 +12,11 @@ import (
 // using the Operator Registry as the data store for CatalogSources. If this
 // is required even after, then it should be replaced with an existing thread
 // safe caching library like go-cache or cash.
+//
+// TODO: Make the cache app-registry version aware so that IsEntryStale() will
+// fire even for the scenario where a Quay namespace has changed without
+// app-registry repositories being added or removed but with existing
+// repositories being updated.
 type cache struct {
 	entries map[types.UID]*v1alpha1.CatalogSourceConfigSpec
 }

--- a/pkg/operatorsource/configuring.go
+++ b/pkg/operatorsource/configuring.go
@@ -102,6 +102,12 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1alpha1.Oper
 		WithOwnerLabel(in).
 		CatalogSourceConfig()
 
+	// Drop the status to force a CatalogSourceConfig update. This is to account
+	// for the the scenario where a Quay namespace has changed without
+	// app-registry repositories being added or removed but with existing
+	// repositories being updated.
+	cscUpdate.Status = v1alpha1.CatalogSourceConfigStatus{}
+
 	err = r.client.Update(ctx, cscUpdate)
 	if err != nil {
 		r.logger.Errorf("Unexpected error while updating CatalogSourceConfig: %s", err.Error())

--- a/pkg/operatorsource/syncer.go
+++ b/pkg/operatorsource/syncer.go
@@ -53,7 +53,7 @@ func (s *registrySyncer) Sync(stop <-chan struct{}) {
 	for {
 		select {
 		case <-time.After(s.resyncInterval):
-			log.Debug("[sync] Checking for operator source update(s) in remote registry")
+			log.Info("[sync] Checking for operator source update(s) in remote registry")
 			s.poller.Poll()
 
 		case <-stop:


### PR DESCRIPTION
**Problem**
Prior to f9d37cc029, as part of syncing `OperatorSources`, the associated `CatalogSourceConfigs` were being deleted and recreated. This always ensured that we got the latest state from Quay. With that change we moved to updating `CatalogSourceConfigs`. Now in the scenario where a Quay namespace has changed without app-registry repositories being added or removed but with existing repositories being updated, these updates will not be reflected on the cluster.

**Solution**
The right fix for this would be for the `CatalogSourceConfig` cache to become app-registry version aware and to detect that updates are required not just based on spec changes. In the short term an easy fix is to drop the `CatalogSourceConfig` status before updating.

This fixes [bug 1685066](https://bugzilla.redhat.com/show_bug.cgi?id=1685066)