### PR TITLE
[migration] Update Subs, remove stale CSC in live clusters

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -22,6 +22,14 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  verbs:
+  - get
+  - update
+  - list  
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/deploy/upstream/05_role.yaml
+++ b/deploy/upstream/05_role.yaml
@@ -13,6 +13,14 @@ rules:
   - delete
   - update
   - list
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  verbs:
+  - get
+  - update
+  - list
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -22,6 +22,14 @@ rules:
   - create
   - get
   - update
+- apiGroups:
+  - operators.coreos.com
+  resources:
+  - subscriptions
+  verbs:
+  - get
+  - update
+  - list
 ---
 kind: Role
 apiVersion: rbac.authorization.k8s.io/v1

--- a/pkg/apis/operators/v1/operatorsource_types.go
+++ b/pkg/apis/operators/v1/operatorsource_types.go
@@ -102,6 +102,11 @@ func (opsrc *OperatorSource) GetCurrentPhaseName() string {
 	return opsrc.Status.CurrentPhase.Name
 }
 
+// GetPackages returns the list of packages from the Status block
+func (opsrc *OperatorSource) GetPackages() []string {
+	return strings.Split(opsrc.Status.Packages, ",")
+}
+
 // IsEqual returns true if the Spec specified in this is the same as the other.
 // Otherwise, the function returns false.
 //

--- a/pkg/migrator/helper_test.go
+++ b/pkg/migrator/helper_test.go
@@ -1,0 +1,37 @@
+package migrator_test
+
+import (
+	"fmt"
+
+	v1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+)
+
+const (
+	TestInstalledCscName = "installed-community-openshift-marketplace"
+
+	TestDatastoreCatalogSourceName = "community-operators"
+
+	TestOpsrcName = "test-operators"
+
+	TestNameSpace = "openshift-marketplace"
+
+	TestOpsrcPackages = "foo,bar"
+)
+
+func helperNewOperatorSourceWithPackage(packages string) *v1.OperatorSource {
+	return &v1.OperatorSource{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: fmt.Sprintf("%s/%s",
+				v1.SchemeGroupVersion.Group, v1.SchemeGroupVersion.Version),
+			Kind: v1.OperatorSourceKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      TestOpsrcName,
+			Namespace: TestNameSpace,
+		},
+		Status: v1.OperatorSourceStatus{
+			Packages: packages,
+		},
+	}
+}

