### PR TITLE
Bug 1686668: [csc] Ignore invalid values when reading `csc.Spec.Packages`

### DIFF
--- a/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
+++ b/pkg/apis/marketplace/v1alpha1/catalogsourceconfig_types.go
@@ -100,9 +100,14 @@ func (csc *CatalogSourceConfig) EnsurePublisher() {
 	}
 }
 
+func (csc *CatalogSourceConfig) GetPackages() string {
+	pkgs := getValidPackageSliceFromString(csc.Spec.Packages)
+	return strings.Join(pkgs, ",")
+}
+
 // GetPackageIDs returns the list of package(s) specified.
 func (csc *CatalogSourceConfig) GetPackageIDs() []string {
-	return strings.Split(strings.Replace(csc.Spec.Packages, " ", "", -1), ",")
+	return getValidPackageSliceFromString(csc.Spec.Packages)
 }
 
 // GetTargetNamespace returns the TargetNamespace where the OLM resources will
@@ -129,5 +134,19 @@ func (csc *CatalogSourceConfig) RemoveOwner(ownerUID types.UID) {
 
 // GetPackageIDs returns the list of package(s) specified.
 func (spec *CatalogSourceConfigSpec) GetPackageIDs() []string {
-	return strings.Split(strings.Replace(spec.Packages, " ", "", -1), ",")
+	return getValidPackageSliceFromString(spec.Packages)
+}
+
+func getValidPackageSliceFromString(pkgs string) []string {
+	pkgIds := make([]string, 0)
+
+	pkgSlice := strings.Split(strings.Replace(pkgs, " ", "", -1), ",")
+
+	for _, pkg := range pkgSlice {
+		if pkg != "" {
+			pkgIds = append(pkgIds, pkg)
+		}
+	}
+
+	return pkgIds
 }

--- a/pkg/catalogsourceconfig/cache.go
+++ b/pkg/catalogsourceconfig/cache.go
@@ -89,7 +89,7 @@ func (c *cache) Evict(csc *v1alpha1.CatalogSourceConfig) {
 
 func (c *cache) Set(csc *v1alpha1.CatalogSourceConfig) {
 	c.entries[csc.ObjectMeta.UID] = &v1alpha1.CatalogSourceConfigSpec{
-		Packages:        csc.Spec.Packages,
+		Packages:        csc.GetPackages(),
 		TargetNamespace: csc.Spec.TargetNamespace,
 	}
 }

--- a/pkg/catalogsourceconfig/registry.go
+++ b/pkg/catalogsourceconfig/registry.go
@@ -96,7 +96,7 @@ func (r *registry) GetAddress() string {
 // ensureDeployment ensures that registry Deployment is present for serving
 // the the grpc interface for the packages from the given operatorSources
 func (r *registry) ensureDeployment(operatorSources string) error {
-	registryCommand := getCommand(r.csc.Spec.Packages, operatorSources)
+	registryCommand := getCommand(r.csc.GetPackages(), operatorSources)
 	deployment := new(DeploymentBuilder).WithTypeMeta().Deployment()
 	if err := r.client.Get(context.TODO(), r.csc.key(), deployment); err != nil {
 		deployment = r.newDeployment(registryCommand)
@@ -402,7 +402,7 @@ func (r *registry) waitForDeploymentScaleDown(retryInterval, timeout time.Durati
 
 // getCommand returns the command used to launch the registry server
 func getCommand(packages string, sources string) []string {
-	return []string{"appregistry-server", "-s", sources, "-o", strings.Replace(packages, " ", "", -1)}
+	return []string{"appregistry-server", "-s", sources, "-o", packages}
 }
 
 // getRules returns the PolicyRule needed to access the given operatorSources and secrets


### PR DESCRIPTION
Problem:
In some cases, when the Openshift UI updates the package list of a csc
after removing a subscription, the update does not properly format the
package list. For example:

`packages: ',strimzi-kafka-operator-test'`

In this example, the package list accidentally includes a leading comma.

Right now, the marketplace doesn't handle poorly formatted package
lists in the csc spec. In general, if a user accidentally leaves a comma
behind the operator should ignore it and proceed as normal with the
list of valid packages.

Solution:
Any time the operator reads the package list, that read happens
from a public method that formats the package list and excludes invalid
packages (specifically empty string).
Added a private method `getValidPackageSliceFromString()` that takes a
package string and removes invalid elements from it.
Updated the two `GetPackages()` methods on the csc and spec types to
call this method before returning.
Added a new method on the csc type called `GetPackages()` that uses the
validation logic to reconstruct the `Spec.Packages` string.
Updated every case where we were referencing the `Spec.Packages` field
directly and replaced it with one of these methods.