### PR TITLE
[e2e] OperatorSource with conflicting packages

### DIFF
--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -156,13 +156,13 @@ func DeleteRuntimeObject(client test.FrameworkClient, obj runtime.Object) error 
 
 // CreateOperatorSourceDefinition returns an OperatorSource definition that can be turned into
 // a runtime object for tests that rely on an OperatorSource
-func CreateOperatorSourceDefinition(namespace string) *marketplace.OperatorSource {
+func CreateOperatorSourceDefinition(name string, namespace string) *marketplace.OperatorSource {
 	return &marketplace.OperatorSource{
 		TypeMeta: metav1.TypeMeta{
 			Kind: marketplace.OperatorSourceKind,
 		},
 		ObjectMeta: metav1.ObjectMeta{
-			Name:      TestOperatorSourceName,
+			Name:      name,
 			Namespace: namespace,
 			Labels: map[string]string{
 				TestOperatorSourceLabelKey: TestOperatorSourceLabelValue,
@@ -175,6 +175,7 @@ func CreateOperatorSourceDefinition(namespace string) *marketplace.OperatorSourc
 		},
 	}
 }
+
 // CheckCscChildResourcesCreated checks that a CatalogSourceConfig's
 // child resources were deployed.
 func CheckCscChildResourcesCreated(client test.FrameworkClient, cscName string, namespace string, targetNamespace string) error {

--- a/test/testgroups/operatorsourcetests.go
+++ b/test/testgroups/operatorsourcetests.go
@@ -20,7 +20,7 @@ func OperatorSourceTestGroup(t *testing.T) {
 	require.NoError(t, err, "Could not get namespace")
 
 	// Create the OperatorSource.
-	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateOperatorSourceDefinition(namespace))
+	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateOperatorSourceDefinition(helpers.TestOperatorSourceName, namespace))
 	require.NoError(t, err, "Could not create OperatorSource")
 
 	// Run the test suites.

--- a/test/testgroups/operatorsourcetests.go
+++ b/test/testgroups/operatorsourcetests.go
@@ -26,5 +26,5 @@ func OperatorSourceTestGroup(t *testing.T) {
 	// Run the test suites.
 	t.Run("opsrc-creation-test-suite", testsuites.OpSrcCreation)
 	t.Run("csc-target-namespace-test-suite", testsuites.CscTargetNamespace)
-	t.Run("csc-packages-test-suite", testsuites.TestCscWithNonExistingPackage)
+	t.Run("packages-test-suite", testsuites.PackageTests)
 }

--- a/test/testsuites/opsrcdeletetests.go
+++ b/test/testsuites/opsrcdeletetests.go
@@ -26,7 +26,7 @@ func testDeleteOpSrc(t *testing.T) {
 	namespace, err := test.NewTestCtx(t).GetNamespace()
 	require.NoError(t, err, "Could not get namespace.")
 
-	testOperatorSource := helpers.CreateOperatorSourceDefinition(namespace)
+	testOperatorSource := helpers.CreateOperatorSourceDefinition(helpers.TestOperatorSourceName, namespace)
 
 	// Create the OperatorSource with no cleanup options.
 	err = helpers.CreateRuntimeObjectNoCleanup(client, testOperatorSource)


### PR DESCRIPTION
Introduce a test that ensures that an OperatorSource and its child resources
are successfully rolled out regardless of whether or not there is a
package conflict with an exiting OperatorSource.