### PR TITLE
[e2e] Add CSC test where namespace != targetNamespace

### DIFF
--- a/test/testgroups/operatorsourcetests.go
+++ b/test/testgroups/operatorsourcetests.go
@@ -20,11 +20,8 @@ func OperatorSourceTestGroup(t *testing.T) {
 		t.Errorf("Could not get namespace: %v", err)
 	}
 
-	// Get global framework variables.
-	f := test.Global
-
 	// Create the OperatorSource.
-	err = helpers.CreateRuntimeObject(f, ctx, helpers.CreateOperatorSourceDefinition(namespace))
+	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateOperatorSourceDefinition(namespace))
 	if err != nil {
 		t.Errorf("Could not create operator source: %v", err)
 	}

--- a/test/testsuites/csctargetnamespacetests.go
+++ b/test/testsuites/csctargetnamespacetests.go
@@ -4,122 +4,101 @@ import (
 	"fmt"
 	"testing"
 
-	operator "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	marketplace "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-marketplace/test/helpers"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	corev1 "k8s.io/api/core/v1"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
-// CscTargetNamespace is a test suit that confirms that the targetNamespace field within
-// a CatalogSourceConfig is handled correctly.
-func CscTargetNamespace(t *testing.T) {
-	t.Run("non-existing-target-namespace", testCscWithNonExistingTargetNamespace)
-}
+const (
+	// cscName is the name of the CatalogSourceConfig used in this test suite.
+	cscName string = "target-namespace-operators"
 
-// testCscWithNonExistingTargetNamespace creates context and calls the
-// cscWithNonExistingTargetNamespace test case.
-func testCscWithNonExistingTargetNamespace(t *testing.T) {
+	// targetNamespace is the targetNamespace value of the CatalogSourceConfig used in this test suite.
+	targetNamespace string = "target-namespace"
+)
+
+// CscTargetNamespace is a test suit that confirms that targetNamespace values are handled appropriately.
+func CscTargetNamespace(t *testing.T) {
 	ctx := test.NewTestCtx(t)
 	defer ctx.Cleanup()
 
 	// Get global framework variables.
-	f := test.Global
+	client := test.Global.Client
+
+	// Get test namespace.
+	namespace, err := ctx.GetNamespace()
+	if err != nil {
+		t.Fatalf("Could not get namespace: %v", err)
+	}
+
+	// Create a new CatalogSourceConfig with a non-existing targetNamespace.
+	nonExistingTargetNamespaceCsc := &marketplace.CatalogSourceConfig{
+		TypeMeta: metav1.TypeMeta{
+			Kind: marketplace.CatalogSourceConfigKind,
+		}, ObjectMeta: metav1.ObjectMeta{
+			Name:      cscName,
+			Namespace: namespace,
+		},
+		Spec: marketplace.CatalogSourceConfigSpec{
+			TargetNamespace: targetNamespace,
+			Packages:        "camel-k-marketplace-e2e-tests",
+		}}
+
+	// Create the CatalogSourceConfig and if an error occurs do not run tests that
+	// rely on the existence of the CatalogSourceConfig.
+	err = helpers.CreateRuntimeObject(client, ctx, nonExistingTargetNamespaceCsc)
+	if err != nil {
+		t.Fatalf("Unable to create test CatalogSourceConfig: %v", err)
+	}
 
 	// Run tests.
-	if err := cscWithNonExistingTargetNamespace(t, f, ctx); err != nil {
-		t.Fatal(err)
+	t.Run("configuring-state-when-target-namespace-dne", configuringStateWhenTargetNamespaceDoesNotExist)
+
+	// Create a namespace based on the targetNamespace string.
+	resultNamespace := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: targetNamespace}}
+	err = helpers.CreateRuntimeObject(client, ctx, resultNamespace)
+	if err != nil {
+		t.Fatalf("Unable to create test namespace: %v", err)
+	}
+
+	t.Run("succeeded-state-after-target-namespace-created", succeededStateAfterTargetNamespaceCreated)
+}
+
+// configuringStateWhenTargetNamespaceDoesNotExist is a test case that creates a CatalogSourceConfig
+// with a targetNamespace that doesn't exist and ensures that the status is updated to reflect the
+// nonexistent namespace.
+func configuringStateWhenTargetNamespaceDoesNotExist(t *testing.T) {
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	if err != nil {
+		t.Fatalf("Could not get namespace: %v", err)
+	}
+
+	// Check that the CatalogSourceConfig with an non-existing targetNamespace eventually reaches the
+	// configuring phase with the expected message.
+	expectedPhase := "Configuring"
+	expectedMessage := fmt.Sprintf("namespaces \"%s\" not found", targetNamespace)
+	err = helpers.WaitForExpectedPhaseAndMessage(test.Global.Client, cscName, namespace, expectedPhase, expectedMessage)
+	if err != nil {
+		t.Fatalf("CatalogSourceConfig never reached expected phase/message, expected %v/%v", expectedPhase, expectedMessage)
 	}
 }
 
-// cscWithNonExistingTargetNamespace is a test case that creates a CatalogSourceConfig
-// with a targetNamespace that doesn't exist and ensures that the status is updated to reflect the
-// nonexistant namespace. The test then creates the targeted namespace and ensures that the
-// CatalogSourceConfig is properly reconciled.
-func cscWithNonExistingTargetNamespace(t *testing.T, f *test.Framework, ctx *test.TestCtx) error {
+// succeededStateAfterTargetNamespaceCreated is a test case that confirms that a csc that had a
+// targetNamespace which did not exist eventually reaches a succeeded state once the targetNamespace is created.
+func succeededStateAfterTargetNamespaceCreated(t *testing.T) {
 	// Get test namespace.
 	namespace, err := test.NewTestCtx(t).GetNamespace()
 	if err != nil {
-		return fmt.Errorf("Could not get namespace: %v", err)
-	}
-
-	// nonExistingTargetNamespaceCscName is the name of the CatalogSourceConfig that points
-	// to a non-existing targetNamespace.
-	nonExistingTargetNamespaceCscName := "non-existing-namespace-operators"
-
-	// targetNamespace is the non-existing target namespace.
-	targetNamespace := "non-existing-namespace"
-
-	// Create a new CatalogSourceConfig with a non-existing targetNamespace.
-	nonExistingTargetNamespaceCsc := &operator.CatalogSourceConfig{
-		TypeMeta: metav1.TypeMeta{
-			Kind: operator.CatalogSourceConfigKind,
-		}, ObjectMeta: metav1.ObjectMeta{
-			Name:      nonExistingTargetNamespaceCscName,
-			Namespace: namespace,
-		},
-		Spec: operator.CatalogSourceConfigSpec{
-			TargetNamespace: targetNamespace,
-			Packages:        "descheduler",
-		}}
-	err = helpers.CreateRuntimeObject(f, ctx, nonExistingTargetNamespaceCsc)
-	if err != nil {
-		return err
-	}
-
-	// Check that we created the CatalogSourceConfig with a non-existing targetNamespace.
-	resultCatalogSourceConfig := &operator.CatalogSourceConfig{}
-	err = helpers.WaitForResult(t, resultCatalogSourceConfig, namespace, nonExistingTargetNamespaceCscName)
-	if err != nil {
-		return err
-	}
-
-	// Check if the CatalogSourceConfig phase and message are the expected values.
-	expectedPhase := "Configuring"
-	expectedMessage := fmt.Sprintf("namespaces \"%s\" not found", targetNamespace)
-	// Check that the CatalogSourceConfig with an non-existing targetNamespace eventually reaches the
-	// configuring phase with the expected message.
-	err = wait.Poll(helpers.RetryInterval, helpers.Timeout, func() (bool, error) {
-		// CatalogSourceConfig should exist so no wait.
-		err = helpers.WaitForResult(t, resultCatalogSourceConfig, namespace, nonExistingTargetNamespaceCscName)
-		if err != nil {
-			return false, err
-		}
-		if resultCatalogSourceConfig.Status.CurrentPhase.Name == expectedPhase &&
-			resultCatalogSourceConfig.Status.CurrentPhase.Message == expectedMessage {
-			return true, nil
-		}
-		return false, nil
-	})
-	if err != nil {
-		return fmt.Errorf("CatalogSourceConfig never reached expected phase/message, expected %v/%v", expectedPhase, expectedMessage)
-	}
-
-	// Create a namespace based on the targetNamespace string.
-	targetNamespaceRuntimeObject := &corev1.Namespace{ObjectMeta: metav1.ObjectMeta{Name: targetNamespace}}
-	err = helpers.CreateRuntimeObject(f, ctx, targetNamespaceRuntimeObject)
-	if err != nil {
-		return err
+		t.Fatalf("Could not get namespace: %v", err)
 	}
 
 	// Now that the targetNamespace has been created, periodically check that the CatalogSourceConfig
 	// has reached the Succeeded phase.
-	expectedPhase = "Succeeded"
-	err = wait.Poll(helpers.RetryInterval, helpers.Timeout, func() (bool, error) {
-		// CatalogSourceConfig should exist so no wait.
-		err = helpers.WaitForResult(t, resultCatalogSourceConfig, namespace, nonExistingTargetNamespaceCscName)
-		if err != nil {
-			return false, err
-		}
-		if resultCatalogSourceConfig.Status.CurrentPhase.Name == expectedPhase {
-			return true, nil
-		}
-		return false, nil
-	})
+	expectedPhase := "Succeeded"
+	err = helpers.WaitForExpectedPhaseAndMessage(test.Global.Client, cscName, namespace, expectedPhase, "")
 	if err != nil {
-		return fmt.Errorf("CatalogSourceConfig never reached expected phase/message, expected %v", expectedPhase)
+		t.Fatalf("CatalogSourceConfig never reached expected phase/message, expected %v", expectedPhase)
 	}
-
-	return nil
 }

--- a/test/testsuites/opsrccreationtests.go
+++ b/test/testsuites/opsrccreationtests.go
@@ -4,11 +4,8 @@ import (
 	"testing"
 
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
-	marketplace "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-marketplace/test/helpers"
 	"github.com/operator-framework/operator-sdk/pkg/test"
-	apps "k8s.io/api/apps/v1"
-	corev1 "k8s.io/api/core/v1"
 )
 
 // OpSrcCreation is a test suite that ensures that the expected kubernetets resources are
@@ -30,40 +27,20 @@ func testOperatorSourceGeneratesExpectedObjects(t *testing.T) {
 		t.Errorf("Could not get namespace: %v", err)
 	}
 
-	// Check that we created the CatalogSourceConfig.
-	resultCatalogSourceConfig := &marketplace.CatalogSourceConfig{}
-	err = helpers.WaitForResult(t, resultCatalogSourceConfig, namespace, helpers.TestOperatorSourceName)
+	// Check for the CatalogSourceConfig and it's child resources.
+	err = helpers.CheckCatalogSourceConfigAndChildResourcesCreated(test.Global.Client, helpers.TestOperatorSourceName, namespace, namespace)
 	if err != nil {
 		t.Error(err)
 	}
 
 	// Then check for the CatalogSource.
 	resultCatalogSource := &olm.CatalogSource{}
-	err = helpers.WaitForResult(t, resultCatalogSource, namespace, helpers.TestOperatorSourceName)
+	err = helpers.WaitForResult(test.Global.Client, resultCatalogSource, namespace, helpers.TestOperatorSourceName)
 	if err != nil {
 		t.Error(err)
 	}
 
-	// Then check that the service was created.
-	resultService := &corev1.Service{}
-	err = helpers.WaitForResult(t, resultService, namespace, helpers.TestOperatorSourceName)
-	if err != nil {
-		t.Error(err)
-	}
-
-	// Then check that the deployment was created.
-	resultDeployment := &apps.Deployment{}
-	err = helpers.WaitForResult(t, resultDeployment, namespace, helpers.TestOperatorSourceName)
-	if err != nil {
-		t.Error(err)
-	}
-
-	// Now check that the deployment is ready.
-	err = helpers.WaitForSuccessfulDeployment(t, *resultDeployment)
-	if err != nil {
-		t.Error(err)
-	}
-
+	// Check that the CatalogSource has the expected labels.
 	labels := resultCatalogSource.GetLabels()
 	groupGot, ok := labels[helpers.TestOperatorSourceLabelKey]
 


### PR DESCRIPTION
Extended the targetNamespace testsuite to check that a CatalogSourceConfig
with different namespace and targetNamespace values is properly deployed
and cleaned up.

Other notes:
* Updates CSC packages to pull package from marketplace_e2e operator source.
* Add new functions to helpers package