### PR TITLE
[status] Use builder pattern in status

### DIFF
--- a/pkg/status/statusbuilder.go
+++ b/pkg/status/statusbuilder.go
@@ -1,0 +1,28 @@
+package status
+
+import (
+	configv1 "github.com/openshift/api/config/v1"
+	"k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+// StatusBuilder builds a new slice of ClusterOperatorStatusConditions.
+type StatusBuilder struct {
+	statusList []configv1.ClusterOperatorStatusCondition
+}
+
+// StatusList returns a slice of ClusterOperatorStatusConditions.
+func (s *StatusBuilder) StatusList() *[]configv1.ClusterOperatorStatusCondition {
+	return &s.statusList
+}
+
+func (s *StatusBuilder) WithStatus(conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus, conditionMessage string) *StatusBuilder {
+	time := v1.Now()
+	s.statusList = append(s.statusList, configv1.ClusterOperatorStatusCondition{
+		Type:               conditionType,
+		Status:             conditionStatus,
+		Message:            conditionMessage,
+		LastTransitionTime: time,
+	})
+
+	return s
+}

--- a/pkg/status/syncutils.go
+++ b/pkg/status/syncutils.go
@@ -3,7 +3,6 @@ package status
 import (
 	configv1 "github.com/openshift/api/config/v1"
 	cohelpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
 // compareArrayClusterOperatorStatusConditions takes two arrays of
@@ -37,18 +36,4 @@ func compareClusterOperatorStatusConditions(a configv1.ClusterOperatorStatusCond
 		return true
 	}
 	return false
-}
-
-func clusterStatusListBuilder() func(conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus, conditionMessage string) []configv1.ClusterOperatorStatusCondition {
-	time := v1.Now()
-	list := []configv1.ClusterOperatorStatusCondition{}
-	return func(conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus, conditionMessage string) []configv1.ClusterOperatorStatusCondition {
-		list = append(list, configv1.ClusterOperatorStatusCondition{
-			Type:               conditionType,
-			Status:             conditionStatus,
-			Message:            conditionMessage,
-			LastTransitionTime: time,
-		})
-		return list
-	}
 }


### PR DESCRIPTION
Problem:
Currently seeing an issue on some cluster installs where it seems like
the status is not being set properly. This seems to be due to a bug in
the status reporting package where we were relying on a function to
create an object in memory when it was called multiple times, which
is not happening on some environments.

Solution:
Use a builder that creates the object and references it in a specific
memory location.
Additionally, rename the new() function in the status package to
newStatus so that the builtin new is available.
Also fixes a log formatting issue.