### PR TITLE
Bug 1686121: Update Marketplace management of clusterOperator conditions

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -101,7 +101,7 @@ func main() {
 	operatorStatus.SetAvailable(fmt.Sprintf("Version %s of the operator is available", operatorStatus.GetVersion()))
 
 	// Start the Cmd
-	log.Fatal(mgr.Start(stopCh))
+	fatal(mgr.Start(stopCh), operatorStatus)
 }
 
 func fatal(err error, operatorStatus status.Status) {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -130,7 +130,6 @@ func (s *status) setStatus(condition configv1.ClusterStatusConditionType, messag
 	}
 	s.ensureClusterOperator()
 	s.setStatusCondition(condition, message)
-	s.setOperandVersion()
 	s.updateStatus()
 }
 
@@ -159,6 +158,8 @@ func (s *status) setStatusCondition(condition configv1.ClusterStatusConditionTyp
 	case configv1.OperatorAvailable:
 		availableStatus = configv1.ConditionTrue
 		availableMessage = message
+		// The operator version should only be set when the operator becomes available
+		s.setOperandVersion()
 
 	case configv1.OperatorFailing:
 		failingStatus = configv1.ConditionTrue


### PR DESCRIPTION
* Report version only after operator becomes available.

This fixes https://bugzilla.redhat.com/show_bug.cgi?id=1686121