### PR TITLE
[e2e] Enable tests to run against minikube

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -54,3 +54,6 @@ e2e-test:
 
 e2e-job:
 	./scripts/run-e2e-job.sh
+
+e2e-test-minikube:
+	./scripts/e2e-tests.sh minikube

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -1,7 +1,12 @@
 #!/bin/bash
-set -e
+set -eu
 
-TEST_NAMESPACE="openshift-marketplace"
+ARG1=${1-}
+if [ "$ARG1" = "minikube" ]; then
+    TEST_NAMESPACE="marketplace"
+else
+    TEST_NAMESPACE="openshift-marketplace"
+fi
 
 # Run the tests through the operator-sdk
 echo "Running operator-sdk test"

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -15,6 +15,8 @@ import (
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 )
 
+var coAPINotPresent = true
+
 func TestMain(m *testing.M) {
 	test.MainEntry(m)
 }
@@ -24,7 +26,9 @@ func TestMarketplace(t *testing.T) {
 	initTestingFramework(t)
 
 	// Run Test Groups
-	t.Run("cluster-operator-status-test-group", testgroups.ClusterOperatorTestGroup)
+	if coAPINotPresent {
+		t.Run("cluster-operator-status-test-group", testgroups.ClusterOperatorTestGroup)
+	}
 	t.Run("operator-source-test-group", testgroups.OperatorSourceTestGroup)
 	t.Run("no-setup-test-group", testgroups.NoSetupTestGroup)
 }
@@ -74,8 +78,13 @@ func initTestingFramework(t *testing.T) {
 				configv1.SchemeGroupVersion.Group, configv1.SchemeGroupVersion.Version),
 		},
 	}
+
+	// We are assuming that ClusterOperator API will always be added successfully
+	// on an OpenShift cluster. This is to allow the tests be run on non-OpenSHift
+	// clusters
 	err = test.AddToFrameworkScheme(configv1.Install, clusterOperator)
 	if err != nil {
-		t.Fatalf("failed to add ClusterOperator custom resource scheme to framework: %v", err)
+		t.Logf("failed to add ClusterOperator custom resource scheme to framework: %v. ClusterOperator test will not run.", err)
+		coAPINotPresent = false
 	}
 }


### PR DESCRIPTION
- Add a new Makefile target for minikube
- Update e2e-tests.sh to accept an argument that will decide which namespace the marketplace operator is running in
- Only run the ClusterOperator test if the API can be added to the scheme