### PR TITLE
Bug 1691241: [csc] Don't ignore cache on restart

### DIFF
--- a/pkg/catalogsourceconfig/cache.go
+++ b/pkg/catalogsourceconfig/cache.go
@@ -53,8 +53,9 @@ func (c *cache) Get(csc *v1alpha1.CatalogSourceConfig) (*v1alpha1.CatalogSourceC
 
 func (c *cache) IsEntryStale(csc *v1alpha1.CatalogSourceConfig) (bool, bool) {
 	spec, found := c.Get(csc)
+	// Found is false if the CSC wasn't found in the cache. So it must be stale.
 	if !found {
-		return false, false
+		return true, true
 	}
 
 	if spec.TargetNamespace != csc.Spec.TargetNamespace {


### PR DESCRIPTION
Problem:
Rebuilding the `CatalogSourceConfig` state relies on the cache
implementation. Currently, if the spec is updated on a csc it will
not automatically attempt to reconcile that change. Instead, the phase
factory checks if the spec has been updated from the previous update.
To accomplish this, it checks an in-memory cache that compares the
cached spec to the current spec. This is troublesome in the case where
the `marketplace` restarts, because the in memory cache is lost. This
bug is caused when an existing `catalogsourceconfig` gets an update:
the cache is empty for that `csc` but we do not return stale.

Resolution:
Update the `IsEntryStale` method on the `csc` cache. In all cases, if
the `csc` is not found in the cache we should return stale.
Also update `GetPhaseReconciler` to only check the cache is stale when
the phase is not set to `Initial` or `Configuring`, since we are already
in the process of reconciling and updating the cache in that case. This
also prevents infinite loops of constantly going to `Update`.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1691241