### PR TITLE
Fix Operator-SDK build

### DIFF
--- a/build/Dockerfile
+++ b/build/Dockerfile
@@ -3,4 +3,4 @@ FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 RUN useradd marketplace-operator
 USER marketplace-operator
 
-ADD build/_output/bin/operator-marketplace /usr/local/bin/operator-marketplace
+ADD build/_output/bin/operator-marketplace /usr/local/bin/marketplace-operator


### PR DESCRIPTION
Problem:
Using the operator-sdk build command is currently broken on this project
The operator-sdk expects a dockerfile in the path `build/Dockerfile`
to build the container image
Currently, that Dockerfile refers to a source binary that is incorrectly
named

Solution:
Update the dockerfile to point to the correct binary:
`marketplace-operator`