### PR TITLE
[status] Reformat status comments

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -67,9 +67,9 @@ func main() {
 	catalogsourceconfig.InitializeStaticSyncer(mgr.GetClient(), initialWait)
 	registrySyncer := operatorsource.NewRegistrySyncer(mgr.GetClient(), initialWait, resyncInterval, updateNotificationSendWait, catalogsourceconfig.Syncer, catalogsourceconfig.Syncer)
 
-	// monitorStopCh is used to send a signal to stop reporting cluster operator status
+	// monitorStopCh is used to send a signal to stop reporting ClusterOperator status
 	monitorStopCh := make(chan struct{})
-	// monitorDoneCh will recieve a signal when threads have stopped updating cluster operator status
+	// monitorDoneCh will recieve a signal when threads have stopped updating ClusterOperator status
 	monitorDoneCh := status.StartReporting(cfg, mgr, namespace, os.Getenv("RELEASE_VERSION"), monitorStopCh)
 
 	// Setup Scheme for all defined resources

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -20,7 +20,7 @@ import (
 )
 
 const (
-	// clusterOperatorName is the name of the cluster operator
+	// clusterOperatorName is the name of the ClusterOperator
 	clusterOperatorName = "marketplace"
 
 	// minSyncsBeforeReporting is the minimum number of syncs we wish to see
@@ -42,7 +42,7 @@ const (
 	syncsBeforeTruncate = 10000
 	syncTruncateValue   = 100
 
-	// coStatusReportInterval is the interval at which the cluster operator status is updated
+	// coStatusReportInterval is the interval at which the ClusterOperator status is updated
 	coStatusReportInterval = 20 * time.Second
 )
 
@@ -89,7 +89,7 @@ func StartReporting(cfg *rest.Config, mgr manager.Manager, namespace string, ver
 	// ensure instance is only created once.
 	once.Do(func() {
 		instance = new(cfg, mgr, namespace, version, stopCh)
-		// exit if cluster operator api is not present
+		// exit if ClusterOperator api is not present
 		if instance.coAPINotPresent {
 			return
 		}
@@ -275,7 +275,7 @@ func (s *status) syncChannelReceiver() {
 	}
 }
 
-// monitorClusterStatus updates the cluster operator's status based on
+// monitorClusterStatus updates the ClusterOperator's status based on
 // the number of successful syncs / total syncs
 func (s *status) monitorClusterStatus() {
 	// Signal to the main channel that we have stopped reporting status.
@@ -296,7 +296,7 @@ func (s *status) monitorClusterStatus() {
 				log.Error("[status] " + statusErr.Error())
 			}
 			return
-		// Attempt to update the cluster operator status whenever the seconds
+		// Attempt to update the ClusterOperator status whenever the seconds
 		// number of seconds defined by coStatusReportInterval passes.
 		case <-time.After(coStatusReportInterval):
 			// Log any status update errors after exit.
@@ -307,7 +307,7 @@ func (s *status) monitorClusterStatus() {
 				}
 			}()
 
-			// Create the cluster operator in the progressing state if it does not exist
+			// Create the ClusterOperator in the progressing state if it does not exist
 			// or if it is the first report.
 			if s.clusterOperator == nil {
 				conditionListBuilder := clusterStatusListBuilder()

--- a/pkg/status/syncratio.go
+++ b/pkg/status/syncratio.go
@@ -8,7 +8,7 @@ import (
 )
 
 // SyncRatio provides an interface for managing syncs which are used to report
-// operator status to CVO.
+// ClusterOperator status to CVO.
 type SyncRatio interface {
 	GetSyncs() (failedSyncs int, syncEvents int)
 	ReportFailedSync()
@@ -41,7 +41,7 @@ func NewSyncRatio(successRatio float32, syncsBeforeTruncate int, syncTruncateVal
 }
 
 type syncRatio struct {
-	// successRatio is the ratio of successfulSyncs to syncEvents
+	// successRatio is the ratio of successfulSyncs to syncEvents.
 	successRatio float32
 
 	// syncsBeforeTruncate the number of syncEvents before failedSyncs and
@@ -53,6 +53,7 @@ type syncRatio struct {
 
 	// failedSyncs represents the number of failed syncs.
 	failedSyncs int
+
 	// syncEvents represents the sum of syncs events.
 	syncEvents int
 
@@ -60,21 +61,21 @@ type syncRatio struct {
 	lock sync.Mutex
 }
 
-// GetSyncs returns the number of failedSyncs and the number of syncEvents
+// GetSyncs returns the number of failedSyncs and the number of syncEvents.
 func (s *syncRatio) GetSyncs() (failedSyncs int, syncEvents int) {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	return s.failedSyncs, s.syncEvents
 }
 
-// ReportFailedSync increments the number of syncEvents by one
+// ReportFailedSync increments the number of syncEvents by one.
 func (s *syncRatio) ReportFailedSync() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
 	s.failedSyncs++
 }
 
-// ReportSyncEvent increments the number of syncEvents
+// ReportSyncEvent increments the number of syncEvents.
 func (s *syncRatio) ReportSyncEvent() {
 	s.lock.Lock()
 	defer s.lock.Unlock()
@@ -89,11 +90,11 @@ func (s *syncRatio) truncateSyncs() {
 	s.failedSyncs = s.failedSyncs % s.syncTruncateValue
 }
 
-// isSucceeding returns whether or not the cluster operator should report a successful state.
-// If syncEvents is less than or equal to 0 an error is returned and syncr.
+// isSucceeding returns whether or not the ClusterOperator should report a successful state.
+// If syncEvents is less than or equal to 0 then (false, nil) is returned.
 func (s *syncRatio) IsSucceeding() (bool, *float32) {
 	ratio := s.getRatio()
-	// return error if s.syncs <= 0
+	// return (false, nil) if s.syncs <= 0.
 	if ratio == nil {
 		return false, ratio
 	}
@@ -105,9 +106,9 @@ func (s *syncRatio) IsSucceeding() (bool, *float32) {
 }
 
 // getRatio returns the ratio of successfulSyncs to syncEvents
-// If s.syncs is equal to 0 then nil is returned
+// If s.syncs is less than or equal to 0 then nil is returned.
 func (s *syncRatio) getRatio() *float32 {
-	// Prevent number of syncs from growing indefinitely
+	// Prevent number of syncs from growing indefinitely.
 	if s.syncEvents > s.syncsBeforeTruncate {
 		s.truncateSyncs()
 	}


### PR DESCRIPTION
Fix small errors in comment and rename `cluster operator` to `ClusterOperator`.