### PR TITLE
Migrate to fake client for OperatorSource unit tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -34,10 +34,11 @@ generate-mocks:
 	@echo making sure directory for mocks exists
 	mkdir -p $(MOCKS_DIR)
 
+	# $(mockgen) -destination=<Path/file where the mock is generated> -package=<The package that the generated mock files will belong to> -mock_names=<Original Interface name>=<Name of Generated mocked Interface> <Go package path of the original interface> <comma seperated list of the interface you want to mock>
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_datastore.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=Reader=DatastoreReader,Writer=DatastoreWriter $(PKG)/datastore Reader,Writer
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_phase_reconciler.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=Reconciler=PhaseReconciler $(PKG)/operatorsource Reconciler
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_phase_tansitioner.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=Transitioner=PhaseTransitioner $(PKG)/phase Transitioner
-	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_kubeclient.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=Client=KubeClient $(CONTROLLER_RUNTIME_PKG)/client Client
+	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_client.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=Client=Client $(PKG)/client Client
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_phase_reconciler_strategy.go -package=$(OPERATORSOURCE_MOCK_PKG) $(PKG)/operatorsource PhaseReconcilerFactory
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_appregistry.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=ClientFactory=AppRegistryClientFactory,Client=AppRegistryClient $(PKG)/appregistry ClientFactory,Client
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_syncer.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=PackageRefreshNotificationSender=SyncerPackageRefreshNotificationSender $(PKG)/operatorsource PackageRefreshNotificationSender

