### PR TITLE
[e2e] Check ClusterOperator Status upon initialization

### DIFF
--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-marketplace/pkg/apis"
 	marketplace "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
@@ -23,6 +24,7 @@ func TestMarketplace(t *testing.T) {
 	initTestingFramework(t)
 
 	// Run Test Groups
+	t.Run("cluster-operator-status-test-group", testgroups.ClusterOperatorTestGroup)
 	t.Run("operator-source-test-group", testgroups.OperatorSourceTestGroup)
 	t.Run("no-setup-test-group", testgroups.NoSetupTestGroup)
 }
@@ -63,5 +65,17 @@ func initTestingFramework(t *testing.T) {
 	err = test.AddToFrameworkScheme(olm.AddToScheme, catalogSource)
 	if err != nil {
 		t.Fatalf("failed to add CatalogSource custom resource scheme to framework: %v", err)
+	}
+	// Add (configv1) ClusterOperator to framework scheme
+	clusterOperator := &configv1.ClusterOperator{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ClusterOperator",
+			APIVersion: fmt.Sprintf("%s/%s",
+				configv1.SchemeGroupVersion.Group, configv1.SchemeGroupVersion.Version),
+		},
+	}
+	err = test.AddToFrameworkScheme(configv1.Install, clusterOperator)
+	if err != nil {
+		t.Fatalf("failed to add ClusterOperator custom resource scheme to framework: %v", err)
 	}
 }

--- a/test/testgroups/clusteroperatortests.go
+++ b/test/testgroups/clusteroperatortests.go
@@ -1,0 +1,13 @@
+package testgroups
+
+import (
+	"testing"
+
+	"github.com/operator-framework/operator-marketplace/test/testsuites"
+)
+
+// ClusterOperatorTestGroup runs test suites that check the status of the Cluster Operator
+func ClusterOperatorTestGroup(t *testing.T) {
+	// Run the test suites.
+	t.Run("cluster-operator-status-on-startup-test-suite", testsuites.ClusterOperatorStatusOnStartup)
+}

--- a/test/testsuites/clusteroperatorstatustests.go
+++ b/test/testsuites/clusteroperatorstatustests.go
@@ -1,0 +1,56 @@
+package testsuites
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// ClusterOperatorStatusOnStartup is a test suite that ensures the ClusterOperator resource which
+// defines the status of the marketplace operator has the correct status upon initialization
+func ClusterOperatorStatusOnStartup(t *testing.T) {
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	// Get global framework variables.
+	client := test.Global.Client
+
+	// Get namespace
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	require.NoError(t, err, "Could not get namespace")
+
+	// Check that the ClusterOperator resource has the correct status
+	clusterOperatorName := "marketplace"
+	expectedTypeStatus := map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{
+		configv1.OperatorProgressing: configv1.ConditionFalse,
+		configv1.OperatorAvailable:   configv1.ConditionTrue,
+		configv1.OperatorDegraded:    configv1.ConditionFalse}
+
+	// Poll to ensure ClusterOperator is present and has the correct status
+	// i.e. ConditionType has a ConditionStatus matching expectedTypeStatus
+	namespacedName := types.NamespacedName{Name: clusterOperatorName, Namespace: namespace}
+	result := &configv1.ClusterOperator{}
+	RetryInterval := time.Second * 5
+	Timeout := time.Minute * 5
+	err = wait.PollImmediate(RetryInterval, Timeout, func() (done bool, err error) {
+		err = client.Get(context.TODO(), namespacedName, result)
+		if err != nil {
+			return false, err
+		}
+		for _, condition := range result.Status.Conditions {
+			if expectedTypeStatus[condition.Type] != condition.Status {
+				return false, fmt.Errorf("Expecting condition type %v of status %v but got %v", condition.Type, expectedTypeStatus[condition.Type], condition.Status)
+			}
+		}
+		return true, nil
+	})
+	assert.NoError(t, err, "ClusterOperator never reached expected status")
+}


### PR DESCRIPTION
This test checks each of the ClusterOperator Conditions in its Status and
ensures that these match the expected Conditions when the marketplace operator
is available and healthy.