### PR TITLE
Bug 1679284: Properly sync catalogsourceconfigs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -40,6 +40,7 @@ generate-mocks:
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_kubeclient.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=Client=KubeClient $(CONTROLLER_RUNTIME_PKG)/client Client
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_phase_reconciler_strategy.go -package=$(OPERATORSOURCE_MOCK_PKG) $(PKG)/operatorsource PhaseReconcilerFactory
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_appregistry.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=ClientFactory=AppRegistryClientFactory,Client=AppRegistryClient $(PKG)/appregistry ClientFactory,Client
+	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_syncer.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=PackageRefreshNotificationSender=SyncerPackageRefreshNotificationSender $(PKG)/operatorsource PackageRefreshNotificationSender
 
 clean-mocks:
 	@echo cleaning mock folder

--- a/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
+++ b/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
@@ -54,6 +54,9 @@ type CatalogSourceConfigSpec struct {
 type CatalogSourceConfigStatus struct {
 	// Current phase of the CatalogSourceConfig object.
 	CurrentPhase ObjectPhase `json:"currentPhase,omitempty"`
+
+	// Map of packages (key) and their app registry package version (value)
+	PackageRepositioryVersions map[string]string `json:"packageMap,omitempty"`
 }
 
 func init() {

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -33,6 +33,10 @@ type Reader interface {
 	// The OpsrcRef returned can be used to determine how to download manifests
 	// for a specific operator package.
 	Read(packageID string) (opsrcMeta *OpsrcRef, err error)
+
+	// ReadVersion takes a package identifer and returns version metadata
+	// to associate that package to a particular repository version.
+	ReadRepositoryVersion(packageID string) (version string, err error)
 }
 
 // Writer is an interface that is used to manage the underlying datastore
@@ -123,6 +127,17 @@ func (ds *memoryDatastore) Read(packageID string) (opsrcMeta *OpsrcRef, err erro
 	}
 
 	opsrcMeta = repository.Opsrc
+
+	return
+}
+
+func (ds *memoryDatastore) ReadRepositoryVersion(packageID string) (version string, err error) {
+	repository, err := ds.GetRepositoryByPackageName(packageID)
+	if err != nil {
+		return
+	}
+
+	version = repository.Metadata.Release
 
 	return
 }

--- a/pkg/datastore/update_result.go
+++ b/pkg/datastore/update_result.go
@@ -18,6 +18,12 @@ func NewPackageUpdateAggregator() *PackageUpdateAggregator {
 	}
 }
 
+func NewPackageRefreshNotification() *PackageUpdateAggregator {
+	return &PackageUpdateAggregator{
+		refreshNeeded: true,
+	}
+}
+
 // UpdateResult holds information related to what has changed in the remote
 // registry associated with an operator source.
 type UpdateResult struct {
@@ -50,14 +56,24 @@ type PackageUpdateNotification interface {
 
 	// IsUpdated returns true if the specified package has a new version.
 	IsUpdated(pkg string) bool
+
+	// IsRefreshNotification returns true if the notification is used to update the
+	// initial state. We use this on startup and as a way to force update when
+	// the cache is in a bad state.
+	IsRefreshNotification() bool
 }
 
 // PackageUpdateAggregator is used to aggregate update information from across
 // all operator source(s).
 // PackageUpdateAggregator also implements PackageUpdateNotification interface.
 type PackageUpdateAggregator struct {
-	updated map[string]bool
-	removed map[string]bool
+	updated       map[string]bool
+	removed       map[string]bool
+	refreshNeeded bool
+}
+
+func (a *PackageUpdateAggregator) IsRefreshNotification() bool {
+	return a.refreshNeeded
 }
 
 // Add accepts an UpdateResult for a given operator source and aggregates it.

--- a/pkg/operatorsource/factory.go
+++ b/pkg/operatorsource/factory.go
@@ -38,6 +38,7 @@ type phaseReconcilerFactory struct {
 	registryClientFactory appregistry.ClientFactory
 	datastore             datastore.Writer
 	client                client.Client
+	refresher             PackageRefreshNotificationSender
 }
 
 func (s *phaseReconcilerFactory) GetPhaseReconciler(logger *log.Entry, opsrc *v1alpha1.OperatorSource) (Reconciler, error) {
@@ -59,7 +60,7 @@ func (s *phaseReconcilerFactory) GetPhaseReconciler(logger *log.Entry, opsrc *v1
 		return NewValidatingReconciler(logger, s.datastore), nil
 
 	case phase.OperatorSourceDownloading:
-		return NewDownloadingReconciler(logger, s.registryClientFactory, s.datastore, s.client), nil
+		return NewDownloadingReconciler(logger, s.registryClientFactory, s.datastore, s.client, s.refresher), nil
 
 	case phase.Configuring:
 		return NewConfiguringReconciler(logger, s.datastore, s.client), nil

--- a/pkg/operatorsource/handler.go
+++ b/pkg/operatorsource/handler.go
@@ -31,6 +31,7 @@ func NewHandler(mgr manager.Manager, client client.Client) Handler {
 			registryClientFactory: appregistry.NewClientFactory(),
 			datastore:             datastore.Cache,
 			client:                client,
+			refresher:             cscRefresher,
 		},
 		transitioner:       phase.NewTransitioner(),
 		newCacheReconciler: NewOutOfSyncCacheReconciler,


### PR DESCRIPTION
Currently, the opsrc poller will update the package list and send a
notification to the catalog syncer if there are changes to any of its
packages. This has several limitations however, primarily that if there
is any service hiccup or an opsrc is deleted, the history of upgrade is
lost. To alleviate that issue, the following has been updated:

- Added a PackageMap to the status of catalogsourceconfig. This is a
mapping between PackageName and current version at the time the
catalogsourceconfig was created.
- Modified the catalogsyncer to include a new method,
SyncRefresh() that pushes an empty notification onto the listening
channel and calls the Trigger()
- Modified the trigger method so that, when this empty notification is
sent, the triggerer will compare all non-datastore catalogsourceconfigs
with the current versions in the datastore and update them if out of
sync.
- We now call the SyncRefresh() method in two cases. First
whenever the operator first comes up to ensure any cache related issues
are resolved. Second, whenever a new opsrc is created.
are resolved. Second, whenever a new opsrc is created.
- Reduced the initial wait from 10 minutes to 1 minute, to account for
the initial resync.
- Made catalogSyncer global so that the SendRefresh()  method can be
called while the opsrc handler handles creation of new operator sources