### PR TITLE
Bug 1706867: ClusterOperator degrading on exit

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -289,8 +289,8 @@ func (s *status) monitorClusterStatus() {
 			// be set to degraded.
 			conditionListBuilder := clusterStatusListBuilder()
 			conditionListBuilder(configv1.OperatorProgressing, configv1.ConditionFalse, "")
-			conditionListBuilder(configv1.OperatorAvailable, configv1.ConditionFalse, "")
-			statusConditions := conditionListBuilder(configv1.OperatorDegraded, configv1.ConditionTrue, "Operator exited")
+			conditionListBuilder(configv1.OperatorAvailable, configv1.ConditionFalse, "The operator has exited and is no longer reporting status.")
+			statusConditions := conditionListBuilder(configv1.OperatorDegraded, configv1.ConditionFalse, "")
 			statusErr := s.setStatus(statusConditions)
 			if statusErr != nil {
 				log.Error("[status] " + statusErr.Error())


### PR DESCRIPTION
Problem:
When the marketplace operator is stopped and restarted, it should not
implicitly mark the ClusterOperator status as degrading.

Solution:
When the Operator exits, simply log that the operator has exited and exit
gracefully.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1706867