### PR TITLE
[e2e] Modularize waiting for opsrc creation

### DIFF
--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -2,6 +2,7 @@ package helpers
 
 import (
 	"context"
+	"strings"
 	"time"
 
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -99,6 +100,27 @@ func WaitForExpectedPhaseAndMessage(client test.FrameworkClient, cscName string,
 		}
 		return false, nil
 	})
+}
+
+// WaitForOpSrcExpectedPhaseAndMessage checks if a OperatorSource with the given name exists in the namespace
+// and makes sure that the phase and message matches the expected values.
+func WaitForOpSrcExpectedPhaseAndMessage(client test.FrameworkClient, opSrcName string, namespace string, expectedPhase string, expectedMessage string) error {
+	resultOperatorSource := &marketplace.OperatorSource{}
+	err := wait.Poll(RetryInterval, Timeout, func() (bool, error) {
+		err := WaitForResult(client, resultOperatorSource, namespace, opSrcName)
+		if err != nil {
+			return false, err
+		}
+		if resultOperatorSource.Status.CurrentPhase.Name == expectedPhase &&
+			strings.Contains(resultOperatorSource.Status.CurrentPhase.Message, expectedMessage) {
+			return true, nil
+		}
+		return false, nil
+	})
+	if err != nil {
+		return err
+	}
+	return nil
 }
 
 // WaitForNotFound polls the cluster for a particular resource name and namespace

--- a/test/testsuites/invalidopsrctests.go
+++ b/test/testsuites/invalidopsrctests.go
@@ -2,7 +2,6 @@ package testsuites
 
 import (
 	"fmt"
-	"strings"
 	"testing"
 
 	operator "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
@@ -11,7 +10,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/util/wait"
 )
 
 const (
@@ -64,19 +62,8 @@ func testOpSrcWithInvalidEndpoint(t *testing.T) {
 	require.NoError(t, err, "Could not create OperatorSource")
 
 	// Check that OperatorSource is in "Configuring" state with appropriate message
-	resultOperatorSource := &operator.OperatorSource{}
 	expectedPhase := "Configuring"
-	err = wait.Poll(helpers.RetryInterval, helpers.Timeout, func() (bool, error) {
-		err = helpers.WaitForResult(client, resultOperatorSource, namespace, opSrcName)
-		if err != nil {
-			return false, err
-		}
-		if resultOperatorSource.Status.CurrentPhase.Name == expectedPhase &&
-			strings.Contains(resultOperatorSource.Status.CurrentPhase.Message, "no such host") {
-			return true, nil
-		}
-		return false, nil
-	})
+	err = helpers.WaitForOpSrcExpectedPhaseAndMessage(client, opSrcName, namespace, expectedPhase, "no such host")
 	assert.NoError(t, err, fmt.Sprintf("OperatorSource never reached expected phase/message, expected %v", expectedPhase))
 }
 
@@ -115,19 +102,8 @@ func testOpSrcWithInvalidURL(t *testing.T) {
 	require.NoError(t, err, "Could not create OperatorSource")
 
 	// Check that OperatorSource reaches "Failed" state eventually
-	resultOperatorSource := &operator.OperatorSource{}
 	expectedPhase := "Failed"
-	err = wait.Poll(helpers.RetryInterval, helpers.Timeout, func() (bool, error) {
-		err = helpers.WaitForResult(client, resultOperatorSource, namespace, opSrcName)
-		if err != nil {
-			return false, err
-		}
-		if resultOperatorSource.Status.CurrentPhase.Name == expectedPhase &&
-			strings.Contains(resultOperatorSource.Status.CurrentPhase.Message, "Invalid OperatorSource endpoint") {
-			return true, nil
-		}
-		return false, nil
-	})
+	err = helpers.WaitForOpSrcExpectedPhaseAndMessage(client, opSrcName, namespace, expectedPhase, "Invalid OperatorSource endpoint")
 	assert.NoError(t, err, fmt.Sprintf("OperatorSource never reached expected phase/message, expected %v", expectedPhase))
 }
 
@@ -169,18 +145,7 @@ func testOpSrcWithNonexistentRegistryNamespace(t *testing.T) {
 	require.NoError(t, err, "Could not create OperatorSource")
 
 	// Check that OperatorSource reaches "Failed" state eventually
-	resultOperatorSource := &operator.OperatorSource{}
 	expectedPhase := "Failed"
-	err = wait.Poll(helpers.RetryInterval, helpers.Timeout, func() (bool, error) {
-		err = helpers.WaitForResult(client, resultOperatorSource, namespace, opSrcName)
-		if err != nil {
-			return false, err
-		}
-		if resultOperatorSource.Status.CurrentPhase.Name == expectedPhase &&
-			strings.Contains(resultOperatorSource.Status.CurrentPhase.Message, "The OperatorSource endpoint returned an empty manifest list") {
-			return true, nil
-		}
-		return false, nil
-	})
+	err = helpers.WaitForOpSrcExpectedPhaseAndMessage(client, opSrcName, namespace, expectedPhase, "The OperatorSource endpoint returned an empty manifest list")
 	assert.NoError(t, err, fmt.Sprintf("OperatorSource never reached expected phase/message, expected %v", expectedPhase))
 }


### PR DESCRIPTION
Add a helper function that waits for an OperatorSource to be created and reach the expected phase and message.