--- a/pkg/migrator/migrator.go
+++ b/pkg/migrator/migrator.go
@@ -1,0 +1,224 @@
+// Package migrator contains upgrade logic that's needed to upgrade a cluster from
+// openshift 4.1.x to openshift 4.2.0.
+package migrator
+
+import (
+	"context"
+	"fmt"
+	"strings"
+
+	"github.com/operator-framework/operator-marketplace/pkg/builders"
+
+	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
+	"github.com/sirupsen/logrus"
+	log "github.com/sirupsen/logrus"
+	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+)
+
+// NewMigrator returns a migrator that updates/cleans up existing/stale
+// resources, when a Openshift 4.1.x cluster is migrated to version 4.2.x.
+// In an openshift 4.1.x cluster, CatalogSourceConfigs were used in the
+// install flow of an operator, and the Subscriptions created during
+// installing operators were referencing the CatalogSources created by the
+// CatalogSourceConfigs(named Installed CatalogSources). In an openshift 4.2 cluster,
+// the operator installation flow has been changed, and CatalogSourceConfigs
+// are no longer used in the install flow. Instead the CatalogSources are
+// directly created by the OperatorSources(named DataStore CatalogSources).
+// The migrator updates existing Subscriptions that referenced Installed CatalogSources
+// during operator installation in an Openshift 4.1.x cluster, to reference
+// Datastore CatalogSources instead. The migrator also deletes the stale
+// CatalogSourceConfigs that were created during operator installation, and
+// the datastore CatalogSourceConfigs created by OperatorSources
+// in an Openshift 4.1.x cluster.
+func NewMigrator(client client.Client) migrator {
+	return migrator{
+		logger: log.NewEntry(log.New()),
+		client: client,
+	}
+}
+
+type migrator struct {
+	logger *logrus.Entry
+	client client.Client
+}
+
+// Migrate updates existing Subscriptions, deletes the CSCs installed during
+// operator installation as well the stale datastore CSCs when the cluster is
+// migrating from Openshift 4.1.x to Openshift 4.2.x
+func (m *migrator) Migrate(operatorNamespace string) {
+	installedCscs := m.updateSubscriptions()
+	m.deleteInstalledCscs(installedCscs, operatorNamespace)
+	m.deleteDatastoreCscs(operatorNamespace)
+}
+
+// updateSubscriptions updates the existing Subscriptions'
+// spec.source and spec.sourcenamespace fields. Existing
+// Subscriptions referenced installed CatalogSources, which
+// are updated to reference datastore CatalogSources
+// instead.
+func (m *migrator) updateSubscriptions() []types.NamespacedName {
+	var installedCscs []types.NamespacedName
+	options := &client.ListOptions{}
+	options.SetLabelSelector(fmt.Sprintf(builders.OwnerNameLabel))
+
+	subscriptions := &olm.SubscriptionList{}
+	// Get the list of existing Subscriptions that have the label "csc-owner-name"
+	err := m.client.List(context.TODO(), options, subscriptions)
+	if err != nil {
+		m.logger.Errorf(fmt.Sprintf("Client error: %s", err.Error()))
+		return []types.NamespacedName{}
+	}
+	for _, instance := range subscriptions.Items {
+		installedCscs = append(installedCscs, types.NamespacedName{Name: instance.GetLabels()[builders.OwnerNameLabel], Namespace: instance.GetLabels()[builders.OwnerNamespaceLabel]})
+		// try to infer the datastore CatalogSource from the Subscription
+		datastoreCs, err := findCatalogSource(&instance, m.client)
+		if k8s_errors.IsNotFound(err) {
+			// infer the CatalogSource from the OperatorSource that has the package
+			datastoreCs, err = findCsFromOpsrc(&instance, m.client)
+			if err != nil {
+				m.logger.Errorf("[migration] Could not infer datastore CatalogSource for Subscription %s.", instance.GetName())
+				continue
+			}
+		}
+		// update the Subscription to reference the datastore CatalogSource
+		instance.Spec.CatalogSource = datastoreCs.GetName()
+		instance.Spec.CatalogSourceNamespace = datastoreCs.GetNamespace()
+		err = m.client.Update(context.TODO(), &instance)
+		if err != nil {
+			m.logger.Errorf("[migration] Error updating subscription %s. Error: %s", instance.GetName(), err.Error())
+		} else {
+			m.logger.Infof("[migration] Successfully updated Subscription %s", instance.GetName())
+		}
+	}
+	return installedCscs
+}
+
+// deleteInstalledCscs deletes the CSCs installed during operator installation.
+// The child resources of the CSCs are delete by the finalizer.
+func (m *migrator) deleteInstalledCscs(cscs []types.NamespacedName, operatorNamespace string) {
+	for _, cscInfo := range cscs {
+		// If the CatalogSourceConfig namespace information is missing, try and find the
+		// CatalogSourceConfig in the marketplace-operator's namespace
+		if cscInfo.Namespace == "" {
+			cscInfo.Namespace = operatorNamespace
+		}
+		csc := newCatalogSourceConfig(cscInfo.Namespace, cscInfo.Name)
+		err := m.client.Delete(context.TODO(), csc)
+		if err != nil {
+			m.logger.Errorf("[migration] Failed to delete installed CSC %s with error: ", cscInfo.Name, err.Error())
+		} else {
+			m.logger.Infof("[migration] Stale CSC %s scheduled for deletion.", cscInfo.Name)
+		}
+	}
+}
+
+// deleteDatastoreCscs deletes the datastore CSCs created by OperatorSources.
+// The child resources of the CSCs are deleted by the finalizer.
+func (m *migrator) deleteDatastoreCscs(operatorNamespace string) {
+	options := &client.ListOptions{}
+	options.SetLabelSelector(fmt.Sprintf("opsrc-datastore: \"true\""))
+	options.InNamespace(operatorNamespace)
+	cscs := &v2.CatalogSourceConfigList{}
+	// Get the list of existing cscs that have the label "opsrc-datastore: "true" "
+	err := m.client.List(context.TODO(), options, cscs)
+	if err != nil {
+		m.logger.Errorf("Client error: %s", err.Error())
+		return
+	}
+	for _, csc := range cscs.Items {
+		err = m.client.Delete(context.TODO(), &csc)
+		if err != nil {
+			m.logger.Errorf("[migration] Failed to delete CatalogSourceConfig %s. Error: %s", csc.GetName(), err.Error())
+		} else {
+			m.logger.Infof("[migration] Datastore CSC %s scheduled for deletion.", csc.GetName())
+		}
+	}
+}
+
+// findCatalogSource infers the datastore CatalogSource created by the OperatorSource
+// in an Openshift 4.2.0 cluster. The inferred datastore CatalogSource will then be
+// referenced from an existing Subscription.
+func findCatalogSource(subscription *olm.Subscription, client client.Client) (*olm.CatalogSource, error) {
+	associatedCscName := subscription.GetLabels()[builders.OwnerNameLabel]
+	possibleCsName := ExtractCsName(associatedCscName)
+	possibleCsNamespace := subscription.GetLabels()[builders.OwnerNamespaceLabel]
+	// try and fetch the CatalogSource
+	datastoreCs := &olm.CatalogSource{}
+	namespacedName := types.NamespacedName{Name: possibleCsName, Namespace: possibleCsNamespace}
+	err := client.Get(context.TODO(), namespacedName, datastoreCs)
+	if err != nil {
+		return nil, err
+	}
+	return datastoreCs, nil
+}
+
+// findCsFromOpsrc extracts the packageName from a Subscription,
+// and finds the corresponding CatalogSource that the package belongs to.
+func findCsFromOpsrc(subscription *olm.Subscription, kubeClient client.Client) (*olm.CatalogSource, error) {
+	packageName := subscription.Spec.Package
+	opsrcs := &v1.OperatorSourceList{}
+	err := kubeClient.List(context.TODO(), &client.ListOptions{}, opsrcs)
+	if err != nil {
+		return nil, err
+	}
+	for _, instance := range opsrcs.Items {
+		if !IsPackageInOpsrc(packageName, &instance) {
+			continue
+		}
+		// fetch the CatalogSource with the same name
+		datastoreCs := &olm.CatalogSource{}
+		namespacedName := types.NamespacedName{Name: instance.GetName(), Namespace: instance.GetNamespace()}
+		err = kubeClient.Get(context.TODO(), namespacedName, datastoreCs)
+		if err != nil {
+			return nil, err
+		}
+		return datastoreCs, nil
+	}
+	return nil, nil
+}
+
+// IsPackageInOpsrc takes the name of a package, and an OperatorSource
+// as input, and returns true if the package is present in the OperatorSource's
+// status.Packages field
+func IsPackageInOpsrc(packageName string, opsrc *v1.OperatorSource) bool {
+	packages := opsrc.GetPackages()
+	for _, pkg := range packages {
+		if pkg == packageName {
+			return true
+		}
+	}
+	return false
+}
+
+// ExtractCsName takes the name of a CatalogSourceConfig
+// as input, and infers the name of the corresponding
+// datastore CatalogSource. Installed CSCs follow the
+// following naming pattern: installed-publisher-namespace.
+// For example, for a CatalogSourceConfig named
+// `installed-community-openshift-operators`, extractCsName
+// extracts `community` off the name, appends `operators`
+// to it, and returns `community-operators` as output
+func ExtractCsName(cscName string) string {
+	possibleCsName := strings.Split(cscName, "-")[1]
+	return fmt.Sprintf("%s-%s", possibleCsName, "operators")
+}
+
+// newCatalogSourceConfig returns a newly built CatalogSourceConfig
+func newCatalogSourceConfig(namespace, name string) *v2.CatalogSourceConfig {
+	return &v2.CatalogSourceConfig{
+		TypeMeta: metav1.TypeMeta{
+			APIVersion: fmt.Sprintf("%s/%s",
+				v1.SchemeGroupVersion.Group, v1.SchemeGroupVersion.Version),
+			Kind: v2.CatalogSourceConfigKind,
+		},
+		ObjectMeta: metav1.ObjectMeta{
+			Name:      name,
+			Namespace: namespace,
+		},
+	}
+}

