### PR TITLE
[csc] Update CSC to specify a source name

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,15 +35,19 @@ The creation of an `OperatorSource` results in the creation of an OLM `CatalogSo
 
 #### CatalogSourceConfig
 
-`CatalogSourceConfig` is used to create OLM `CatalogSources` consisting of operators from one or more `OperatorSources` so that these operators can then be managed by OLM.
+`CatalogSourceConfig` is used to create OLM `CatalogSources` consisting of operators from one `OperatorSource` so that these operators can then be managed by OLM.
 
 Here is a description of the spec fields:
 
 - `targetNamespace` is the namespace that OLM is watching. This is where the resulting `CatalogSource`, which will have the same name as the `CatalogSourceConfig`, is created or updated.
 
+- `source` is the name of the `OperatorSource` that the packages originate from.
+
 - `packages` is a comma separated list of operators.
 
 - `csDisplayName` and `csPublisher` are optional but will result in the `CatalogSource` having proper UI displays.
+
+To learn more about how the Marketplace Operator resolves source and package combinations, please review [this doc](docs/csc-source-resolution.md).
 
 Please see [here](deploy/examples/catalogsourceconfig.cr.yaml) for an example `CatalogSourceConfig`.
 

--- a/deploy/crds/operators_v2_catalogsourceconfig_crd.yaml
+++ b/deploy/crds/operators_v2_catalogsourceconfig_crd.yaml
@@ -45,7 +45,13 @@ spec:
           required:
           - targetNamespace
           - packages
+          - source
           properties:
+            source:
+              type: string
+              description: The name of the OperatorSource that the packages originate from
+              # This pattern accepts valid metadata.name values and empty strings.
+              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
             targetNamespace:
               type: string
               description: The namespace where the operators will be enabled

--- a/deploy/examples/catalogsourceconfig.cr.yaml
+++ b/deploy/examples/catalogsourceconfig.cr.yaml
@@ -1,9 +1,10 @@
-apiVersion: "operators.coreos.com/v1"
+apiVersion: "operators.coreos.com/v2"
 kind: "CatalogSourceConfig"
 metadata:
   name: "installed-upstream-community-operators"
   namespace: "marketplace"
 spec:
   targetNamespace: local-operators
+  source: upstream-community-operators
   packages: jaeger
 

--- a/deploy/upstream/02_catalogsourceconfig.crd.yaml
+++ b/deploy/upstream/02_catalogsourceconfig.crd.yaml
@@ -45,7 +45,13 @@ spec:
           required:
           - targetNamespace
           - packages
+          - source
           properties:
+            source:
+              type: string
+              description: The name of the OperatorSource that the packages originate from
+              # This pattern accepts valid metadata.name values and empty strings.
+              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
             targetNamespace:
               type: string
               description: The namespace where the operators will be enabled

--- a/docs/csc-source-resolution.md
+++ b/docs/csc-source-resolution.md
@@ -1,0 +1,17 @@
+# CatalogSourceConfig Source Resolution
+
+v2 of the `CatalogSourceConfig CRD` expects a `source` that matches the name of an `OperatorSource` on cluster that all packages must originate from. If a CatalogSourceConfig is created without specifying a `source`, the Marketplace Operator will attempt to update the `source` field with the name of a valid `OperatorSource` that contains the list of `packages`.
+
+This document will describe how the Marketplace Operator will attempt to reconcile invalid and missing `sources` and the phase that the `CatalogSourceConfig` will eventually reach. Any `CatalogSourceConfig` placed in the `Configuring` phase can eventually be resolved if the described errors are addressed.
+
+## CSC Includes Source Scenarios
+
+1. If a `CatalogSourceConfig` defines a `source` that exists on the cluster and contains the requested `packages`, the `CatalogSourceConfig` will be placed in the `Succeeded` phase.
+2. If a `CatalogSourceConfig` defines a `source` that exists on the cluster but does not contain the requested `packages`, the `CatalogSourceConfig` will be placed in the `Configuring` phase and the `phase.message` will be updated to reflect that the `OperatorSource` does not include the expected `packages`.
+3. If a `CatalogSourceConfig` defines a `source` that does not exist on the cluster, the `CatalogSourceConfig` will be placed in the `Configuring` phase and the `phase.message` will be updated to reflect that the `source` does not exist.
+
+## CSC Missing Source Scenarios
+
+1. If a `CatalogSourceConfig` does not define a `source` and an `OperatorSource` contains the requested `packages`, the `CatalogSourceConfig` will be updated to include the valid `OperatorSource` as its `source` and placed in the `Succeeded` phase.
+2. If a `CatalogSourceConfig` does not define a `source` and multiple `OperatorSources` contain the requested `packages`, the `CatalogSourceConfig` will be updated to include one of the valid `OperatorSources` as its `source`.
+3. If a `CatalogSourceConfig` does not define a `source` and no `OperatorSource` contains the requested `packages`, the `CatalogSourceConfig` will be placed in the `Configuring` phase and the `phase.message` will be updated to reflect that a `source` could not be resolved.

--- a/manifests/02_catalogsourceconfig.crd.yaml
+++ b/manifests/02_catalogsourceconfig.crd.yaml
@@ -45,7 +45,13 @@ spec:
           required:
           - targetNamespace
           - packages
+          - source
           properties:
+            source:
+              type: string
+              description: The name of the OperatorSource that the packages originate from
+              # This pattern accepts valid metadata.name values and empty strings.
+              pattern: ^$|^[a-z0-9]([-a-z0-9]*[a-z0-9])?(\.[a-z0-9]([-a-z0-9]*[a-z0-9])?)*$
             targetNamespace:
               type: string
               description: The namespace where the operators will be enabled

--- a/pkg/apis/operators/v2/catalogsourceconfig_types.go
+++ b/pkg/apis/operators/v2/catalogsourceconfig_types.go
@@ -39,6 +39,8 @@ type CatalogSourceConfigList struct {
 
 // CatalogSourceConfigSpec defines the desired state of CatalogSourceConfig
 type CatalogSourceConfigSpec struct {
+	// The name of the OperatorSource that the packages originate from
+	Source          string `json:"source"`
 	TargetNamespace string `json:"targetNamespace"`
 	Packages        string `json:"packages"`
 

--- a/pkg/catalogsourceconfig/cache.go
+++ b/pkg/catalogsourceconfig/cache.go
@@ -62,6 +62,11 @@ func (c *cache) IsEntryStale(csc *v2.CatalogSourceConfig) (bool, bool) {
 		return true, true
 	}
 
+	// If the source has changed, packages are stale.
+	if spec.Source != csc.Spec.Source {
+		return true, false
+	}
+
 	cachedPackages := spec.GetPackageIDs()
 	inPackageIDs := csc.GetPackageIDs()
 
@@ -90,6 +95,7 @@ func (c *cache) Evict(csc *v2.CatalogSourceConfig) {
 
 func (c *cache) Set(csc *v2.CatalogSourceConfig) {
 	c.entries[csc.ObjectMeta.UID] = &v2.CatalogSourceConfigSpec{
+		Source:          csc.Spec.Source,
 		Packages:        csc.GetPackages(),
 		TargetNamespace: csc.Spec.TargetNamespace,
 	}

--- a/pkg/catalogsourceconfig/syncer.go
+++ b/pkg/catalogsourceconfig/syncer.go
@@ -81,8 +81,9 @@ func (s *catalogSyncer) Send(notification datastore.PackageUpdateNotification) {
 }
 
 // SendRefresh sends a refresh notification to trigger refresh of all packages
-// if their datastore and status versions differ
-func (s *catalogSyncer) SendRefresh() {
-	refreshNotification := datastore.NewPackageRefreshNotification()
+// if their datastore and status versions differ. The refresh will only update
+// CatalogSourceConfigs whose sources match the name of the opSrc parameter.
+func (s *catalogSyncer) SendRefresh(opSrc string) {
+	refreshNotification := datastore.NewPackageRefreshNotification(opSrc)
 	s.Send(refreshNotification)
 }

--- a/pkg/datastore/datastore.go
+++ b/pkg/datastore/datastore.go
@@ -32,19 +32,30 @@ func New() *memoryDatastore {
 
 // Reader is the interface that wraps the Read method.
 type Reader interface {
-	// Read takes a package identifier and returns metadata defined in the opsrc
+	// Read takes an OperatorSource name and package identifier and returns metadata defined in the opsrc
 	// spec to associate that package to a specific opsrc in the marketplace.
 	// The OpsrcRef returned can be used to determine how to download manifests
 	// for a specific operator package.
-	Read(packageID string) (opsrcMeta *OpsrcRef, err error)
+	Read(source, packageID string) (opsrcMeta *OpsrcRef, err error)
 
-	// ReadVersion takes a package identifer and returns version metadata
+	// ReadRepositoryVersion takes an OperatorSource name and package identifer and returns version
 	// to associate that package to a particular repository version.
-	ReadRepositoryVersion(packageID string) (version string, err error)
+	ReadRepositoryVersion(source, packageID string) (version string, err error)
+
+	// GetAllOperatorSources returns a list of all OperatorSource objecs(s) that
+	// datastore is aware of.
+	GetAllOperatorSources() []*OperatorSourceKey
 
 	// CheckPackages returns an error if there are packages missing from the
 	// datastore but listed in the spec.
-	CheckPackages(packageIDs []string) error
+	CheckPackages(source string, packageIDs []string) error
+
+	// SearchForSource will return an OperatorSource that contains the list of packages.
+	// If an OperatorSource does not contains the list of packages, an error is returned.
+	SearchForSource(requiredPackages []string) (string, error)
+
+	// DoesSourceExist returns true if an OperatorSource with the given name exists
+	DoesSourceExist(source string) bool
 }
 
 // Writer is an interface that is used to manage the underlying datastore
@@ -128,8 +139,8 @@ type memoryDatastore struct {
 	rows *operatorSourceRowMap
 }
 
-func (ds *memoryDatastore) Read(packageID string) (opsrcMeta *OpsrcRef, err error) {
-	repository, err := ds.GetRepositoryByPackageName(packageID)
+func (ds *memoryDatastore) Read(source, packageID string) (opsrcMeta *OpsrcRef, err error) {
+	repository, err := ds.GetRepository(source, packageID)
 	if err != nil {
 		return
 	}
@@ -139,8 +150,8 @@ func (ds *memoryDatastore) Read(packageID string) (opsrcMeta *OpsrcRef, err erro
 	return
 }
 
-func (ds *memoryDatastore) ReadRepositoryVersion(packageID string) (version string, err error) {
-	repository, err := ds.GetRepositoryByPackageName(packageID)
+func (ds *memoryDatastore) ReadRepositoryVersion(source, packageID string) (version string, err error) {
+	repository, err := ds.GetRepository(source, packageID)
 	if err != nil {
 		return
 	}
@@ -169,6 +180,7 @@ func (ds *memoryDatastore) Write(opsrc *v1.OperatorSource, registryMetas []*Regi
 			Metadata: *metadata,
 			Package:  metadata.Repository,
 			Opsrc: &OpsrcRef{
+				Name:                 opsrc.Name,
 				Endpoint:             opsrc.Spec.Endpoint,
 				RegistryNamespace:    opsrc.Spec.RegistryNamespace,
 				SecretNamespacedName: secretNamespacedName,
@@ -183,17 +195,17 @@ func (ds *memoryDatastore) Write(opsrc *v1.OperatorSource, registryMetas []*Regi
 	return
 }
 
-func (ds *memoryDatastore) GetRepositoryByPackageName(pkg string) (repository *Repository, err error) {
+func (ds *memoryDatastore) GetRepository(sourceName, pkg string) (repository *Repository, err error) {
 	repositories := ds.rows.GetAllRepositories()
-
 	if len(repositories) == 0 {
 		err = fmt.Errorf("Datastore is empty. No package metadata to return.")
 		return
 	}
 
 	for _, repo := range repositories {
-		if repo.Package == pkg {
+		if repo.Package == pkg && repo.Opsrc.Name == sourceName {
 			repository = repo
+			break
 		}
 	}
 	if repository == nil {
@@ -217,10 +229,10 @@ func (ds *memoryDatastore) GetPackageIDsByOperatorSource(opsrcUID types.UID) str
 	return strings.Join(packages, ",")
 }
 
-func (ds *memoryDatastore) CheckPackages(packageIDs []string) error {
+func (ds *memoryDatastore) CheckPackages(source string, packageIDs []string) error {
 	missingPackages := []string{}
 	for _, packageID := range packageIDs {
-		if _, err := ds.Read(packageID); err != nil {
+		if _, err := ds.Read(source, packageID); err != nil {
 			missingPackages = append(missingPackages, packageID)
 			continue
 		}
@@ -228,8 +240,8 @@ func (ds *memoryDatastore) CheckPackages(packageIDs []string) error {
 
 	if len(missingPackages) > 0 {
 		return fmt.Errorf(
-			"Still resolving package(s) - %s. Please make sure these are valid packages.",
-			strings.Join(missingPackages, ","),
+			"Still resolving package(s) - %s. Please make sure these are valid packages within the %s OperatorSource.",
+			strings.Join(missingPackages, ","), source,
 		)
 	}
 	return nil
@@ -259,7 +271,7 @@ func (ds *memoryDatastore) OperatorSourceHasUpdate(opsrcUID types.UID, metadata 
 		return
 	}
 
-	result = newUpdateResult()
+	result = newUpdateResult(row.Name.Name)
 
 	for _, remote := range metadata {
 		if remote.Release == "" {
@@ -307,4 +319,33 @@ func (ds *memoryDatastore) OperatorSourceHasUpdate(opsrcUID types.UID, metadata 
 
 func (ds *memoryDatastore) GetAllOperatorSources() []*OperatorSourceKey {
 	return ds.rows.GetAllRows()
+}
+
+func (ds *memoryDatastore) DoesSourceExist(source string) bool {
+	for _, opSrc := range ds.GetAllOperatorSources() {
+		if source == opSrc.Name.Name {
+			return true
+		}
+	}
+	return false
+}
+
+func (ds *memoryDatastore) SearchForSource(packages []string) (string, error) {
+	opSrcs := ds.GetAllOperatorSources()
+	for _, opSrc := range opSrcs {
+		if ds.doesSourceContainPackages(opSrc.Name.Name, packages) {
+			return opSrc.Name.Name, nil
+		}
+	}
+	return "", fmt.Errorf("Unable to resolve the source - no source contains the requested package(s) %s", packages)
+}
+
+// doesSourceContainPackages returns true if the cached OperatorSource contains the list of packages.
+func (ds *memoryDatastore) doesSourceContainPackages(opSrc string, packages []string) bool {
+	for _, packageID := range packages {
+		if _, err := ds.Read(opSrc, packageID); err != nil {
+			return false
+		}
+	}
+	return true
 }

--- a/pkg/datastore/datastore_test.go
+++ b/pkg/datastore/datastore_test.go
@@ -1,6 +1,7 @@
 package datastore_test
 
 import (
+	"fmt"
 	"strings"
 	"testing"
 
@@ -88,12 +89,12 @@ func TestReadOpsrcMeta(t *testing.T) {
 	_, err := ds.Write(opsrc, metadata)
 	require.NoError(t, err)
 
-	opsrcmeta, err := ds.Read("amq-streams")
+	opsrcmeta, err := ds.Read(opsrc.Name, "amq-streams")
 	require.NoError(t, err)
 	assert.Equal(t, "https://quay.io/cnr", opsrcmeta.Endpoint)
 	assert.Equal(t, "registry-namespace", opsrcmeta.RegistryNamespace)
 
-	opsrcmeta, err = ds.Read("etcd")
+	opsrcmeta, err = ds.Read(opsrc.Name, "etcd")
 	require.NoError(t, err)
 	assert.Equal(t, "https://quay.io/cnr", opsrcmeta.Endpoint)
 	assert.Equal(t, "registry-namespace", opsrcmeta.RegistryNamespace)
@@ -151,18 +152,107 @@ func TestReadOpsrcMetaMultipleOpsrc(t *testing.T) {
 	_, err = ds.Write(opsrc2, metadata)
 	require.NoError(t, err)
 
-	opsrcmeta, err := ds.Read("amq-streams")
+	opsrcmeta, err := ds.Read(opsrc.Name, "amq-streams")
 	require.NoError(t, err)
 	assert.Equal(t, "https://quay.io/cnr", opsrcmeta.Endpoint)
 	assert.Equal(t, "registry-namespace", opsrcmeta.RegistryNamespace)
 
-	opsrcmeta, err = ds.Read("etcd")
+	opsrcmeta, err = ds.Read(opsrc.Name, "etcd")
 	require.NoError(t, err)
 	assert.Equal(t, "https://quay.io/cnr", opsrcmeta.Endpoint)
 	assert.Equal(t, "registry-namespace", opsrcmeta.RegistryNamespace)
 
-	opsrcmeta, err = ds.Read("federationv2")
+	opsrcmeta, err = ds.Read(opsrc2.Name, "federationv2")
 	require.NoError(t, err)
 	assert.Equal(t, "https://quay-diff.io/cnr", opsrcmeta.Endpoint)
 	assert.Equal(t, "registry-namespace-diff", opsrcmeta.RegistryNamespace)
+
+}
+
+// In this test we make sure that, if we have a datastore, we can search for
+// an opsrc that contains a list of packages.
+func TestSearchForSource(t *testing.T) {
+	opsrc := &v1.OperatorSource{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID("123456"),
+			Name:      "operators-opsrc",
+			Namespace: "operators",
+		},
+		Spec: v1.OperatorSourceSpec{
+			Endpoint:          "https://quay.io/cnr",
+			RegistryNamespace: "registry-namespace",
+		},
+	}
+
+	metadata := []*datastore.RegistryMetadata{
+		&datastore.RegistryMetadata{
+			Repository: "amq-streams",
+			Namespace:  "operators",
+		},
+		&datastore.RegistryMetadata{
+			Repository: "etcd",
+			Namespace:  "operators",
+		},
+	}
+
+	ds := datastore.New()
+	_, err := ds.Write(opsrc, metadata)
+	require.NoError(t, err)
+
+	opsrc2 := &v1.OperatorSource{
+		ObjectMeta: metav1.ObjectMeta{
+			UID:       types.UID("456789"),
+			Name:      "operators-different",
+			Namespace: "operators",
+		},
+		Spec: v1.OperatorSourceSpec{
+			Endpoint:          "https://quay-diff.io/cnr",
+			RegistryNamespace: "registry-namespace-diff",
+		},
+	}
+
+	metadata = []*datastore.RegistryMetadata{
+		&datastore.RegistryMetadata{
+			Repository: "federationv2",
+			Namespace:  "operators",
+		},
+		&datastore.RegistryMetadata{
+			Repository: "etcd",
+			Namespace:  "operators",
+		},
+	}
+
+	_, err = ds.Write(opsrc2, metadata)
+	require.NoError(t, err)
+
+	// Search for a source that contains the amq-streams package.
+	source, err := ds.SearchForSource([]string{"amq-streams"})
+	require.NoError(t, err)
+	assert.Equal(t, opsrc.Name, source)
+
+	// Search for a source that contains both the amq-streams and etcd package.
+	source, err = ds.SearchForSource([]string{"amq-streams", "etcd"})
+	require.NoError(t, err)
+	assert.Equal(t, opsrc.Name, source)
+
+	// Search for a source that contains the amq-streams package.
+	source, err = ds.SearchForSource([]string{"federationv2"})
+	require.NoError(t, err)
+	assert.Equal(t, opsrc2.Name, source)
+
+	// Search for a package contained in multiple sources.
+	source, err = ds.SearchForSource([]string{"etcd"})
+	assert.NoError(t, err)
+
+	// Search for a list of packages that aren't contained in a single source.
+	packages := []string{"amq-streams", "etcd", "federationv2"}
+	source, err = ds.SearchForSource(packages)
+	assert.Error(t, err)
+	assert.Equal(t, fmt.Sprintf("Unable to resolve the source - no source contains the requested package(s) %v", packages), err.Error())
+
+	// Search for a package that isn't contained in any existing source.
+	packages = []string{"missing-package"}
+	source, err = ds.SearchForSource(packages)
+	assert.Error(t, err)
+	assert.Equal(t, fmt.Sprintf("Unable to resolve the source - no source contains the requested package(s) %v", packages), err.Error())
 }

--- a/pkg/datastore/metadata.go
+++ b/pkg/datastore/metadata.go
@@ -40,6 +40,9 @@ type Repository struct {
 // OpsrcRef defines the endpoint, registry namespace and secret for a given
 // OperatorSource.
 type OpsrcRef struct {
+	// Name is the name of the OperatorSource.
+	Name string
+
 	// Endpoint points to the remote app registry server from
 	// where operator manifests can be fetched.
 	Endpoint string

--- a/pkg/datastore/update_result.go
+++ b/pkg/datastore/update_result.go
@@ -4,22 +4,27 @@ import (
 	"fmt"
 )
 
-func newUpdateResult() *UpdateResult {
+func newUpdateResult(opSrc string) *UpdateResult {
 	return &UpdateResult{
+		opSrc:   opSrc,
 		Updated: make([]string, 0),
 		Removed: make([]string, 0),
 	}
 }
 
-func NewPackageUpdateAggregator() *PackageUpdateAggregator {
+func NewPackageUpdateAggregator(opSrc string) *PackageUpdateAggregator {
 	return &PackageUpdateAggregator{
+		opSrc:   opSrc,
 		updated: map[string]bool{},
 		removed: map[string]bool{},
 	}
 }
 
-func NewPackageRefreshNotification() *PackageUpdateAggregator {
+// NewPackageRefreshNotification is used to update packages associated with
+// the OperatorSource.
+func NewPackageRefreshNotification(opSrc string) *PackageUpdateAggregator {
 	return &PackageUpdateAggregator{
+		opSrc:         opSrc,
 		refreshNeeded: true,
 	}
 }
@@ -27,6 +32,7 @@ func NewPackageRefreshNotification() *PackageUpdateAggregator {
 // UpdateResult holds information related to what has changed in the remote
 // registry associated with an operator source.
 type UpdateResult struct {
+	opSrc string
 	// RegistryHasUpdate indicates whether the remote registry associated with
 	// the operatour source has any change. It is set to true if any of the
 	// following is true:
@@ -51,6 +57,10 @@ func (a *UpdateResult) String() string {
 // PackageUpdateNotification is an interface used to determine whether a
 // specified operator has a new version or has been removed.
 type PackageUpdateNotification interface {
+	// GetOpSrc returns the name of the OperaterSource that update should
+	// be applied to.
+	GetOpSrc() string
+
 	// IsRemoved returns true if the specified package has been removed.
 	IsRemoved(pkg string) bool
 
@@ -67,6 +77,7 @@ type PackageUpdateNotification interface {
 // all operator source(s).
 // PackageUpdateAggregator also implements PackageUpdateNotification interface.
 type PackageUpdateAggregator struct {
+	opSrc         string
 	updated       map[string]bool
 	removed       map[string]bool
 	refreshNeeded bool
@@ -74,6 +85,10 @@ type PackageUpdateAggregator struct {
 
 func (a *PackageUpdateAggregator) IsRefreshNotification() bool {
 	return a.refreshNeeded
+}
+
+func (a *PackageUpdateAggregator) GetOpSrc() string {
+	return a.opSrc
 }
 
 // Add accepts an UpdateResult for a given operator source and aggregates it.

--- a/pkg/grpccatalog/grpccatalog.go
+++ b/pkg/grpccatalog/grpccatalog.go
@@ -41,19 +41,19 @@ type GrpcCatalog struct {
 // EnsureResources creates a GRPC CatalogSource if one does not already
 // exists otherwise it updates an existing one. It then creates/updates all the
 // resources it requires.
-func (r *GrpcCatalog) EnsureResources(key types.NamespacedName, displayName, publisher, targetNamespace, packages string, labels map[string]string) error {
+func (r *GrpcCatalog) EnsureResources(key types.NamespacedName, displayName, publisher, targetNamespace, source, packages string, labels map[string]string) error {
 	// Ensure reader is not nil
 	if r.reader == nil {
 		return fmt.Errorf("GrpcCatalog.reader is not defined")
 	}
 	// Ensure that the packages in the spec are available in the datastore
-	err := r.reader.CheckPackages(v2.GetValidPackageSliceFromString(packages))
+	err := r.reader.CheckPackages(source, v2.GetValidPackageSliceFromString(packages))
 	if err != nil {
 		return err
 	}
 
 	// Ensure that a registry deployment is available
-	registry := registry.NewRegistry(r.log, r.client, r.reader, key, packages, registry.ServerImage)
+	registry := registry.NewRegistry(r.log, r.client, r.reader, key, source, packages, registry.ServerImage)
 	err = registry.Ensure()
 	if err != nil {
 		return err

--- a/pkg/operatorsource/configuring.go
+++ b/pkg/operatorsource/configuring.go
@@ -108,7 +108,7 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1.OperatorSo
 	// If it is, let's force a resync for CatalogSourceConfig.
 	if isResyncNeeded {
 		r.logger.Info("New opsrc detected. Refreshing catalogsourceconfigs.")
-		r.refresher.SendRefresh()
+		r.refresher.SendRefresh(out.Name)
 	}
 
 	packages := r.datastore.GetPackageIDsByOperatorSource(out.GetUID())
@@ -126,7 +126,7 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1.OperatorSo
 	for key, value := range in.Labels {
 		labels[key] = value
 	}
-	err = grpcCatalog.EnsureResources(key, in.Spec.DisplayName, in.Spec.Publisher, in.Namespace, packages, labels)
+	err = grpcCatalog.EnsureResources(key, in.Spec.DisplayName, in.Spec.Publisher, in.Namespace, in.Name, packages, labels)
 	if err != nil {
 		nextPhase = phase.GetNextWithMessage(phase.Configuring, err.Error())
 		return

--- a/pkg/operatorsource/configuring_test.go
+++ b/pkg/operatorsource/configuring_test.go
@@ -70,16 +70,16 @@ func TestReconcile_ScheduledForConfiguring_Succeeded(t *testing.T) {
 	writer.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return("")
 
 	// Then we expect to call send refresh, because the package list was empty.
-	refresher.EXPECT().SendRefresh()
+	refresher.EXPECT().SendRefresh(gomock.Any())
 
 	// We expect datastore to return the specified list of packages.
 	writer.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return(opsrcWant.Status.Packages)
 
 	// Then we expect to read the packages
-	reader.EXPECT().CheckPackages(gomock.Any()).Return(nil)
+	reader.EXPECT().CheckPackages(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Then we expect a read to the datastore
-	reader.EXPECT().Read(gomock.Any()).Return(&datastore.OpsrcRef{}, nil).AnyTimes()
+	reader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(&datastore.OpsrcRef{}, nil).AnyTimes()
 
 	opsrcGot, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
 
@@ -178,16 +178,16 @@ func TestReconcile_NotConfigured_NewCatalogConfigSourceObjectCreated(t *testing.
 	writer.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return("")
 
 	// Then we expect to call send refresh, because the package list was empty.
-	refresher.EXPECT().SendRefresh()
+	refresher.EXPECT().SendRefresh(gomock.Any())
 
 	packages := "a,b,c"
 	writer.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return(packages)
 
 	// Then we expect to read the packages
-	reader.EXPECT().CheckPackages(gomock.Any()).Return(nil)
+	reader.EXPECT().CheckPackages(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Then we expect a read to the datastore
-	reader.EXPECT().Read(gomock.Any()).Return(&datastore.OpsrcRef{}, nil).AnyTimes()
+	reader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(&datastore.OpsrcRef{}, nil).AnyTimes()
 
 	cscWant := helperNewCatalogSourceConfigWithLabels(opsrcIn.Namespace, opsrcIn.Name, labelsWant)
 	cscWant.Spec = v2.CatalogSourceConfigSpec{
@@ -253,16 +253,16 @@ func TestReconcile_CatalogSourceConfigAlreadyExists_Updated(t *testing.T) {
 	writer.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return("")
 
 	// Then we expect to call send refresh, because the package list was empty.
-	refresher.EXPECT().SendRefresh()
+	refresher.EXPECT().SendRefresh(gomock.Any())
 
 	packages := "a,b,c"
 	writer.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return(packages)
 
 	// Then we expect to read the packages
-	reader.EXPECT().CheckPackages(gomock.Any()).Return(nil)
+	reader.EXPECT().CheckPackages(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Then we expect a read to the datastore
-	reader.EXPECT().Read(gomock.Any()).Return(&datastore.OpsrcRef{}, nil).AnyTimes()
+	reader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(&datastore.OpsrcRef{}, nil).AnyTimes()
 
 	fakeclient := NewFakeClientWithChildResources(&appsv1.Deployment{}, &corev1.Service{}, &v1alpha1.CatalogSource{})
 
@@ -322,15 +322,15 @@ func TestReconcile_UpdateError_MovedToFailedPhase(t *testing.T) {
 	writer.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return("")
 
 	// Then we expect to call send refresh, because the package list was empty.
-	refresher.EXPECT().SendRefresh()
+	refresher.EXPECT().SendRefresh(gomock.Any())
 
 	writer.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID())
 
 	// Then we expect to read the packages
-	reader.EXPECT().CheckPackages(gomock.Any()).Return(nil)
+	reader.EXPECT().CheckPackages(gomock.Any(), gomock.Any()).Return(nil)
 
 	// Then we expect a read to the datastore
-	reader.EXPECT().Read(gomock.Any()).Return(&datastore.OpsrcRef{}, nil).AnyTimes()
+	reader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(&datastore.OpsrcRef{}, nil).AnyTimes()
 
 	kubeclient.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).Return(nil)
 	kubeclient.EXPECT().Update(context.TODO(), gomock.Any()).Return(updateError)

--- a/pkg/operatorsource/syncer.go
+++ b/pkg/operatorsource/syncer.go
@@ -33,7 +33,7 @@ type PackageUpdateNotificationSender interface {
 // blocking operation. When this notification is sent, all non datastore
 // catalogsourceconfigs check their version map in the status against the datastore.
 type PackageRefreshNotificationSender interface {
-	SendRefresh()
+	SendRefresh(opSrc string)
 }
 
 // RegistrySyncer is an interface that wraps the Sync method.

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -41,6 +41,7 @@ type registry struct {
 	log      *logrus.Entry
 	client   wrapper.Client
 	reader   datastore.Reader
+	source   string
 	packages string
 	key      types.NamespacedName
 	image    string
@@ -55,11 +56,12 @@ type Registry interface {
 }
 
 // NewRegistry returns an initialized instance of Registry
-func NewRegistry(log *logrus.Entry, client wrapper.Client, reader datastore.Reader, key types.NamespacedName, packages, image string) Registry {
+func NewRegistry(log *logrus.Entry, client wrapper.Client, reader datastore.Reader, key types.NamespacedName, source, packages, image string) Registry {
 	return &registry{
 		log:      log,
 		client:   client,
 		reader:   reader,
+		source:   source,
 		packages: packages,
 		key:      key,
 		image:    image,
@@ -250,7 +252,7 @@ func (r *registry) getLabel() map[string]string {
 func (r *registry) getAppRegistries() (appRegistries []string, secretIsPresent bool) {
 	packageIDs := v2.GetValidPackageSliceFromString(r.packages)
 	for _, packageID := range packageIDs {
-		opsrcMeta, err := r.reader.Read(packageID)
+		opsrcMeta, err := r.reader.Read(r.source, packageID)
 		if err != nil {
 			r.log.Errorf("Error %v reading package %s", err, packageID)
 			continue


### PR DESCRIPTION
This changes introduces logic that allows CSCs to specify a specific
OpSrc to pull the packages from::
* If a source is not specified in a CSC, marketplace will attempt to
  identify an OpSrc that contains all packages and will update the
  spec.source of the CSC to point to the OpSrc. If an appropriate
  OpSrc is not found, or if multiple OpSrcs could be selected,
  the CSC will be moved to the Configuring phase and alert the user.
* If a source is specified in a CSC but does not exist, the CSC will
  be moved to the Configuring phase and alert the user.
* If a source is specified but that OpSrc is missing packages, the
  CSC will be moved to the Configuring phase and alert the user about
  the missing packages.
* If a source is specified and contains all packages, the CSC will be
  reconciled appropriately.

This update also changes how CSC are updated as a result of an OpSrc
  sync:
* An OpSrc will include it's name in the notification that signals
  that packages need to be refreshed.
* The Trigger will check that the name CSC source matches the name of
  the OpSrc that sent the notification before refreshing its
  packages.