### PR TITLE
[e2e] Make CLI output for tests more verbose

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -5,4 +5,4 @@ TEST_NAMESPACE="openshift-marketplace"
 
 # Run the tests through the operator-sdk
 echo "Running operator-sdk test"
-operator-sdk test local ./test/e2e/ --no-setup --namespace $TEST_NAMESPACE
+operator-sdk test local ./test/e2e/ --no-setup --go-test-flags -v --namespace $TEST_NAMESPACE


### PR DESCRIPTION
Feeding `--go-test-flags -v` flag to `operator-sdk test` command
to make output of e2e tests more verbose.