### PR TITLE
[e2e] Add opsrc delete test

### DIFF
--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -135,6 +135,18 @@ func CreateRuntimeObject(client test.FrameworkClient, ctx *test.TestCtx, obj run
 		})
 }
 
+// CreateRuntimeObjectNoCleanup creates a runtime object without any cleanup
+// options. Using this method to create a runtime object means that the framework
+// will not automatically delete the object after test execution, and it must
+// be manually deleted.
+func CreateRuntimeObjectNoCleanup(client test.FrameworkClient, obj runtime.Object) error {
+	return client.Create(
+		context.TODO(),
+		obj,
+		nil,
+	)
+}
+
 // DeleteRuntimeObject deletes a runtime object using the test framework
 func DeleteRuntimeObject(client test.FrameworkClient, obj runtime.Object) error {
 	return client.Delete(

--- a/test/testgroups/nosetuptests.go
+++ b/test/testgroups/nosetuptests.go
@@ -10,4 +10,5 @@ import (
 func NoSetupTestGroup(t *testing.T) {
 	// Run the test suites.
 	t.Run("invalid-operator-source-test-suite", testsuites.InvalidOpSrc)
+	t.Run("delete-operator-source-test-suite", testsuites.DeleteOpSrc)
 }

--- a/test/testsuites/opsrcdeletetests.go
+++ b/test/testsuites/opsrcdeletetests.go
@@ -1,0 +1,47 @@
+package testsuites
+
+import (
+	"testing"
+
+	"github.com/operator-framework/operator-marketplace/test/helpers"
+	"github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/stretchr/testify/require"
+)
+
+// DeleteOpSrc tests that the correct cleanup occurs when an OpSrc is deleted
+func DeleteOpSrc(t *testing.T) {
+	t.Run("delete-operator-source", testDeleteOpSrc)
+}
+
+// testDeleteOpSrc ensures that after deleting an OperatorSource that the
+// objects created as a result are deleted
+func testDeleteOpSrc(t *testing.T) {
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	// Get global framework variables
+	client := test.Global.Client
+
+	// Get test namespace
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	require.NoError(t, err, "Could not get namespace.")
+
+	testOperatorSource := helpers.CreateOperatorSourceDefinition(namespace)
+
+	// Create the OperatorSource with no cleanup options.
+	err = helpers.CreateRuntimeObjectNoCleanup(client, testOperatorSource)
+	require.NoError(t, err, "Could not create operator source.")
+
+	// Check for the datastore CatalogSourceConfig and its child resources.
+	err = helpers.CheckCatalogSourceConfigAndChildResourcesCreated(test.Global.Client, testOperatorSource.Name, namespace, namespace)
+	require.NoError(t, err, "Could not ensure that CatalogSourceConfig and its child resources were deleted")
+
+	// Now let's delete the OperatorSource
+	err = helpers.DeleteRuntimeObject(client, testOperatorSource)
+	require.NoError(t, err, "OperatorSource could not be deleted successfully. Client returned error.")
+
+	// Now let's wait until the OperatorSource is successfully deleted and the
+	// child resources are removed.
+	err = helpers.CheckCatalogSourceConfigAndChildResourcesDeleted(test.Global.Client, testOperatorSource.Name, namespace, targetNamespace)
+	require.NoError(t, err, "Could not ensure that CatalogSourceConfig and its child resources were deleted.")
+}


### PR DESCRIPTION
-Added an e2e test which confirms that if an operator source is deleted
the resulting resources are deleted as well
-Added a helper function to create a resource without cleanup options