### PR TITLE
Bug 1686121 & 1689443: Update management of clusterOperator

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -14,12 +14,6 @@ rules:
   - update
   - list
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-- apiGroups:
   - config.openshift.io
   resources:
   - clusteroperators

--- a/deploy/upstream/05_role.yaml
+++ b/deploy/upstream/05_role.yaml
@@ -13,12 +13,6 @@ rules:
   - delete
   - update
   - list
-- apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -14,12 +14,6 @@ rules:
   - update
   - list
 - apiGroups:
-  - apiextensions.k8s.io
-  resources:
-  - customresourcedefinitions
-  verbs:
-  - get
-- apiGroups:
   - config.openshift.io
   resources:
   - clusteroperators

--- a/manifests/11_clusteroperator.yaml
+++ b/manifests/11_clusteroperator.yaml
@@ -1,7 +1,7 @@
 apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
-  name: marketplace-operator
+  name: marketplace
   namespace: openshift-marketplace
 status:
   versions:

--- a/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
+++ b/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
@@ -5,6 +5,7 @@ import (
 
 	marketplacev1alpha1 "github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
 	catalogsourceconfighandler "github.com/operator-framework/operator-marketplace/pkg/catalogsourceconfig"
+	"github.com/operator-framework/operator-marketplace/pkg/status"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -81,10 +82,19 @@ type ReconcileCatalogSourceConfig struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileCatalogSourceConfig) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	log.Printf("Reconciling CatalogSourceConfig %s/%s\n", request.Namespace, request.Name)
+	// Reconcile kicked off, message Sync Channel
+	status.SendSyncMessage(nil)
 
+	// If err is not nil at the end of this function message the syncCh channel
+	var err error
+	defer func() {
+		if err != nil {
+			status.SendSyncMessage(err)
+		}
+	}()
 	// Fetch the CatalogSourceConfig instance
 	instance := &marketplacev1alpha1.CatalogSourceConfig{}