--- a/pkg/migrator/migrator_test.go
+++ b/pkg/migrator/migrator_test.go
@@ -1,0 +1,26 @@
+package migrator_test
+
+import (
+	"github.com/operator-framework/operator-marketplace/pkg/migrator"
+	"github.com/stretchr/testify/assert"
+	"testing"
+)
+
+// TestMigrator_InfersDatastoreCatalogSource_Correctly tests if
+// ExtractCsName extracts the CatalogSource name from a given
+// CatalogSourceConfig name correctly
+func TestMigrator_InfersDatastoreCatalogSource_Correctly(t *testing.T) {
+	assert.Equal(t, migrator.ExtractCsName(TestInstalledCscName), TestDatastoreCatalogSourceName)
+}
+
+// TestMigrator_ReportsPackageInOpsrc_True tests if IsPackageInOpsrc
+// reports True if a given package is present in a given OperatorSource.
+func TestMigrator_ReportsPackageInOpsrc_True(t *testing.T) {
+	assert.True(t, migrator.IsPackageInOpsrc("foo", helperNewOperatorSourceWithPackage(TestOpsrcPackages)))
+}
+
+// TestMigrator_ReportsPackageInOpsrc_False tests if IsPackageInOpsrc
+// reports False if a given package is not present in a given OperatorSource.
+func TestMigrator_ReportsPackageInOpsrc_False(t *testing.T) {
+	assert.False(t, migrator.IsPackageInOpsrc("baz", helperNewOperatorSourceWithPackage(TestOpsrcPackages)))
+}

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -7,8 +7,8 @@ import (
 	configv1 "github.com/openshift/api/config/v1"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-marketplace/pkg/apis"
-	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
-	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
+	v1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	v2 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
 
 	"github.com/operator-framework/operator-marketplace/test/testgroups"
 	"github.com/operator-framework/operator-sdk/pkg/test"
@@ -32,6 +32,7 @@ func TestMarketplace(t *testing.T) {
 	}
 	t.Run("operator-source-test-group", testgroups.OperatorSourceTestGroup)
 	t.Run("no-setup-test-group", testgroups.NoSetupTestGroup)
+	t.Run("migration-test-group", testgroups.MigrationTestGroup)
 }
 
 // initTestingFramework adds the marketplace OperatorSource and CatalogSourceConfig types as well as the

