### PR TITLE
[e2e] csc with non-existent package

### DIFF
--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -175,20 +175,12 @@ func CreateOperatorSourceDefinition(namespace string) *marketplace.OperatorSourc
 		},
 	}
 }
-
-// CheckCatalogSourceConfigAndChildResourcesCreated checks that a CatalogSourceConfig
-// and it's child resources were deployed.
-func CheckCatalogSourceConfigAndChildResourcesCreated(client test.FrameworkClient, cscName string, namespace string, targetNamespace string) error {
-	// Check that the CatalogSourceConfig was created.
-	resultCatalogSourceConfig := &marketplace.CatalogSourceConfig{}
-	err := WaitForResult(client, resultCatalogSourceConfig, namespace, cscName)
-	if err != nil {
-		return err
-	}
-
+// CheckCscChildResourcesCreated checks that a CatalogSourceConfig's
+// child resources were deployed.
+func CheckCscChildResourcesCreated(client test.FrameworkClient, cscName string, namespace string, targetNamespace string) error {
 	// Check that the CatalogSource was created.
 	resultCatalogSource := &olm.CatalogSource{}
-	err = WaitForResult(client, resultCatalogSource, targetNamespace, cscName)
+	err := WaitForResult(client, resultCatalogSource, targetNamespace, cscName)
 	if err != nil {
 		return err
 	}
@@ -215,19 +207,12 @@ func CheckCatalogSourceConfigAndChildResourcesCreated(client test.FrameworkClien
 	return nil
 }
 
-// CheckCatalogSourceConfigAndChildResourcesDeleted checks that a CatalogSourceConfig
-// and it's child resources were deleted.
-func CheckCatalogSourceConfigAndChildResourcesDeleted(client test.FrameworkClient, cscName string, namespace string, targetNamespace string) error {
-	// Check that the CatalogSourceConfig was deleted.
-	resultCatalogSourceConfig := &marketplace.CatalogSourceConfig{}
-	err := WaitForNotFound(client, resultCatalogSourceConfig, namespace, cscName)
-	if err != nil {
-		return err
-	}
-
+// CheckCscChildResourcesDeleted checks that a CatalogSourceConfig's
+// child resources were deleted.
+func CheckCscChildResourcesDeleted(client test.FrameworkClient, cscName string, namespace string, targetNamespace string) error {
 	// Check that the CatalogSource was deleted.
 	resultCatalogSource := &olm.CatalogSource{}
-	err = WaitForNotFound(client, resultCatalogSource, targetNamespace, cscName)
+	err := WaitForNotFound(client, resultCatalogSource, targetNamespace, cscName)
 	if err != nil {
 		return err
 	}
@@ -245,5 +230,43 @@ func CheckCatalogSourceConfigAndChildResourcesDeleted(client test.FrameworkClien
 	if err != nil {
 		return err
 	}
+	return nil
+}
+
+// CheckCscSuccessfulCreation checks that a CatalogSourceConfig
+// and it's child resources were deployed.
+func CheckCscSuccessfulCreation(client test.FrameworkClient, cscName string, namespace string, targetNamespace string) error {
+	// Check that the CatalogSourceConfig was created.
+	resultCatalogSourceConfig := &marketplace.CatalogSourceConfig{}
+	err := WaitForResult(client, resultCatalogSourceConfig, namespace, cscName)
+	if err != nil {
+		return err
+	}
+
+	// Check that all child resources were created.
+	err = CheckCscChildResourcesCreated(client, cscName, namespace, targetNamespace)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// CheckCscSuccessfulDeletion checks that a CatalogSourceConfig
+// and it's child resources were deleted.
+func CheckCscSuccessfulDeletion(client test.FrameworkClient, cscName string, namespace string, targetNamespace string) error {
+	// Check that the CatalogSourceConfig was deleted.
+	resultCatalogSourceConfig := &marketplace.CatalogSourceConfig{}
+	err := WaitForNotFound(client, resultCatalogSourceConfig, namespace, cscName)
+	if err != nil {
+		return err
+	}
+
+	// Check that all child resources were deleted.
+	err = CheckCscChildResourcesDeleted(client, cscName, namespace, targetNamespace)
+	if err != nil {
+		return err
+	}
+
 	return nil
 }

--- a/test/testgroups/operatorsourcetests.go
+++ b/test/testgroups/operatorsourcetests.go
@@ -29,4 +29,5 @@ func OperatorSourceTestGroup(t *testing.T) {
 	// Run the test suites.
 	t.Run("opsrc-creation-test-suite", testsuites.OpSrcCreation)
 	t.Run("csc-target-namespace-test-suite", testsuites.CscTargetNamespace)
+	t.Run("csc-packages-test-suite", testsuites.TestCscWithNonExistingPackage)
 }

--- a/test/testsuites/const.go
+++ b/test/testsuites/const.go
@@ -8,4 +8,7 @@ const (
 
 	// targetNamespace is the targetNamespace value of the CatalogSourceConfig used in this test suite.
 	targetNamespace string = "target-namespace"
+
+	// nonExistingPackageName is the non-existing package
+	nonExistingPackageName string = "non-existing-package"
 )

--- a/test/testsuites/const.go
+++ b/test/testsuites/const.go
@@ -1,0 +1,11 @@
+package testsuites
+
+const (
+	// CSC constants
+
+	// cscName is the name of the CatalogSourceConfig used in this test suite.
+	cscName string = "test-operators-csc"
+
+	// targetNamespace is the targetNamespace value of the CatalogSourceConfig used in this test suite.
+	targetNamespace string = "target-namespace"
+)

--- a/test/testsuites/cscpackagetests.go
+++ b/test/testsuites/cscpackagetests.go
@@ -1,0 +1,84 @@
+package testsuites
+
+import (
+	"fmt"
+	"testing"
+
+	operator "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	"github.com/operator-framework/operator-marketplace/test/helpers"
+	"github.com/operator-framework/operator-sdk/pkg/test"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// TestCscWithNonExistingPackage tests that a csc with a non-existing package
+// is handled correctly by the marketplace operator and its child resources are not
+// created.
+func TestCscWithNonExistingPackage(t *testing.T) {
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	// Get global framework variables.
+	client := test.Global.Client
+
+	// Get test namespace
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatalf("Could not get namespace: %v", err)
+	}
+
+	// Create a new catalogsourceconfig with a non-existing Package
+	nonExistingPackageCSC := &operator.CatalogSourceConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind: operator.CatalogSourceConfigKind,
+		}, ObjectMeta: metav1.ObjectMeta{
+			Name:      cscName,
+			Namespace: namespace,
+		},
+		Spec: operator.CatalogSourceConfigSpec{
+			TargetNamespace: namespace,
+			Packages:        nonExistingPackageName,
+		}}
+
+	err = helpers.CreateRuntimeObject(client, ctx, nonExistingPackageCSC)
+	if err != nil {
+		t.Fatalf("Unable to create test CatalogSourceConfig: %v", err)
+	}
+
+	// Check status is updated correctly then check child resources are not created
+	t.Run("configuring-state-when-package-name-does-not-exist", configuringStateWhenPackageNameDoesNotExist)
+	t.Run("child-resources-not-created", childResourcesNotCreated)
+}
+
+// configuringStateWhenTargetNamespaceDoesNotExist is a test case that creates a CatalogSourceConfig
+// with a targetNamespace that doesn't exist and ensures that the status is updated to reflect the
+// nonexistent namespace.
+func configuringStateWhenPackageNameDoesNotExist(t *testing.T) {
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	if err != nil {
+		t.Fatalf("Could not get namespace: %v", err)
+	}
+
+	// Check that the catalogsourceconfig with an non-existing package eventually reaches the
+	// configuring phase with the expected message
+	expectedPhase := "Configuring"
+	expectedMessage := fmt.Sprintf("Still resolving package(s) - %v. Please make sure these are valid packages.", nonExistingPackageName)
+	err = helpers.WaitForExpectedPhaseAndMessage(test.Global.Client, cscName, namespace, expectedPhase, expectedMessage)
+	if err != nil {
+		t.Fatalf("CatalogSourceConfig never reached expected phase/message, expected %v/%v", expectedPhase, expectedMessage)
+	}
+}
+
+// childResourcesNotCreated checks that once a CatalogSourceConfig with a wrong package name
+// is created that all expected runtime objects are not created.
+func childResourcesNotCreated(t *testing.T) {
+	// Get test namespace.
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	if err != nil {
+		t.Fatalf("Could not get namespace: %v", err)
+	}
+	// Check that the CatalogSourceConfig's child resources were not created.
+	err = helpers.CheckCscChildResourcesDeleted(test.Global.Client, cscName, namespace, namespace)
+	if err != nil {
+		t.Fatal(err)
+	}
+}

--- a/test/testsuites/csctargetnamespacetests.go
+++ b/test/testsuites/csctargetnamespacetests.go
@@ -11,14 +11,6 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
-const (
-	// cscName is the name of the CatalogSourceConfig used in this test suite.
-	cscName string = "target-namespace-operators"
-
-	// targetNamespace is the targetNamespace value of the CatalogSourceConfig used in this test suite.
-	targetNamespace string = "target-namespace"
-)
-
 // CscTargetNamespace is a test suit that confirms that targetNamespace values are handled appropriately.
 func CscTargetNamespace(t *testing.T) {
 	ctx := test.NewTestCtx(t)

--- a/test/testsuites/csctargetnamespacetests.go
+++ b/test/testsuites/csctargetnamespacetests.go
@@ -115,7 +115,7 @@ func childResourcesCreated(t *testing.T) {
 		t.Fatalf("Could not get namespace: %v", err)
 	}
 	// Check that the CatalogSourceConfig and its child resources were created.
-	err = helpers.CheckCatalogSourceConfigAndChildResourcesCreated(test.Global.Client, cscName, namespace, targetNamespace)
+	err = helpers.CheckCscSuccessfulCreation(test.Global.Client, cscName, namespace, targetNamespace)
 	if err != nil {
 		t.Fatal(err)
 
@@ -132,7 +132,7 @@ func childResourcesDeleted(t *testing.T) {
 	}
 
 	// Check that the CatalogSourceConfig and its child resources were deleted.
-	err = helpers.CheckCatalogSourceConfigAndChildResourcesDeleted(test.Global.Client, cscName, namespace, targetNamespace)
+	err = helpers.CheckCscSuccessfulDeletion(test.Global.Client, cscName, namespace, targetNamespace)
 	if err != nil {
 		t.Fatalf("Could not ensure that CatalogSourceConfig and its child resources were deleted: %v", err)
 	}

--- a/test/testsuites/opsrccreationtests.go
+++ b/test/testsuites/opsrccreationtests.go
@@ -28,7 +28,7 @@ func testOperatorSourceGeneratesExpectedObjects(t *testing.T) {
 	}
 
 	// Check for the CatalogSourceConfig and it's child resources.
-	err = helpers.CheckCatalogSourceConfigAndChildResourcesCreated(test.Global.Client, helpers.TestOperatorSourceName, namespace, namespace)
+	err = helpers.CheckCscSuccessfulCreation(test.Global.Client, helpers.TestOperatorSourceName, namespace, namespace)
 	if err != nil {
 		t.Error(err)
 	}

--- a/test/testsuites/opsrcdeletetests.go
+++ b/test/testsuites/opsrcdeletetests.go
@@ -33,7 +33,7 @@ func testDeleteOpSrc(t *testing.T) {
 	require.NoError(t, err, "Could not create operator source.")
 
 	// Check for the datastore CatalogSourceConfig and its child resources.
-	err = helpers.CheckCatalogSourceConfigAndChildResourcesCreated(test.Global.Client, testOperatorSource.Name, namespace, namespace)
+	err = helpers.CheckCscSuccessfulCreation(test.Global.Client, testOperatorSource.Name, namespace, namespace)
 	require.NoError(t, err, "Could not ensure that CatalogSourceConfig and its child resources were deleted")
 
 	// Now let's delete the OperatorSource
@@ -42,6 +42,6 @@ func testDeleteOpSrc(t *testing.T) {
 
 	// Now let's wait until the OperatorSource is successfully deleted and the
 	// child resources are removed.
-	err = helpers.CheckCatalogSourceConfigAndChildResourcesDeleted(test.Global.Client, testOperatorSource.Name, namespace, targetNamespace)
+	err = helpers.CheckCscSuccessfulDeletion(test.Global.Client, testOperatorSource.Name, namespace, targetNamespace)
 	require.NoError(t, err, "Could not ensure that CatalogSourceConfig and its child resources were deleted.")
 }


### PR DESCRIPTION
Adds e2e test to check that a csc with a non-existent package fails
properly and does not create child resources