### PR TITLE
Bug 1685331: Update priority for operator

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -16,6 +16,7 @@ spec:
       serviceAccountName: marketplace-operator
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists
       containers:

--- a/manifests/10_operator.yaml
+++ b/manifests/10_operator.yaml
@@ -16,6 +16,7 @@ spec:
       serviceAccountName: marketplace-operator
       nodeSelector:
         node-role.kubernetes.io/master: ""
+      priorityClassName: "system-cluster-critical"
       tolerations:
       - operator: Exists
       containers:


### PR DESCRIPTION
- Specify `system-cluster-critical` priority for operator
- Blocks passing smoke tests for ensuring control plane pods always schedule

See: openshift/origin#22217
Fixes [bug 1685331](https://bugzilla.redhat.com/show_bug.cgi?id=1685331)