### PR TITLE
Bug 1717439: [status] Populate RelatedObjects

### DIFF
--- a/test/testsuites/clusteroperatorstatustests.go
+++ b/test/testsuites/clusteroperatorstatustests.go
@@ -7,6 +7,9 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
+	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,7 +18,8 @@ import (
 )
 
 // ClusterOperatorStatusOnStartup is a test suite that ensures the ClusterOperator resource which
-// defines the status of the marketplace operator has the correct status upon initialization
+// defines the status of the marketplace operator has the correct status upon initialization. It
+// also confirms that the ClusterOperator's RelatedObjects contains the expected list of objects.
 func ClusterOperatorStatusOnStartup(t *testing.T) {
 	ctx := test.NewTestCtx(t)
 	defer ctx.Cleanup()
@@ -53,4 +57,28 @@ func ClusterOperatorStatusOnStartup(t *testing.T) {
 		return true, nil
 	})
 	assert.NoError(t, err, "ClusterOperator never reached expected status")
+
+	// Check if the expected default ObjectReferences are present in RelatedObjects
+	expectedRelatedObjects := []configv1.ObjectReference{
+		{
+			Resource: "namespaces",
+			Name:     namespace,
+		},
+		{
+			Group:     v1.SchemeGroupVersion.Group,
+			Resource:  v1.OperatorSourceKind,
+			Namespace: namespace,
+		},
+		{
+			Group:     v2.SchemeGroupVersion.Group,
+			Resource:  v2.CatalogSourceConfigKind,
+			Namespace: namespace,
+		},
+		{
+			Group:     olm.GroupName,
+			Resource:  olm.CatalogSourceKind,
+			Namespace: namespace,
+		},
+	}
+	assert.ElementsMatch(t, result.Status.RelatedObjects, expectedRelatedObjects, "ClusterOperator did not list the exepcted RelatedObjects")
 }


### PR DESCRIPTION
**Problem:**
The must-gather tool is not able to gather enough information about the marketplace operator.
    
**Solution:**
The must-gather tool requires a field, RelatedObjects, in the ClusterOperator CR to be populated with ObjectReferences of the resources associated with the operator. This PR populates this field with the operator's namespace and the default OperatorSource/CatalogSourceConfig/CatalogSource resources.