### PR TITLE
Bug 1693964: Log reconciliation update error

### DIFF
--- a/pkg/catalogsourceconfig/handler.go
+++ b/pkg/catalogsourceconfig/handler.go
@@ -71,14 +71,14 @@ func (h *catalogsourceconfighandler) Handle(ctx context.Context, in *marketplace
 	// reconciliation has either completed successfully or failed. In either
 	// case, we need to update the modified CatalogSourceConfig object.
 	if updateErr := h.client.Update(ctx, out); updateErr != nil {
+		log.Errorf("Failed to update object - %v", updateErr)
+
 		if err == nil {
 			// No reconciliation err, but update of object has failed!
 			return updateErr
 		}
 
 		// Presence of both Reconciliation error and object update error.
-		log.Errorf("Failed to update object - %v", updateErr)
-
 		// TODO: find a way to chain the update error?
 		return err
 	}

--- a/pkg/operatorsource/handler.go
+++ b/pkg/operatorsource/handler.go
@@ -108,14 +108,14 @@ func (h *operatorsourcehandler) transition(ctx context.Context, logger *log.Entr
 	// either completed successfully or failed.
 	// In either case, we need to update the modified OperatorSource object.
 	if updateErr := h.client.Update(ctx, opsrc); updateErr != nil {
+		logger.Errorf("Failed to update object - %v", updateErr)
+
 		if reconciliationErr == nil {
 			// No reconciliation err, but update of object has failed!
 			return updateErr
 		}
 
 		// Presence of both Reconciliation error and object update error.
-		logger.Errorf("Failed to update object - %v", updateErr)
-
 		// TODO: find a way to chain the update error?
 		return reconciliationErr
 	}


### PR DESCRIPTION
If a user edits an OperatorSource with validation off and sets a
required attribute to an invalid value then marketplace operator runs
into update error when it tries to reconcile the object.

We don't currently log the update error from within the handler. Add
logging to both OperatorSource and CatalogSourceConfig handler to log
the update error during reconciliation error.

Bugzilla: https://bugzilla.redhat.com/show_bug.cgi?id=1693964
Jira: https://jira.coreos.com/browse/MKTPLC-329