### PR TITLE
Bug 1688703: Properly handle delete failures

### DIFF
--- a/pkg/catalogsourceconfig/handler.go
+++ b/pkg/catalogsourceconfig/handler.go
@@ -54,6 +54,11 @@ func (h *catalogsourceconfighandler) Handle(ctx context.Context, in *v1alpha1.Ca
 	}
 
 	out, status, err := reconciler.Reconcile(ctx, in)
+	if out == nil {
+		// If the reconciler didn't return an object, that means it must have been deleted.
+		// In that case, we should just return without attempting to modify it.
+		return err
+	}
 
 	// If reconciliation threw an error, we can't quit just yet. We need to
 	// figure out whether the CatalogSourceConfig object needs to be updated.

--- a/pkg/operatorsource/handler.go
+++ b/pkg/operatorsource/handler.go
@@ -86,6 +86,12 @@ func (h *operatorsourcehandler) Handle(ctx context.Context, in *v1alpha1.Operato
 	}
 
 	out, status, err = phaseReconciler.Reconcile(ctx, in)
+	if out == nil {
+		// If the reconciler didn't return an object, that means it must have been deleted.
+		// In that case, we should just return without attempting to modify it.
+		return err
+	}
+
 	return h.transition(ctx, logger, out, status, err)
 }
 


### PR DESCRIPTION
Problem:
This recent change
(https://github.com/operator-framework/operator-marketplace/pull/127)
introduced a reduced scope to our cluster role. However, when deleting
`CatalogSourceConfigs` the current implementation of the delete
reconciler still required the cluster roles that were removed.
Because of this, the reconciler was producing an error and prevented the
`csc` from being deleted. Additionally, the operator was panicking
because the transitioner logic expected an object to return in that case

Solution:
Update the `deleteCreatedResources` method in the `deletedReconciler` to
use a namespace option when getting the lists of services, deployments,
rolebindings, roles and service accounts.

Update the`Reconcile` method in both the csc's and the opsrc's
`deletedReconciler` to always return the `out` object in the case of
error, as well as return the current phase to force a retry in the case
of failure.

Update both handlers to check that the `out` object is set before
attempting to transition. If it is not set, just return.

This fixes bug https://bugzilla.redhat.com/show_bug.cgi?id=1688703