-	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	err = r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/pkg/controller/operatorsource/operatorsource_controller.go
+++ b/pkg/controller/operatorsource/operatorsource_controller.go
@@ -5,6 +5,7 @@ import (
 
 	marketplacev1alpha1 "github.com/operator-framework/operator-marketplace/pkg/apis/marketplace/v1alpha1"
 	operatorsourcehandler "github.com/operator-framework/operator-marketplace/pkg/operatorsource"
+	"github.com/operator-framework/operator-marketplace/pkg/status"
 	log "github.com/sirupsen/logrus"
 	"k8s.io/apimachinery/pkg/api/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -63,10 +64,19 @@ type ReconcileOperatorSource struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileOperatorSource) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	log.Printf("Reconciling OperatorSource %s/%s\n", request.Namespace, request.Name)
+	// Reconcile kicked off, message Sync Channel with sync event
+	status.SendSyncMessage(nil)
 
+	// If err is not nil at the end of this function message the syncCh channel
+	var err error
+	defer func() {
+		if err != nil {
+			status.SendSyncMessage(err)
+		}
+	}()
 	// Fetch the OperatorSource instance
 	instance := &marketplacev1alpha1.OperatorSource{}
-	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	err = r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -1,22 +1,54 @@
 package status
 
 import (
-	"context"
+	"fmt"
+	"sync"
+	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
 	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	cohelpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	operatorhelpers "github.com/openshift/library-go/pkg/operator/v1helpers"
 	log "github.com/sirupsen/logrus"
-	"k8s.io/apiextensions-apiserver/pkg/apis/apiextensions/v1beta1"
-	"k8s.io/apimachinery/pkg/api/errors"
+	apierrors "k8s.io/apimachinery/pkg/api/errors"
 	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime/schema"
+	"k8s.io/client-go/discovery"
+	"k8s.io/client-go/kubernetes"
 	"k8s.io/client-go/rest"
-	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 )
 
-const clusterOperatorName = "marketplace-operator"
+const (
+	// clusterOperatorName is the name of the cluster operator
+	clusterOperatorName = "marketplace-operator"
+
+	// minSyncsBeforeReporting is the minimum number of syncs we wish to see
+	// before reporting that the operator is available
+	minSyncsBeforeReporting = 4
+
+	// successRatio is the ratio of successful syncs / total syncs that we
+	// want to see in order to report that the marketplace operator is healthy.
+	// This value is low right now because the failed syncs come from invalid CRs.
+	// As the status reporting evolves we can tweek this ratio to be a better
+	// representation of the operator's health.
+	successRatio = 0.3
+
+	// syncsBeforeTruncate is used to prevent the totalSyncs and
+	// failedSyncs values from overflowing in a long running operator.
+	// Once totalSyncs reaches the maxSyncsBeforeTruncate value, totalSyncs
+	// and failedSyncs will be recalculated with the following
+	// equation: updatedValue = currentValue % syncTruncateValue.
+	syncsBeforeTruncate = 10000
+	syncTruncateValue   = 100
+
+	// coStatusReportInterval is the interval at which the cluster operator status is updated
+	coStatusReportInterval = 20 * time.Second
+)
+
+// status will be a singleton
+var instance *status
+var once sync.Once
 
 type status struct {
 	configClient    *configclient.ConfigV1Client
@@ -24,52 +56,87 @@ type status struct {
 	namespace       string
 	clusterOperator *configv1.ClusterOperator
 	version         string
+	syncRatio       SyncRatio
+	// syncCh is used to report sync events
+	syncCh chan error
+	// stopCh is used to signal that threads should stop reporting ClusterOperator status
+	stopCh <-chan struct{}
+	// monitorDoneCh is used to signal that threads are done reporting ClusterOperator status
+	monitorDoneCh chan struct{}
 }
 
-// Status is the interface to report the health of the operator to CVO
-type Status interface {
-	SetFailing(message string)
-	SetAvailable(message string)
-	SetProgressing(message string)
-	GetVersion() string
-}
-
-func (s *status) GetVersion() string {
-	return s.version
-}
-
-// New returns an initialized Status
-func New(cfg *rest.Config, mgr manager.Manager, namespace string, version string) Status {
-	// The default client serves read requests from the cache which contains
-	// objects only from the namespace the operator is watching. Given we need
-	// to query CRDs which are cluster wide, we add the CRDs to the manager's
-	// scheme and create our own client.
-	if err := v1beta1.AddToScheme(mgr.GetScheme()); err != nil {
-		log.Fatal(err)
+// SendSyncMessage is used to send messages to the syncCh. If the channel is
+// busy, the sync will be dropped to prevent the controller from stalling.
+func SendSyncMessage(err error) {
+	// If the coAPI is not available do not attempt to send messages to the
+	// sync channel
+	if instance == nil || instance.coAPINotPresent {
+		return
 	}
+	// A missing sync status is better than stalling the controller
+	select {
+	case instance.syncCh <- err:
+		log.Debugf("[status] Sent message to the sync channel")
+		break
+	default:
+		log.Debugf("[status] Sync channel is busy, not reporting sync")
+	}
+}
 
-	controllerClient, err := client.New(cfg, client.Options{Scheme: mgr.GetScheme()})
+// StartReporting ensures that the cluster supports reporting ClusterOperator status
+// and returns a channel that reports if it is actively reporting.
+func StartReporting(cfg *rest.Config, mgr manager.Manager, namespace string, version string, stopCh <-chan struct{}) <-chan struct{} {
+	// ensure instance is only created once.
+	once.Do(func() {
+		instance = new(cfg, mgr, namespace, version, stopCh)
+		// exit if cluster operator api is not present
+		if instance.coAPINotPresent {
+			return
+		}
+
+		// start consuming messages on the sync channel
+		go instance.syncChannelReceiver()
+
+		// start reporting ClusterOperator status
+		go instance.monitorClusterStatus()
+	})
+
+	return instance.monitorDoneCh
+}
+
+// New returns an initialized status
+func new(cfg *rest.Config, mgr manager.Manager, namespace string, version string, stopCh <-chan struct{}) *status {
+	// Check if the ClusterOperator API is present on the cluster. If the API
+	// is not present on the cluster set the status.coAPINotPresent to true so
+	// status is not reported
+	k8sInterface, err := kubernetes.NewForConfig(cfg)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("[status] " + err.Error())
 	}
+	err = discovery.ServerSupportsVersion(k8sInterface.Discovery(), schema.GroupVersion{
+		Group:   "config.openshift.io",
+		Version: "v1",
+	})
 
-	// Check if the ClusterOperator API is present on the cluster. This is so
-	// that we can continue to work with Kubernetes clusters that don't have
-	// this API.
-	key := client.ObjectKey{
-		Name: "clusteroperators.config.openshift.io",
-	}
-	err = controllerClient.Get(context.TODO(), key, (&v1beta1.CustomResourceDefinition{}))
+	monitorDoneCh := make(chan struct{})
 	coAPINotPresent := false
 	if err != nil {
-		log.Warningf("ClusterOperator API not present: %v", err)
+		log.Warningf("[status] ClusterOperator API not present: %v", err)
 		coAPINotPresent = true
+		// If the co is not present, close the monitorDoneCh channel to prevent
+		// recievers from stalling
+		close(monitorDoneCh)
 	}
 
 	// Client for handling reporting of operator status
 	configClient, err := configclient.NewForConfig(cfg)
 	if err != nil {
-		log.Fatal(err)
+		log.Fatal("[status] " + err.Error())
+	}
+
+	syncRatio, err := NewSyncRatio(successRatio, syncsBeforeTruncate, syncTruncateValue)
+	if err != nil {
+		log.Fatal("[status] " + err.Error())
 	}
 
 	return &status{
@@ -77,37 +144,42 @@ func New(cfg *rest.Config, mgr manager.Manager, namespace string, version string
 		coAPINotPresent: coAPINotPresent,
 		namespace:       namespace,
 		version:         version,
+		syncRatio:       syncRatio,
+		// Add a buffer to prevent dropping syncs
+		syncCh:        make(chan error, 25),
+		stopCh:        stopCh,
+		monitorDoneCh: monitorDoneCh,
 	}
 }
 
-// SetFailing reports that operator has failed along with the error message
-func (s *status) SetFailing(message string) {
-	s.setStatus(configv1.OperatorFailing, message)
+// setFailing reports that operator has failed along with the error message
+func (s *status) setFailing(message string) error {
+	return s.setStatus(configv1.OperatorFailing, message)
 }
 
-// SetAvailable reports that the operator is available to process events
-func (s *status) SetAvailable(message string) {
-	s.setStatus(configv1.OperatorAvailable, message)
+// setAvailable reports that the operator is available to process events
+func (s *status) setAvailable(message string) error {
+	return s.setStatus(configv1.OperatorAvailable, message)
 }
 
-// SetProgressing reports that the operator is being deployed
-func (s *status) SetProgressing(message string) {
-	s.setStatus(configv1.OperatorProgressing, message)
+// setProgressing reports that the operator is being deployed
+func (s *status) setProgressing(message string) error {
+	return s.setStatus(configv1.OperatorProgressing, message)
 }
 
 // ensureClusterOperator ensures that a ClusterOperator CR is present on the
 // cluster
-func (s *status) ensureClusterOperator() {
+func (s *status) ensureClusterOperator() error {
 	var err error
 	s.clusterOperator, err = s.configClient.ClusterOperators().Get(clusterOperatorName, v1.GetOptions{})
 
 	if err == nil {
-		log.Info("Found existing ClusterOperator")
-		return
+		log.Debug("[status] Found existing ClusterOperator")
+		return nil
 	}
 
-	if err != nil && !errors.IsNotFound(err) {
-		log.Fatalf("Error %v getting ClusterOperator", err)
+	if err != nil && !apierrors.IsNotFound(err) {
+		return fmt.Errorf("Error %v getting ClusterOperator", err)
 	}
 
 	s.clusterOperator, err = s.configClient.ClusterOperators().Create(&configv1.ClusterOperator{
@@ -117,24 +189,34 @@ func (s *status) ensureClusterOperator() {
 		},
 	})
 	if err != nil {
-		log.Fatalf("Error %v creating ClusterOperator", err)
+		return fmt.Errorf("Error %v creating ClusterOperator", err)
 	}
-	log.Info("Created ClusterOperator")
+	log.Info("[status] Created ClusterOperator")
+	return nil
 }
 
 // setStatus handles setting all the required fields for the given
 // ClusterStatusConditionType
-func (s *status) setStatus(condition configv1.ClusterStatusConditionType, message string) {
+func (s *status) setStatus(condition configv1.ClusterStatusConditionType, message string) error {
 	if s.coAPINotPresent {
-		return
+		return nil
 	}
-	s.ensureClusterOperator()
-	s.setStatusCondition(condition, message)
-	s.setOperandVersion()
-	s.updateStatus()
+	err := s.ensureClusterOperator()
+	if err != nil {
+		return err
+	}
+	previousStatus := s.clusterOperator.Status.DeepCopy()
+	updatedCondition := s.setStatusCondition(condition, message)
+	err = s.updateStatus(previousStatus, updatedCondition, message)
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // setOperandVersion sets the operator version in the ClusterOperator Status
+// Per instructions from the CVO team, setOperandVersion should only be called
+// when the operator becomes available
 func (s *status) setOperandVersion() {
 	// Report the operator version
 	operatorVersion := configv1.OperandVersion{
@@ -145,8 +227,8 @@ func (s *status) setOperandVersion() {
 }
 
 // setStatusCondition sets the operator StatusCondition in the ClusterOperator Status
-func (s *status) setStatusCondition(condition configv1.ClusterStatusConditionType, message string) {
-	log.Infof("Setting ClusterOperator condition: %s message: %s", condition, message)
+func (s *status) setStatusCondition(condition configv1.ClusterStatusConditionType, message string) string {
+	updatedCondition := string(condition)
 
 	availableStatus := configv1.ConditionFalse
 	failingStatus := configv1.ConditionFalse
@@ -159,6 +241,8 @@ func (s *status) setStatusCondition(condition configv1.ClusterStatusConditionTyp
 	case configv1.OperatorAvailable:
 		availableStatus = configv1.ConditionTrue
 		availableMessage = message
+		// Only update the version when the operator becomes available
+		s.setOperandVersion()
 
 	case configv1.OperatorFailing:
 		failingStatus = configv1.ConditionTrue
@@ -191,12 +275,100 @@ func (s *status) setStatusCondition(condition configv1.ClusterStatusConditionTyp
 		Message:            failingMessage,
 		LastTransitionTime: time,
 	})
+	return updatedCondition
 }
 
-// updateStatus makes the API call to update the ClusterOperator
-func (s *status) updateStatus() {
-	_, err := s.configClient.ClusterOperators().UpdateStatus(s.clusterOperator)
-	if err != nil {
-		log.Fatalf("Error %v updating ClusterOperator", err)
+// updateStatus makes the API call to update the ClusterOperator if the status has changed.
+func (s *status) updateStatus(previousStatus *configv1.ClusterOperatorStatus, updatedCondition string, message string) error {
+	var err error
+	if compareClusterOperatorStatusConditionArrays(previousStatus.Conditions, s.clusterOperator.Status.Conditions) {
+		log.Debugf("[status] Previous and current ClusterOperator Status are the same, the ClusterOperator Status will not be updated.")
+	} else {
+		log.Debugf("[status] Previous and current ClusterOperator Status are different, attempting to update the ClusterOperator Status.")
+
+		// Check if the ClusterOperator version has changed and log the attempt to upgrade if it has
+		previousVersion := operatorhelpers.FindOperandVersion(previousStatus.Versions, "operator")
+		currentVersion := operatorhelpers.FindOperandVersion(s.clusterOperator.Status.Versions, "operator")
+		if currentVersion != nil {
+			if previousVersion == nil {
+				log.Infof("[status] Attempting to set ClusterOperator to version %s", currentVersion.Version)
+			} else if previousVersion.Version != currentVersion.Version {
+				log.Infof("[status] Attempting to upgrade ClusterOperator version from %s to %s", previousVersion.Version, currentVersion.Version)
+			}
+		}
+
+		_, err := s.configClient.ClusterOperators().UpdateStatus(s.clusterOperator)
+		if err != nil {
+			return fmt.Errorf("Error %v updating ClusterOperator", err)
+		}
+		// Log status change
+		log.Infof(fmt.Sprintf("[status] Set ClusterOperator condition: %s message: %s", updatedCondition, message))
+	}
+	return err
+}
+
+// syncChannelReceiver will listen on the sync channel and update the status
+// syncsRatio filed until the stopCh is closed.
+func (s *status) syncChannelReceiver() {
+	log.Info("[status] Starting sync consumer")
+	for {
+		select {
+		case <-s.stopCh:
+			return
+		case err := <-s.syncCh:
+			if err == nil {
+				s.syncRatio.ReportSyncEvent()
+			} else {
+				s.syncRatio.ReportFailedSync()
+			}
+			failedSyncs, syncs := s.syncRatio.GetSyncs()
+			log.Debugf("[status] Faild Syncs / Total Syncs : %d/%d", failedSyncs, syncs)
+		}
+	}
+}
+
+// monitorClusterStatus updates the cluster operator's status based on
+// the number of successful syncs / total syncs
+func (s *status) monitorClusterStatus() {
+	// Signal to the main channel that we have stopped reporting status.
+	defer func() {
+		close(s.monitorDoneCh)
+	}()
+	for {
+		select {
+		case <-s.stopCh:
+			// If the stopCh is closed, the operator will exit and CO should
+			// be set to failing.
+			s.setFailing("Operator exited")
+			return
+		// Attempt to update the cluster operator status whenever the seconds
+		// number of seconds defined by coStatusReportInterval passes
+		case <-time.After(coStatusReportInterval):
+			var statusErr error
+			// create the cluster operator in the porgressing state if it does not exist
+			// or if it is the first report
+			if s.clusterOperator == nil {
+				statusErr = s.setProgressing(fmt.Sprintf("Progressing towards %s", s.version))
+			} else {
+				// wait until the operator has reconciled at least one sync
+				_, syncEvents := s.syncRatio.GetSyncs()
+				if syncEvents >= minSyncsBeforeReporting {
+					// update the status with the appropriate state
+					isSucceeding, ratio := s.syncRatio.IsSucceeding()
+					if ratio != nil {
+						if isSucceeding {
+							statusErr = s.setAvailable(fmt.Sprintf("%s is available", s.version))
+						} else {
+							statusErr = s.setFailing(fmt.Sprintf("Current sync ratio (%g) does not meet the expected success ratio (%g)", *ratio, successRatio))
+						}
+					}
+				} else {
+					log.Debugf("[status] Waiting to observe %d additional sync(s)", minSyncsBeforeReporting-syncEvents)
+				}
+			}
+			if statusErr != nil {
+				log.Error("[status] " + statusErr.Error())
+			}
+		}
 	}
 }

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -21,7 +21,7 @@ import (
 
 const (
 	// clusterOperatorName is the name of the cluster operator
-	clusterOperatorName = "marketplace-operator"
+	clusterOperatorName = "marketplace"
 
 	// minSyncsBeforeReporting is the minimum number of syncs we wish to see
 	// before reporting that the operator is available

--- a/pkg/status/syncratio.go
+++ b/pkg/status/syncratio.go
@@ -1,0 +1,120 @@
+package status
+
+import (
+	"errors"
+	"sync"
+
+	log "github.com/sirupsen/logrus"
+)
+
+// SyncRatio provides an interface for managing syncs which are used to report
+// operator status to CVO.
+type SyncRatio interface {
+	GetSyncs() (failedSyncs int, syncEvents int)
+	ReportFailedSync()
+	ReportSyncEvent()
+	IsSucceeding() (bool, *float32)
+}
+
+// NewSyncRatio returns a syncRatio object or an error if invalid parameters
+// are provided.
+func NewSyncRatio(successRatio float32, syncsBeforeTruncate int, syncTruncateValue int) (SyncRatio, error) {
+	errMsg := ""
+	if successRatio < 0 || successRatio > 1 {
+		errMsg += "successRatio must be greater than or equal to 0 and less than or equal to 1. "
+	}
+	if syncsBeforeTruncate <= 0 {
+		errMsg += "syncsBeforeTruncate must be greater than 0. "
+	}
+	if syncTruncateValue <= 0 {
+		errMsg += "syncTruncateValue must be greater than 0."
+	}
+	if errMsg != "" {
+		return nil, errors.New(errMsg)
+	}
+
+	return &syncRatio{
+		successRatio:        successRatio,
+		syncsBeforeTruncate: syncsBeforeTruncate,
+		syncTruncateValue:   syncTruncateValue,
+	}, nil
+}
+
+type syncRatio struct {
+	// successRatio is the ratio of successfulSyncs to syncEvents
+	successRatio float32
+
+	// syncsBeforeTruncate the number of syncEvents before failedSyncs and
+	// syncEvents are truncated.
+	syncsBeforeTruncate int
+
+	// The value that failedSyncs and syncEvents will be truncated by.
+	syncTruncateValue int
+
+	// failedSyncs represents the number of failed syncs.
+	failedSyncs int
+	// syncEvents represents the sum of syncs events.
+	syncEvents int
+
+	// lock is used to prevent race condition on syncEvents and failedSyncs fields.
+	lock sync.Mutex
+}
+
+// GetSyncs returns the number of failedSyncs and the number of syncEvents
+func (s *syncRatio) GetSyncs() (failedSyncs int, syncEvents int) {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	return s.failedSyncs, s.syncEvents
+}
+
+// ReportFailedSync increments the number of syncEvents by one
+func (s *syncRatio) ReportFailedSync() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.failedSyncs++
+}
+
+// ReportSyncEvent increments the number of syncEvents
+func (s *syncRatio) ReportSyncEvent() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.syncEvents++
+}
+
+// truncateSyncs is used to prevent failedSyncs and syncEvents from overflowing.
+func (s *syncRatio) truncateSyncs() {
+	s.lock.Lock()
+	defer s.lock.Unlock()
+	s.syncEvents = s.syncEvents % s.syncEvents
+	s.failedSyncs = s.failedSyncs % s.syncTruncateValue
+}
+
+// isSucceeding returns whether or not the cluster operator should report a successful state.
+// If syncEvents is less than or equal to 0 an error is returned and syncr.
+func (s *syncRatio) IsSucceeding() (bool, *float32) {
+	ratio := s.getRatio()
+	// return error if s.syncs <= 0
+	if ratio == nil {
+		return false, ratio
+	}
+
+	if *ratio >= s.successRatio {
+		return true, ratio
+	}
+	return false, ratio
+}
+
+// getRatio returns the ratio of successfulSyncs to syncEvents
+// If s.syncs is equal to 0 then nil is returned
+func (s *syncRatio) getRatio() *float32 {
+	// Prevent number of syncs from growing indefinitely
+	if s.syncEvents > s.syncsBeforeTruncate {
+		s.truncateSyncs()
+	}
+	if s.syncEvents <= 0 {
+		return nil
+	}
+	ratio := float32(s.syncEvents-s.failedSyncs) / float32(s.syncEvents)
+	log.Debugf("[status] Successful syncs to total syncs ratio: %v", ratio)
+	return &ratio
+}

--- a/pkg/status/syncutils.go
+++ b/pkg/status/syncutils.go
@@ -1,0 +1,39 @@
+package status
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	cohelpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
+)
+
+// compareArrayClusterOperatorStatusConditions takes two arrays of
+// ClusterOperatorStatusCondition and returns true if the contents
+// match.
+func compareClusterOperatorStatusConditionArrays(a []configv1.ClusterOperatorStatusCondition, b []configv1.ClusterOperatorStatusCondition) bool {
+	if len(a) != len(b) {
+		return false
+	}
+
+	for _, aCondition := range a {
+		bCondition := cohelpers.FindStatusCondition(b, aCondition.Type)
+		if bCondition == nil {
+			return false
+		}
+		isEqual := false
+		if compareClusterOperatorStatusConditions(aCondition, *bCondition) {
+			isEqual = true
+		}
+		if !isEqual {
+			return false
+		}
+	}
+	return true
+}
+
+// compareClusterOperatorStatusConditions takes two ClusterOperatorStatusCondition
+// and returns true if the Name, Type, and Message match.
+func compareClusterOperatorStatusConditions(a configv1.ClusterOperatorStatusCondition, b configv1.ClusterOperatorStatusCondition) bool {
+	if a.Type == b.Type && a.Status == b.Status && a.Message == b.Message {
+		return true
+	}
+	return false
+}


### PR DESCRIPTION
Cluster operators are expected to report the version of the payload
they are included in once they are "deployed", and also to keep the
cluster operator object created. With this update the marketplace
operator will keep CO up to date, report the payload version once it
hits available, and use the count of successful syncs as a
probalistic measurement of "available".

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1686121