--- a/test/testgroups/migrationtests.go
+++ b/test/testgroups/migrationtests.go
@@ -1,0 +1,46 @@
+package testgroups
+
+import (
+	"fmt"
+	"testing"
+
+	"github.com/operator-framework/operator-marketplace/test/helpers"
+	"github.com/operator-framework/operator-marketplace/test/testsuites"
+	"github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/stretchr/testify/require"
+)
+
+// MigrationTestGroup creates a Subscription, an installed  CatalogSourceConfig
+// and a datastore CatalogSourceConfig, restarts the marketplace operator so that
+// the Migrator is run again, and then runs a series of test suites.
+func MigrationTestGroup(t *testing.T) {
+	// Create a ctx that is used to delete the CatalogSourceConfigs and Subscription at the completion of this function.
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	// Get test namespace.
+	namespace, err := ctx.GetNamespace()
+	require.NoError(t, err, "Could not get namespace")
+
+	// Create the Subscription
+	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateSubscription(helpers.TestSubscriptionName, namespace))
+	require.NoError(t, err, "Could not create Subscription")
+
+	// Create the installed CatalogSourceConfig.
+	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateInstalledCsc(namespace))
+	require.NoError(t, err, "Could not create installed CatalogSourceConfig")
+
+	// Create the datastore CatalogSourceConfig.
+	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateDatastoreCsc(helpers.TestDatastoreCscName, namespace))
+	require.NoError(t, err, "Could not create datastore CatalogSourceConfig")
+	// Wait for the child resources to deploy successfully
+	err = helpers.CheckCscChildResourcesCreated(test.Global.Client, helpers.TestDatastoreCscName, namespace, namespace)
+	require.NoError(t, err, fmt.Sprintf("Could not ensure CatalogSourceConfig %s's child resources were created.", helpers.TestDatastoreCscName))
+
+	// Restart marketplace operator
+	err = helpers.RestartMarketplace(test.Global.Client, namespace)
+	require.NoError(t, err, "Could not restart marketplace operator")
+
+	// Run the test suites.
+	t.Run("migration-test-suite", testsuites.MigrationTests)
+}

