### PR TITLE
[e2e] fix wrong csc kind

### DIFF
--- a/test/testsuites/csctargetnamespacetests.go
+++ b/test/testsuites/csctargetnamespacetests.go
@@ -54,7 +54,7 @@ func cscWithNonExistingTargetNamespace(t *testing.T, f *test.Framework, ctx *tes
 	// Create a new CatalogSourceConfig with a non-existing targetNamespace.
 	nonExistingTargetNamespaceCsc := &operator.CatalogSourceConfig{
 		TypeMeta: metav1.TypeMeta{
-			Kind: operator.OperatorSourceKind,
+			Kind: operator.CatalogSourceConfigKind,
 		}, ObjectMeta: metav1.ObjectMeta{
 			Name:      nonExistingTargetNamespaceCscName,
 			Namespace: namespace,


### PR DESCRIPTION
csc kind was set to operatorsource kind in the targetNamespace e2e tests. The kind gets overwritten by the createRuntimeObject function and that's why this error wasn't caught at runtime. This PR fixes the kind to ensure that no runtime error gets produced in the future.