### PR TITLE
[csc][opsrc] Fix handling of Failed phase

### DIFF
--- a/pkg/catalogsourceconfig/factory.go
+++ b/pkg/catalogsourceconfig/factory.go
@@ -49,8 +49,9 @@ func (f *phaseReconcilerFactory) GetPhaseReconciler(log *logrus.Entry, csc *mark
 	// Check if the cache is stale. A stale cache entry is an indicator that the
 	// object has changed and requires updating. Only do this when the object has
 	// already been created (not in the initial phase) and when it is not already
-	// attempting to configure (which will populate the cache).
-	if csc.Status.CurrentPhase.Name != phase.Initial && csc.Status.CurrentPhase.Name != phase.Configuring {
+	// attempting to configure (which will populate the cache) or if it is in the
+	// failed state.
+	if csc.Status.CurrentPhase.Name != phase.Initial && csc.Status.CurrentPhase.Name != phase.Configuring && csc.Status.CurrentPhase.Name != phase.Failed {
 		pkgStale, targetStale := f.cache.IsEntryStale(csc)
 		if pkgStale || targetStale {
 			return NewUpdateReconciler(log, f.client, f.cache, targetStale), nil

--- a/pkg/operatorsource/outofsync.go
+++ b/pkg/operatorsource/outofsync.go
@@ -56,8 +56,8 @@ func (r *outOfSyncCacheReconciler) Reconcile(ctx context.Context, in *marketplac
 	// OperatorSource CR or the user dropped the status field of an existing CR.
 	// In either case, bail out and let the regular phased reconciler handle
 	// the specified OperatorSource object.
-	// If the OperatorSource object is in "Purging" phase, then return.
-	if currentPhase == phase.Initial || currentPhase == phase.OperatorSourcePurging {
+	// If the OperatorSource object is in "Purging" or "Failed" phase, then return.
+	if currentPhase == phase.Initial || currentPhase == phase.OperatorSourcePurging || currentPhase == phase.Failed {
 		return
 	}
 


### PR DESCRIPTION
Don't allow CRs to move out the Failed phase as it implies that manual
intervention is required.
- In the case of CatalogSourceConfigs, don't check if the cache is stale
- In the case of OperatorSources, don't check if it is out of sync