--- a/pkg/client/client.go
+++ b/pkg/client/client.go
@@ -1,0 +1,49 @@
+package client
+
+import (
+	"context"
+
+	"k8s.io/apimachinery/pkg/runtime"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// ObjectKey identifies a Kubernetes Object.
+type ObjectKey = types.NamespacedName
+
+// Client is a wrapper around the raw kube client provided
+// by operator-sdk. Using the wrapper facilitates mocking of client
+// interactions with the cluster, while using fakeclient during unit testing.
+type Client interface {
+	Create(ctx context.Context, obj runtime.Object) error
+	Get(ctx context.Context, key ObjectKey, objExisting runtime.Object) error
+	Update(ctx context.Context, obj runtime.Object) error
+}
+
+// kubeClient is an implementation of the Client interface
+type kubeClient struct {
+	client client.Client
+}
+
+// NewClient returns a kubeClient that can perform
+// create, get and update operations on a runtime object
+func NewClient(client client.Client) Client {
+	return &kubeClient{
+		client: client,
+	}
+}
+
+// Create creates a new runtime object in the cluster
+func (h *kubeClient) Create(ctx context.Context, obj runtime.Object) error {
+	return h.client.Create(ctx, obj)
+}
+
+// Get gets an existing runtime object from the cluster
+func (h *kubeClient) Get(ctx context.Context, key ObjectKey, objExisting runtime.Object) error {
+	return h.client.Get(ctx, key, objExisting)
+}
+
+// Update updates an existing runtime object in the cluster
+func (h *kubeClient) Update(ctx context.Context, obj runtime.Object) error {
+	return h.client.Update(ctx, obj)
+}

--- a/pkg/operatorsource/configuring.go
+++ b/pkg/operatorsource/configuring.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	marketplace "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	interface_client "github.com/operator-framework/operator-marketplace/pkg/client"
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
 	log "github.com/sirupsen/logrus"
@@ -15,6 +16,16 @@ import (
 // NewConfiguringReconciler returns a Reconciler that reconciles
 // an OperatorSource object in "Configuring" phase.
 func NewConfiguringReconciler(logger *log.Entry, datastore datastore.Writer, client client.Client) Reconciler {
+	return NewReconcilerWithInterfaceClient(logger, datastore, interface_client.NewClient(client))
+}
+
+// NewReconcilerWithInterfaceClient returns a configuring Reconciler
+// that reconciles an OperatorSource object in "Configuring" phase.
+// It uses the Client interface which is a wrapper to the raw client
+// provided by the operator-sdk, instead of the raw client itself.
+// Using this interface facilitates mocking of kube client interaction
+// with the cluster, while using fakeclient during unit testing.
+func NewReconcilerWithInterfaceClient(logger *log.Entry, datastore datastore.Writer, client interface_client.Client) Reconciler {
 	return &configuringReconciler{
 		logger:    logger,
 		datastore: datastore,
@@ -28,7 +39,7 @@ func NewConfiguringReconciler(logger *log.Entry, datastore datastore.Writer, cli
 type configuringReconciler struct {
 	logger    *log.Entry
 	datastore datastore.Writer
-	client    client.Client
+	client    interface_client.Client
 	builder   *CatalogSourceConfigBuilder
 }
 

--- a/pkg/operatorsource/downloading_test.go
+++ b/pkg/operatorsource/downloading_test.go
@@ -29,10 +29,10 @@ func TestReconcile_ScheduledForDownload_Success(t *testing.T) {
 
 	writer := mocks.NewDatastoreWriter(controller)
 	factory := mocks.NewAppRegistryClientFactory(controller)
-	kubeclient := mocks.NewKubeClient(controller)
+	fakeclient := NewFakeClient()
 	refresher := mocks.NewSyncerPackageRefreshNotificationSender(controller)
 
-	reconciler := operatorsource.NewDownloadingReconciler(helperGetContextLogger(), factory, writer, kubeclient, refresher)
+	reconciler := operatorsource.NewDownloadingReconciler(helperGetContextLogger(), factory, writer, fakeclient, refresher)
 
 	ctx := context.TODO()
 	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.OperatorSourceDownloading)
@@ -83,10 +83,10 @@ func TestReconcile_OperatorSourceReturnsEmptyManifestList_ErrorExpected(t *testi
 
 	writer := mocks.NewDatastoreWriter(controller)
 	factory := mocks.NewAppRegistryClientFactory(controller)
-	kubeclient := mocks.NewKubeClient(controller)
+	fakeclient := NewFakeClient()
 	refresher := mocks.NewSyncerPackageRefreshNotificationSender(controller)
 
-	reconciler := operatorsource.NewDownloadingReconciler(helperGetContextLogger(), factory, writer, kubeclient, refresher)
+	reconciler := operatorsource.NewDownloadingReconciler(helperGetContextLogger(), factory, writer, fakeclient, refresher)
 
 	ctx := context.TODO()
 	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.OperatorSourceDownloading)

--- a/pkg/operatorsource/helper_test.go
+++ b/pkg/operatorsource/helper_test.go
@@ -3,9 +3,13 @@ package operatorsource_test
 import (
 	"fmt"
 
+	"github.com/operator-framework/operator-marketplace/pkg/apis"
 	marketplace "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	log "github.com/sirupsen/logrus"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/runtime"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/client/fake"
 )
 
 func helperGetContextLogger() *log.Entry {
@@ -87,4 +91,32 @@ func helperNewCatalogSourceConfigWithLabels(namespace, name string, opsrcLabels 
 	csc.SetLabels(labels)
 
 	return csc
+}
+
+func NewFakeClient() client.Client {
+	scheme := runtime.NewScheme()
+	apis.AddToScheme(scheme)
+	return fake.NewFakeClientWithScheme(scheme)
+}
+
+func NewFakeClientWithCSC(csc *marketplace.CatalogSourceConfig) client.Client {
+	objs := []runtime.Object{
+		csc,
+	}
+
+	scheme := runtime.NewScheme()
+	apis.AddToScheme(scheme)
+
+	return fake.NewFakeClientWithScheme(scheme, objs...)
+}
+
+func NewFakeClientWithOpsrc(opsrc *marketplace.OperatorSource) client.Client {
+	scheme := runtime.NewScheme()
+	apis.AddToScheme(scheme)
+
+	objs := []runtime.Object{
+		opsrc,
+	}
+
+	return fake.NewFakeClientWithScheme(scheme, objs...)
 }

--- a/pkg/operatorsource/purging_test.go
+++ b/pkg/operatorsource/purging_test.go
@@ -31,8 +31,8 @@ func TestReconcileWithPurging(t *testing.T) {
 	}
 
 	datastore := mocks.NewDatastoreWriter(controller)
-	client := mocks.NewKubeClient(controller)
-	reconciler := operatorsource.NewPurgingReconciler(helperGetContextLogger(), datastore, client)
+	fakeclient := NewFakeClient()
+	reconciler := operatorsource.NewPurgingReconciler(helperGetContextLogger(), datastore, fakeclient)
 
 	// We expect the operator source to be removed from the datastore.
 	datastore.EXPECT().RemoveOperatorSource(opsrcIn.GetUID()).Times(1)


### PR DESCRIPTION
- Refractor OperatorSource configuring reconciler
- Introduce CatalogSourceConfigCrud for OperatorSource configuring reconciler
- Include tests for CatalogSourceConfigCrud
- Update OperatorSource tests with fake client
- Remove kubeclient mocks from generate-mocks target in Makefile