### PR TITLE
Bug 1679284: [csc] Fix PackageRepositoryVersions json string

### DIFF
--- a/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
+++ b/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
@@ -56,7 +56,7 @@ type CatalogSourceConfigStatus struct {
 	CurrentPhase ObjectPhase `json:"currentPhase,omitempty"`
 
 	// Map of packages (key) and their app registry package version (value)
-	PackageRepositioryVersions map[string]string `json:"packageMap,omitempty"`
+	PackageRepositioryVersions map[string]string `json:"packageRepositioryVersions,omitempty"`
 }
 
 func init() {


### PR DESCRIPTION
Problem:
When adding catalogsourceconfig.status.PackageRepositioryVersions to
the schema of CatalogSourceConfig, the json field was defined improperly

Solution:
Update the `status.PackageRepositoryVersion` json string name from
`packageMap` to `packageRepositioryVersions`

This should have been included as part of the fix for:
https://bugzilla.redhat.com/show_bug.cgi?id=1679284