### PR TITLE
Bug 1685647: Remove unnecessary ClusterRoles

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -1,8 +1,39 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  creationTimestamp: null
   name: marketplace-operator
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  verbs:
+  - get
+  - create
+  - delete
+  - update
+  - list
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  - clusteroperators/status
+  verbs:
+  - create
+  - get
+  - update
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: marketplace-operator
+  namespace: openshift-marketplace
 rules:
 - apiGroups:
   - marketplace.redhat.com
@@ -30,16 +61,6 @@ rules:
   - update
   - list
 - apiGroups:
-  - operators.coreos.com
-  resources:
-  - catalogsources
-  verbs:
-  - get
-  - create
-  - delete
-  - update
-  - list
-- apiGroups:
   - apps
   resources:
   - deployments
@@ -49,21 +70,6 @@ rules:
   - delete
   - update
   - list
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - clusteroperators
-  - clusteroperators/status
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/deploy/role_binding.yaml
+++ b/deploy/role_binding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: default-account-marketplace-operator
+  name: marketplace-operator
 subjects:
 - kind: ServiceAccount
   name: marketplace-operator
@@ -9,4 +9,19 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: marketplace-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: marketplace-operator
+  namespace: openshift-marketplace
+subjects:
+- kind: ServiceAccount
+  name: marketplace-operator
+  namespace: openshift-marketplace
+roleRef:
+  kind: Role
+  name: marketplace-operator
+  namespace: openshift-marketplace
   apiGroup: rbac.authorization.k8s.io

--- a/deploy/upstream/05_role.yaml
+++ b/deploy/upstream/05_role.yaml
@@ -1,8 +1,30 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  creationTimestamp: null
   name: marketplace-operator
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  verbs:
+  - get
+  - create
+  - delete
+  - update
+  - list
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: marketplace-operator
+  namespace: marketplace
 rules:
 - apiGroups:
   - marketplace.redhat.com
@@ -30,16 +52,6 @@ rules:
   - update
   - list
 - apiGroups:
-  - operators.coreos.com
-  resources:
-  - catalogsources
-  verbs:
-  - get
-  - create
-  - delete
-  - update
-  - list
-- apiGroups:
   - apps
   resources:
   - deployments
@@ -49,12 +61,6 @@ rules:
   - delete
   - update
   - list
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/deploy/upstream/06_role_binding.yaml
+++ b/deploy/upstream/06_role_binding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: default-account-marketplace-operator
+  name: marketplace-operator
 subjects:
 - kind: ServiceAccount
   name: marketplace-operator
@@ -9,4 +9,19 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: marketplace-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: marketplace-operator
+  namespace: marketplace
+subjects:
+- kind: ServiceAccount
+  name: marketplace-operator
+  namespace: marketplace
+roleRef:
+  kind: Role
+  name: marketplace-operator
+  namespace: marketplace
   apiGroup: rbac.authorization.k8s.io

--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -1,8 +1,39 @@
 kind: ClusterRole
 apiVersion: rbac.authorization.k8s.io/v1
 metadata:
-  creationTimestamp: null
   name: marketplace-operator
+rules:
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - catalogsources
+  verbs:
+  - get
+  - create
+  - delete
+  - update
+  - list
+- apiGroups:
+  - apiextensions.k8s.io
+  resources:
+  - customresourcedefinitions
+  verbs:
+  - get
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - clusteroperators
+  - clusteroperators/status
+  verbs:
+  - create
+  - get
+  - update
+---
+kind: Role
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: marketplace-operator
+  namespace: openshift-marketplace
 rules:
 - apiGroups:
   - marketplace.redhat.com
@@ -30,16 +61,6 @@ rules:
   - update
   - list
 - apiGroups:
-  - operators.coreos.com
-  resources:
-  - catalogsources
-  verbs:
-  - get
-  - create
-  - delete
-  - update
-  - list
-- apiGroups:
   - apps
   resources:
   - deployments
@@ -49,21 +70,6 @@ rules:
   - delete
   - update
   - list
-- apiGroups:
-  - config.openshift.io
-  resources:
-  - clusteroperators
-  - clusteroperators/status
-  verbs:
-  - create
-  - get
-  - update
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
 - apiGroups:
   - rbac.authorization.k8s.io
   resources:

--- a/manifests/06_role_binding.yaml
+++ b/manifests/06_role_binding.yaml
@@ -1,7 +1,7 @@
 kind: ClusterRoleBinding
 apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
-  name: default-account-marketplace-operator
+  name: marketplace-operator
 subjects:
 - kind: ServiceAccount
   name: marketplace-operator
@@ -9,4 +9,19 @@ subjects:
 roleRef:
   kind: ClusterRole
   name: marketplace-operator
+  apiGroup: rbac.authorization.k8s.io
+---
+kind: RoleBinding
+apiVersion: rbac.authorization.k8s.io/v1beta1
+metadata:
+  name: marketplace-operator
+  namespace: openshift-marketplace
+subjects:
+- kind: ServiceAccount
+  name: marketplace-operator
+  namespace: openshift-marketplace
+roleRef:
+  kind: Role
+  name: marketplace-operator
+  namespace: openshift-marketplace
   apiGroup: rbac.authorization.k8s.io


### PR DESCRIPTION
After moving to using grpc CatalogSources, the operator is dealing with more resources like `Services` and `Deployments`. Initially there were being created in a different namespace that required a `ClusterRole`. But the final implementation saw the resources being created in the same namespace. Given that we create a `Role` and `RoleBinding` for those resources we are dealing with in our namespace. The only resources we need a ClusterRole for are `CustomResourceDefinitions`, `ClusterOperator` and `CatalogSources`.

This fixes [bug 1685647](https://bugzilla.redhat.com/show_bug.cgi?id=1685647)