--- a/test/testsuites/migrationtests.go
+++ b/test/testsuites/migrationtests.go
@@ -1,0 +1,60 @@
+package testsuites
+
+import (
+	"context"
+	"fmt"
+	"testing"
+
+	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/test/helpers"
+	"github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// MigrationTests is a test suite that ensures the following:
+// * All stale datastore CatalogSourceConfigs created by marketplace after the creation of
+// OperatorSources in a 4.1.x cluster are deleted when the cluster is migrated to openshift 4.2.0.
+// * Installed CatalogSourceConfigs created during operator installation in a 4.1 cluster are deleted.
+// * Existing Subscriptions are updated to reference the datastore CatalogSources instead
+// of installed CatalogSources created during operator installation in a openshift 4.1.x cluster.
+func MigrationTests(t *testing.T) {
+	t.Run("catalogsourceconfigs-are-cleaned-up", testCatalogSourceConfigsCleanedUp)
+	t.Run("subscriptions-are-updated", testSubscriptionsUpdated)
+}
+
+// testCatalogSourceConfigsCleanedUp ensures that after a cluster is migrated
+// from openshift 4.1.x to openshift 4.2.0, the following stale objects are cleaned up:
+// Stale CatalogSourceConfigs created during operator installation in a openshift 4.1.x cluster.
+// Datastore CatalogSourceConfigs created by OperatorSources in a openshift 4.1.x cluster.
+func testCatalogSourceConfigsCleanedUp(t *testing.T) {
+	// Get test namespace
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	require.NoError(t, err, "Could not get namespace")
+
+	// Check for successful deletion of datastore CSC.
+	err = helpers.CheckCscSuccessfulDeletion(test.Global.Client, helpers.TestDatastoreCscName, namespace, namespace)
+	require.NoError(t, err)
+
+	// Check for successful deletion of installed CSC.
+	installedCscName := helpers.TestInstalledCscPublisherName + namespace
+	err = helpers.CheckCscSuccessfulDeletion(test.Global.Client, installedCscName, namespace, namespace)
+	require.NoError(t, err)
+}
+
+// testSubscriptionsUpdated ensures that Subscriptions created during operator installation
+// in a openshift 4.1.x cluster are updated to reference the datastore CatalogSources.
+func testSubscriptionsUpdated(t *testing.T) {
+	// Get test namespace
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	require.NoError(t, err, "Could not get namespace")
+
+	// Check that the Subscription has been successfully updated on cluster upgrade
+	// from openshift 4.1.x to openshift 4.2.0 to reference the datastore CatalogSource,
+	// which has the same name as the datastore CatalogSourceConfig, instead of
+	// the Installed CatalogSource.
+	subscription := &olm.Subscription{}
+	err = test.Global.Client.Get(context.TODO(), types.NamespacedName{Name: helpers.TestSubscriptionName, Namespace: namespace}, subscription)
+	require.NoError(t, err, fmt.Sprintf("Could not get Subscription %s", helpers.TestSubscriptionName))
+	require.Equal(t, helpers.TestDatastoreCscName, subscription.Spec.CatalogSource)
+}


### PR DESCRIPTION
With #198 introducing a change in a way that a datastore CatalogSource
is directly created by an OperatorSource instead of a CatalogSourceConfig,
this PR performs some upgrade logic to update/cleanup existing/stale
resources in existing clusters. Specifically:
* Subscriptions with lables "csc-owner-name" and "csc-owner-namespace" are
updated to contain information about dataStore CatalogSources
* Stale datastore CatalogSourceConfigs created before #198 are deleted.
* Stale installed CatalogSourceConfigs created during operator installation
in old clusters are deleted.