### PR TITLE
Bug 1723672: Fix owner labels to specify Kind

### DIFF
--- a/pkg/builders/builders.go
+++ b/pkg/builders/builders.go
@@ -1,21 +1,45 @@
 package builders
 
-// OwnerNameLabel is the label used to mark ownership over a given resources.
-// When this label is set, the reconciler should handle these resources when the owner
-// is deleted.
-const OwnerNameLabel string = "csc-owner-name"
+import (
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
+)
 
-// OwnerNamespaceLabel is the label used to mark ownership over a given resources.
-// When this label is set, the reconciler should handle these resources when the owner
-// is deleted.
-const OwnerNamespaceLabel string = "csc-owner-namespace"
+// CscOwnerNameLabel is the label used to indicate the name of the CatalogSourceConfig
+// that owns this resources. When this label is set, the reconciler should handle these
+// resources when the CatalogSourceConfig is deleted.
+const CscOwnerNameLabel string = "csc-owner-name"
 
-// OpsrcOwnerNameLabel is the label used to mark ownership over resources
-// that are owned by the OperatorSource. When this label is set, the reconciler
-// should handle these resources when the OperatorSource is deleted.
+// CscOwnerNamespaceLabel is the label used to indicate the namespace of the CatalogSourceConfig
+// that owns this resources. When this label is set, the reconciler should handle these
+// resources when the CatalogSourceConfig is deleted.
+const CscOwnerNamespaceLabel string = "csc-owner-namespace"
+
+// OpsrcOwnerNameLabel is the label used to indicate the name of the OperatorSource
+// that owns this resources. When this label is set, the reconciler should handle these
+// resources when the OperatorSource is deleted.
 const OpsrcOwnerNameLabel string = "opsrc-owner-name"
 
-// OpsrcOwnerNamespaceLabel is the label used to mark ownership over resources
-// that are owned by the OperatorSource. When this label is set, the reconciler
-// should handle these resources when the OperatorSource is deleted.
+// OpsrcOwnerNamespaceLabel is the label used to indicate the namespace of the OperatorSource
+// that owns this resources. When this label is set, the reconciler should handle these
+// resources when the OperatorSource is deleted.
 const OpsrcOwnerNamespaceLabel string = "opsrc-owner-namespace"
+
+// GetOwnerLabel returns a map with either the CatalogSourceConfig or the OperatorSource owner
+// name and namespace labels depending what kind is the owner
+func GetOwnerLabel(name, namespace, owner string) map[string]string {
+	switch owner {
+	case v1.OperatorSourceKind:
+		return map[string]string{
+			OpsrcOwnerNameLabel:      name,
+			OpsrcOwnerNamespaceLabel: namespace,
+		}
+	case v2.CatalogSourceConfigKind:
+		return map[string]string{
+			CscOwnerNameLabel:      name,
+			CscOwnerNamespaceLabel: namespace,
+		}
+	default:
+		return map[string]string{}
+	}
+}

--- a/pkg/builders/catalogsourcebuilder.go
+++ b/pkg/builders/catalogsourcebuilder.go
@@ -61,13 +61,26 @@ func (b *CatalogSourceBuilder) WithOLMLabels(cscLabels map[string]string) *Catal
 	return b
 }
 
-// WithOwnerLabel sets the owner label of the CatalogSource object to the given owner.
-func (b *CatalogSourceBuilder) WithOwnerLabel(name, namespace string) *CatalogSourceBuilder {
+// WithOpsrcOwnerLabel sets the owner label of the CatalogSource object to the given owner.
+func (b *CatalogSourceBuilder) WithOpsrcOwnerLabel(name, namespace string) *CatalogSourceBuilder {
 	labels := map[string]string{
-		OwnerNameLabel:      name,
-		OwnerNamespaceLabel: namespace,
+		OpsrcOwnerNameLabel:      name,
+		OpsrcOwnerNamespaceLabel: namespace,
+	}
+	for key, value := range b.cs.GetLabels() {
+		labels[key] = value
 	}
 
+	b.cs.SetLabels(labels)
+	return b
+}
+
+// WithCscOwnerLabel sets the owner label of the CatalogSource object to the given owner.
+func (b *CatalogSourceBuilder) WithCscOwnerLabel(name, namespace string) *CatalogSourceBuilder {
+	labels := map[string]string{
+		CscOwnerNameLabel:      name,
+		CscOwnerNamespaceLabel: namespace,
+	}
 	for key, value := range b.cs.GetLabels() {
 		labels[key] = value
 	}

--- a/pkg/builders/deploymentbuilder.go
+++ b/pkg/builders/deploymentbuilder.go
@@ -36,13 +36,26 @@ func (b *DeploymentBuilder) WithMeta(name, namespace string) *DeploymentBuilder 
 	return b
 }
 
-// WithOwnerLabel sets the owner label of the Deployment object to the given owner.
-func (b *DeploymentBuilder) WithOwnerLabel(name, namespace string) *DeploymentBuilder {
+// WithOpsrcOwnerLabel sets the owner label of the Deployment object to the given owner.
+func (b *DeploymentBuilder) WithOpsrcOwnerLabel(name, namespace string) *DeploymentBuilder {
 	labels := map[string]string{
-		OwnerNameLabel:      name,
-		OwnerNamespaceLabel: namespace,
+		OpsrcOwnerNameLabel:      name,
+		OpsrcOwnerNamespaceLabel: namespace,
+	}
+	for key, value := range b.deployment.GetLabels() {
+		labels[key] = value
 	}
 
+	b.deployment.SetLabels(labels)
+	return b
+}
+
+// WithCscOwnerLabel sets the owner label of the Deployment object to the given owner.
+func (b *DeploymentBuilder) WithCscOwnerLabel(name, namespace string) *DeploymentBuilder {
+	labels := map[string]string{
+		CscOwnerNameLabel:      name,
+		CscOwnerNamespaceLabel: namespace,
+	}
 	for key, value := range b.deployment.GetLabels() {
 		labels[key] = value
 	}

--- a/pkg/builders/rolebindingbuilder.go
+++ b/pkg/builders/rolebindingbuilder.go
@@ -35,13 +35,26 @@ func (b *RoleBindingBuilder) WithMeta(name, namespace string) *RoleBindingBuilde
 	return b
 }
 
-// WithOwnerLabel sets the owner label of the RoleBinding object to the given owner.
-func (b *RoleBindingBuilder) WithOwnerLabel(name, namespace string) *RoleBindingBuilder {
+// WithOpsrcOwnerLabel sets the owner label of the RoleBinding object to the given owner.
+func (b *RoleBindingBuilder) WithOpsrcOwnerLabel(name, namespace string) *RoleBindingBuilder {
 	labels := map[string]string{
-		OwnerNameLabel:      name,
-		OwnerNamespaceLabel: namespace,
+		OpsrcOwnerNameLabel:      name,
+		OpsrcOwnerNamespaceLabel: namespace,
+	}
+	for key, value := range b.rb.GetLabels() {
+		labels[key] = value
 	}
 
+	b.rb.SetLabels(labels)
+	return b
+}
+
+// WithCscOwnerLabel sets the owner label of the RoleBinding object to the given owner.
+func (b *RoleBindingBuilder) WithCscOwnerLabel(name, namespace string) *RoleBindingBuilder {
+	labels := map[string]string{
+		CscOwnerNameLabel:      name,
+		CscOwnerNamespaceLabel: namespace,
+	}
 	for key, value := range b.rb.GetLabels() {
 		labels[key] = value
 	}

--- a/pkg/builders/rolebuilder.go
+++ b/pkg/builders/rolebuilder.go
@@ -35,13 +35,26 @@ func (b *RoleBuilder) WithMeta(name, namespace string) *RoleBuilder {
 	return b
 }
 
-// WithOwnerLabel sets the owner label of the Role object to the given owner.
-func (b *RoleBuilder) WithOwnerLabel(name, namespace string) *RoleBuilder {
+// WithOpsrcOwnerLabel sets the owner label of the Role object to the given owner.
+func (b *RoleBuilder) WithOpsrcOwnerLabel(name, namespace string) *RoleBuilder {
 	labels := map[string]string{
-		OwnerNameLabel:      name,
-		OwnerNamespaceLabel: namespace,
+		OpsrcOwnerNameLabel:      name,
+		OpsrcOwnerNamespaceLabel: namespace,
+	}
+	for key, value := range b.role.GetLabels() {
+		labels[key] = value
 	}
 
+	b.role.SetLabels(labels)
+	return b
+}
+
+// WithCscOwnerLabel sets the owner label of the Role object to the given owner.
+func (b *RoleBuilder) WithCscOwnerLabel(name, namespace string) *RoleBuilder {
+	labels := map[string]string{
+		CscOwnerNameLabel:      name,
+		CscOwnerNamespaceLabel: namespace,
+	}
 	for key, value := range b.role.GetLabels() {
 		labels[key] = value
 	}

--- a/pkg/builders/serviceaccountbuilder.go
+++ b/pkg/builders/serviceaccountbuilder.go
@@ -35,13 +35,26 @@ func (b *ServiceAccountBuilder) WithMeta(name, namespace string) *ServiceAccount
 	return b
 }
 
-// WithOwnerLabel sets the owner label of the ServiceAccount object to the given owner.
-func (b *ServiceAccountBuilder) WithOwnerLabel(name, namespace string) *ServiceAccountBuilder {
+// WithOpsrcOwnerLabel sets the owner label of the ServiceAccount object to the given owner.
+func (b *ServiceAccountBuilder) WithOpsrcOwnerLabel(name, namespace string) *ServiceAccountBuilder {
 	labels := map[string]string{
-		OwnerNameLabel:      name,
-		OwnerNamespaceLabel: namespace,
+		OpsrcOwnerNameLabel:      name,
+		OpsrcOwnerNamespaceLabel: namespace,
+	}
+	for key, value := range b.sa.GetLabels() {
+		labels[key] = value
 	}
 
+	b.sa.SetLabels(labels)
+	return b
+}
+
+// WithCscOwnerLabel sets the owner label of the ServiceAccount object to the given owner.
+func (b *ServiceAccountBuilder) WithCscOwnerLabel(name, namespace string) *ServiceAccountBuilder {
+	labels := map[string]string{
+		CscOwnerNameLabel:      name,
+		CscOwnerNamespaceLabel: namespace,
+	}
 	for key, value := range b.sa.GetLabels() {
 		labels[key] = value
 	}

--- a/pkg/builders/servicebuilder.go
+++ b/pkg/builders/servicebuilder.go
@@ -34,13 +34,26 @@ func (b *ServiceBuilder) WithMeta(name, namespace string) *ServiceBuilder {
 	return b
 }
 
-// WithOwnerLabel sets the owner label of the CatalogSource object to the given owner.
-func (b *ServiceBuilder) WithOwnerLabel(name, namespace string) *ServiceBuilder {
+// WithOpsrcOwnerLabel sets the owner label of the CatalogSource object to the given owner.
+func (b *ServiceBuilder) WithOpsrcOwnerLabel(name, namespace string) *ServiceBuilder {
 	labels := map[string]string{
-		OwnerNameLabel:      name,
-		OwnerNamespaceLabel: namespace,
+		OpsrcOwnerNameLabel:      name,
+		OpsrcOwnerNamespaceLabel: namespace,
+	}
+	for key, value := range b.service.GetLabels() {
+		labels[key] = value
 	}
 
+	b.service.SetLabels(labels)
+	return b
+}
+
+// WithCscOwnerLabel sets the owner label of the CatalogSource object to the given owner.
+func (b *ServiceBuilder) WithCscOwnerLabel(name, namespace string) *ServiceBuilder {
+	labels := map[string]string{
+		CscOwnerNameLabel:      name,
+		CscOwnerNamespaceLabel: namespace,
+	}
 	for key, value := range b.service.GetLabels() {
 		labels[key] = value
 	}

--- a/pkg/catalogsourceconfig/configuring.go
+++ b/pkg/catalogsourceconfig/configuring.go
@@ -84,7 +84,7 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v2.CatalogSou
 		Name:      in.Name,
 		Namespace: in.Namespace,
 	}
-	err = grpcCatalog.EnsureResources(key, in.Spec.DisplayName, in.Spec.Publisher, in.Spec.TargetNamespace, in.Spec.Source, in.Spec.Packages, in.Labels)
+	err = grpcCatalog.EnsureResources(key, in.Spec.DisplayName, in.Spec.Publisher, in.Spec.TargetNamespace, in.Spec.Source, in.Spec.Packages, v2.CatalogSourceConfigKind, in.Labels)
 	if err != nil {
 		nextPhase = phase.GetNextWithMessage(phase.Configuring, err.Error())
 		return

--- a/pkg/catalogsourceconfig/deleted.go
+++ b/pkg/catalogsourceconfig/deleted.go
@@ -62,7 +62,7 @@ func (r *deletedReconciler) Reconcile(ctx context.Context, in *v2.CatalogSourceC
 
 	// Delete all created resources
 	grpcCatalog := grpccatalog.New(r.logger, nil, r.client)
-	err = grpcCatalog.DeleteResources(ctx, in.Name, in.Namespace, in.Spec.TargetNamespace)
+	err = grpcCatalog.DeleteResources(ctx, in.Name, in.Namespace, in.Spec.TargetNamespace, v2.CatalogSourceConfigKind)
 
 	if err != nil {
 		// Something went wrong before we removed the finalizer, let's retry.

--- a/pkg/operatorsource/configuring.go
+++ b/pkg/operatorsource/configuring.go
@@ -126,7 +126,7 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1.OperatorSo
 	for key, value := range in.Labels {
 		labels[key] = value
 	}
-	err = grpcCatalog.EnsureResources(key, in.Spec.DisplayName, in.Spec.Publisher, in.Namespace, in.Name, packages, labels)
+	err = grpcCatalog.EnsureResources(key, in.Spec.DisplayName, in.Spec.Publisher, in.Namespace, in.Name, packages, v1.OperatorSourceKind, labels)
 	if err != nil {
 		nextPhase = phase.GetNextWithMessage(phase.Configuring, err.Error())
 		return

--- a/pkg/operatorsource/configuring_test.go
+++ b/pkg/operatorsource/configuring_test.go
@@ -14,7 +14,6 @@ import (
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/shared"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
 	"github.com/operator-framework/operator-marketplace/pkg/appregistry"
-	"github.com/operator-framework/operator-marketplace/pkg/builders"
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	mocks "github.com/operator-framework/operator-marketplace/pkg/mocks/operatorsource_mocks"
 	"github.com/operator-framework/operator-marketplace/pkg/operatorsource"
@@ -150,12 +149,10 @@ func TestReconcile_NotConfigured_NewCatalogConfigSourceObjectCreated(t *testing.
 	ctx := context.TODO()
 	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.Configuring)
 
-	labelsWant := map[string]string{
-		"opsrc-group":                     "Community",
-		builders.OpsrcOwnerNameLabel:      "foo",
-		builders.OpsrcOwnerNamespaceLabel: "marketplace",
+	labelsNeed := map[string]string{
+		"opsrc-group": "Community",
 	}
-	opsrcIn.SetLabels(labelsWant)
+	opsrcIn.SetLabels(labelsNeed)
 
 	optionsWant := appregistry.Options{Source: opsrcIn.Spec.Endpoint}
 	factory.EXPECT().New(optionsWant).Return(registryClient, nil).Times(1)
@@ -189,7 +186,7 @@ func TestReconcile_NotConfigured_NewCatalogConfigSourceObjectCreated(t *testing.
 	// Then we expect a read to the datastore
 	reader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(&datastore.OpsrcRef{}, nil).AnyTimes()
 
-	cscWant := helperNewCatalogSourceConfigWithLabels(opsrcIn.Namespace, opsrcIn.Name, labelsWant)
+	cscWant := helperNewCatalogSourceConfigWithLabels(opsrcIn.Namespace, opsrcIn.Name, labelsNeed)
 	cscWant.Spec = v2.CatalogSourceConfigSpec{
 		TargetNamespace: opsrcIn.Namespace,
 		Packages:        packages,
@@ -225,15 +222,13 @@ func TestReconcile_CatalogSourceConfigAlreadyExists_Updated(t *testing.T) {
 	ctx := context.TODO()
 	opsrcIn := helperNewOperatorSourceWithPhase(namespace, name, phase.Configuring)
 
-	labelsWant := map[string]string{
-		"opsrc-group":                     "Community",
-		builders.OpsrcOwnerNameLabel:      "foo",
-		builders.OpsrcOwnerNamespaceLabel: "marketplace",
-	}
-	opsrcIn.SetLabels(labelsWant)
-
 	optionsWant := appregistry.Options{Source: opsrcIn.Spec.Endpoint}
 	factory.EXPECT().New(optionsWant).Return(registryClient, nil).Times(1)
+
+	labelsNeed := map[string]string{
+		"opsrc-group": "Community",
+	}
+	opsrcIn.SetLabels(labelsNeed)
 
 	// We expect the remote registry to return a non-empty list of manifest(s).
 	manifestExpected := []*datastore.RegistryMetadata{

--- a/pkg/operatorsource/deleted.go
+++ b/pkg/operatorsource/deleted.go
@@ -64,7 +64,7 @@ func (r *deletedReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource
 	grpcCatalog := grpccatalog.New(r.logger, nil, r.client)
 
 	// Delete the owned registry resources.
-	err = grpcCatalog.DeleteResources(ctx, in.Name, in.Namespace, in.Namespace)
+	err = grpcCatalog.DeleteResources(ctx, in.Name, in.Namespace, in.Namespace, v1.OperatorSourceKind)
 
 	if err != nil {
 		// Something went wrong before we removed the finalizer, let's retry.

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -80,10 +80,10 @@ func WaitForSuccessfulDeployment(client test.FrameworkClient, deployment apps.De
 	})
 }
 
-// WaitForExpectedPhaseAndMessage checks if a CatalogSourceConfig with the given name exists in the namespace
+// WaitForCscExpectedPhaseAndMessage checks if a CatalogSourceConfig with the given name exists in the namespace
 // and makes sure that the phase and message matches the expected values.
 // If expectedMessage is an empty string, only the expectedPhase is checked.
-func WaitForExpectedPhaseAndMessage(client test.FrameworkClient, cscName string, namespace string, expectedPhase, expectedMessage string) error {
+func WaitForCscExpectedPhaseAndMessage(client test.FrameworkClient, cscName, namespace, expectedPhase, expectedMessage string) error {
 	// Check that the CatalogSourceConfig exists.
 	resultCatalogSourceConfig := &v2.CatalogSourceConfig{}
 	return wait.PollImmediate(RetryInterval, Timeout, func() (bool, error) {
@@ -105,7 +105,7 @@ func WaitForExpectedPhaseAndMessage(client test.FrameworkClient, cscName string,
 
 // WaitForOpSrcExpectedPhaseAndMessage checks if a OperatorSource with the given name exists in the namespace
 // and makes sure that the phase and message matches the expected values.
-func WaitForOpSrcExpectedPhaseAndMessage(client test.FrameworkClient, opSrcName string, namespace string, expectedPhase string, expectedMessage string) error {
+func WaitForOpSrcExpectedPhaseAndMessage(client test.FrameworkClient, opSrcName, namespace, expectedPhase, expectedMessage string) error {
 	resultOperatorSource := &v1.OperatorSource{}
 	err := wait.Poll(RetryInterval, Timeout, func() (bool, error) {
 		err := WaitForResult(client, resultOperatorSource, namespace, opSrcName)
@@ -179,7 +179,7 @@ func DeleteRuntimeObject(client test.FrameworkClient, obj runtime.Object) error 
 
 // CreateOperatorSourceDefinition returns an OperatorSource definition that can be turned into
 // a runtime object for tests that rely on an OperatorSource
-func CreateOperatorSourceDefinition(name string, namespace string) *v1.OperatorSource {
+func CreateOperatorSourceDefinition(name, namespace string) *v1.OperatorSource {
 	return &v1.OperatorSource{
 		TypeMeta: metav1.TypeMeta{
 			Kind: v1.OperatorSourceKind,
@@ -199,9 +199,9 @@ func CreateOperatorSourceDefinition(name string, namespace string) *v1.OperatorS
 	}
 }
 
-// CheckCscChildResourcesCreated checks that a CatalogSourceConfig's
+// CheckChildResourcesCreated checks that a CatalogSourceConfig's
 // child resources were deployed.
-func CheckCscChildResourcesCreated(client test.FrameworkClient, cscName string, namespace string, targetNamespace string) error {
+func CheckChildResourcesCreated(client test.FrameworkClient, cscName, namespace, targetNamespace string) error {
 	// Check that the CatalogSource was created.
 	resultCatalogSource := &olm.CatalogSource{}
 	err := WaitForResult(client, resultCatalogSource, targetNamespace, cscName)
@@ -231,9 +231,9 @@ func CheckCscChildResourcesCreated(client test.FrameworkClient, cscName string, 
 	return nil
 }
 
-// CheckCscChildResourcesDeleted checks that a CatalogSourceConfig's
+// CheckChildResourcesDeleted checks that a CatalogSourceConfig's
 // child resources were deleted.
-func CheckCscChildResourcesDeleted(client test.FrameworkClient, cscName string, namespace string, targetNamespace string) error {
+func CheckChildResourcesDeleted(client test.FrameworkClient, cscName, namespace, targetNamespace string) error {
 	// Check that the CatalogSource was deleted.
 	resultCatalogSource := &olm.CatalogSource{}
 	err := WaitForNotFound(client, resultCatalogSource, targetNamespace, cscName)
@@ -259,7 +259,7 @@ func CheckCscChildResourcesDeleted(client test.FrameworkClient, cscName string, 
 
 // CheckCscSuccessfulCreation checks that a CatalogSourceConfig
 // and it's child resources were deployed.
-func CheckCscSuccessfulCreation(client test.FrameworkClient, cscName string, namespace string, targetNamespace string) error {
+func CheckCscSuccessfulCreation(client test.FrameworkClient, cscName, namespace, targetNamespace string) error {
 	// Check that the CatalogSourceConfig was created.
 	resultCatalogSourceConfig := &v2.CatalogSourceConfig{}
 	err := WaitForResult(client, resultCatalogSourceConfig, namespace, cscName)
@@ -268,7 +268,7 @@ func CheckCscSuccessfulCreation(client test.FrameworkClient, cscName string, nam
 	}
 
 	// Check that all child resources were created.
-	err = CheckCscChildResourcesCreated(client, cscName, namespace, targetNamespace)
+	err = CheckChildResourcesCreated(client, cscName, namespace, targetNamespace)
 	if err != nil {
 		return err
 	}
@@ -278,7 +278,7 @@ func CheckCscSuccessfulCreation(client test.FrameworkClient, cscName string, nam
 
 // CheckCscSuccessfulDeletion checks that a CatalogSourceConfig
 // and it's child resources were deleted.
-func CheckCscSuccessfulDeletion(client test.FrameworkClient, cscName string, namespace string, targetNamespace string) error {
+func CheckCscSuccessfulDeletion(client test.FrameworkClient, cscName, namespace, targetNamespace string) error {
 	// Check that the CatalogSourceConfig was deleted.
 	resultCatalogSourceConfig := &v2.CatalogSourceConfig{}
 	err := WaitForNotFound(client, resultCatalogSourceConfig, namespace, cscName)
@@ -287,68 +287,10 @@ func CheckCscSuccessfulDeletion(client test.FrameworkClient, cscName string, nam
 	}
 
 	// Check that all child resources were deleted.
-	err = CheckCscChildResourcesDeleted(client, cscName, namespace, targetNamespace)
+	err = CheckChildResourcesDeleted(client, cscName, namespace, targetNamespace)
 	if err != nil {
 		return err
 	}
 
-	return nil
-}
-
-// CheckOpsrcChildResourcesCreated checks that a OperatorSource's
-// child resources were deployed.
-func CheckOpsrcChildResourcesCreated(client test.FrameworkClient, opsrcName string, namespace string) error {
-	// Check that the CatalogSource was created.
-	resultCatalogSource := &olm.CatalogSource{}
-	err := WaitForResult(client, resultCatalogSource, namespace, opsrcName)
-	if err != nil {
-		return err
-	}
-
-	// Check that the Service was created.
-	resultService := &corev1.Service{}
-	err = WaitForResult(client, resultService, namespace, opsrcName)
-	if err != nil {
-		return err
-	}
-
-	// Check that the Deployment was created.
-	resultDeployment := &apps.Deployment{}
-	err = WaitForResult(client, resultDeployment, namespace, opsrcName)
-	if err != nil {
-		return err
-	}
-
-	// Now check that the Deployment is ready.
-	err = WaitForSuccessfulDeployment(client, *resultDeployment)
-	if err != nil {
-		return err
-	}
-	return nil
-}
-
-// CheckOpsrcChildResourcesDeleted checks that an OperatorSource's
-// child resources were deleted.
-func CheckOpsrcChildResourcesDeleted(client test.FrameworkClient, opsrcName string, namespace string) error {
-	// Check that the CatalogSource was deleted.
-	resultCatalogSource := &olm.CatalogSource{}
-	err := WaitForNotFound(client, resultCatalogSource, namespace, opsrcName)
-	if err != nil {
-		return err
-	}
-
-	// Check that the Service was deleted.
-	resultService := &corev1.Service{}
-	err = WaitForNotFound(client, resultService, namespace, opsrcName)
-	if err != nil {
-		return err
-	}
-
-	// Check that the Deployment was deleted.
-	resultDeployment := &apps.Deployment{}
-	err = WaitForNotFound(client, resultDeployment, namespace, opsrcName)
-	if err != nil {
-		return err
-	}
 	return nil
 }

--- a/test/testsuites/csctargetnamespacetests.go
+++ b/test/testsuites/csctargetnamespacetests.go
@@ -74,7 +74,7 @@ func configuringStateWhenTargetNamespaceDoesNotExist(t *testing.T) {
 	// configuring phase with the expected message.
 	expectedPhase := "Configuring"
 	expectedMessage := fmt.Sprintf("namespaces \"%s\" not found", targetNamespace)
-	err = helpers.WaitForExpectedPhaseAndMessage(test.Global.Client, cscName, namespace, expectedPhase, expectedMessage)
+	err = helpers.WaitForCscExpectedPhaseAndMessage(test.Global.Client, cscName, namespace, expectedPhase, expectedMessage)
 	assert.NoError(t, err, fmt.Sprintf("CatalogSourceConfig never reached expected phase/message, expected %v/%v", expectedPhase, expectedMessage))
 }
 
@@ -88,7 +88,7 @@ func succeededStateAfterTargetNamespaceCreated(t *testing.T) {
 	// Now that the targetNamespace has been created, periodically check that the CatalogSourceConfig
 	// has reached the Succeeded phase.
 	expectedPhase := "Succeeded"
-	err = helpers.WaitForExpectedPhaseAndMessage(test.Global.Client, cscName, namespace, expectedPhase, "")
+	err = helpers.WaitForCscExpectedPhaseAndMessage(test.Global.Client, cscName, namespace, expectedPhase, "")
 	assert.NoError(t, err, fmt.Sprintf("CatalogSourceConfig never reached expected phase, expected %v", expectedPhase))
 }
 

--- a/test/testsuites/opsrccreationtests.go
+++ b/test/testsuites/opsrccreationtests.go
@@ -29,7 +29,7 @@ func testOperatorSourceGeneratesExpectedObjects(t *testing.T) {
 	require.NoError(t, err, "Could not get namespace")
 
 	// Check for child resources.
-	err = helpers.CheckOpsrcChildResourcesCreated(test.Global.Client, helpers.TestOperatorSourceName, namespace)
+	err = helpers.CheckChildResourcesCreated(test.Global.Client, helpers.TestOperatorSourceName, namespace, namespace)
 	require.NoError(t, err)
 
 	// Check that the CatalogSource has the expected labels.

--- a/test/testsuites/opsrccreationtests.go
+++ b/test/testsuites/opsrccreationtests.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-marketplace/test/helpers"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/assert"
@@ -29,7 +30,7 @@ func testOperatorSourceGeneratesExpectedObjects(t *testing.T) {
 	require.NoError(t, err, "Could not get namespace")
 
 	// Check for child resources.
-	err = helpers.CheckChildResourcesCreated(test.Global.Client, helpers.TestOperatorSourceName, namespace, namespace)
+	err = helpers.CheckChildResourcesCreated(test.Global.Client, helpers.TestOperatorSourceName, namespace, namespace, v1.OperatorSourceKind)
 	require.NoError(t, err)
 
 	// Check that the CatalogSource has the expected labels.

--- a/test/testsuites/opsrcdeletetests.go
+++ b/test/testsuites/opsrcdeletetests.go
@@ -33,7 +33,7 @@ func testDeleteOpSrc(t *testing.T) {
 	require.NoError(t, err, "Could not create OperatorSource.")
 
 	// Check for the child resources.
-	err = helpers.CheckOpsrcChildResourcesCreated(test.Global.Client, testOperatorSource.Name, namespace)
+	err = helpers.CheckChildResourcesCreated(test.Global.Client, testOperatorSource.Name, namespace, namespace)
 	require.NoError(t, err, "Could not ensure that child resources were created")
 
 	// Now let's delete the OperatorSource
@@ -42,6 +42,6 @@ func testDeleteOpSrc(t *testing.T) {
 
 	// Now let's wait until the OperatorSource is successfully deleted and the
 	// child resources are removed.
-	err = helpers.CheckOpsrcChildResourcesDeleted(test.Global.Client, testOperatorSource.Name, namespace)
+	err = helpers.CheckChildResourcesDeleted(test.Global.Client, testOperatorSource.Name, namespace, namespace)
 	require.NoError(t, err, "Could not ensure child resources were deleted.")
 }

--- a/test/testsuites/opsrcdeletetests.go
+++ b/test/testsuites/opsrcdeletetests.go
@@ -3,6 +3,7 @@ package testsuites
 import (
 	"testing"
 
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-marketplace/test/helpers"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/require"
@@ -33,7 +34,7 @@ func testDeleteOpSrc(t *testing.T) {
 	require.NoError(t, err, "Could not create OperatorSource.")
 
 	// Check for the child resources.
-	err = helpers.CheckChildResourcesCreated(test.Global.Client, testOperatorSource.Name, namespace, namespace)
+	err = helpers.CheckChildResourcesCreated(test.Global.Client, testOperatorSource.Name, namespace, namespace, v1.OperatorSourceKind)
 	require.NoError(t, err, "Could not ensure that child resources were created")
 
 	// Now let's delete the OperatorSource

--- a/test/testsuites/packagestests.go
+++ b/test/testsuites/packagestests.go
@@ -7,6 +7,7 @@ import (
 
 	"github.com/stretchr/testify/assert"
 
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
 	"github.com/operator-framework/operator-marketplace/test/helpers"
 	"github.com/operator-framework/operator-sdk/pkg/test"
@@ -108,7 +109,7 @@ func testOpSrcWithIdenticalPackages(t *testing.T) {
 	assert.NoError(t, err, "Could not create operator source")
 
 	// Check that the child resources were created.
-	err = helpers.CheckChildResourcesCreated(client, opSrcName, namespace, namespace)
+	err = helpers.CheckChildResourcesCreated(client, opSrcName, namespace, namespace, v1.OperatorSourceKind)
 	assert.NoError(t, err)
 
 	t.Run("resolved-multiple-sources", resolvedMultipleSources)

--- a/test/testsuites/packagestests.go
+++ b/test/testsuites/packagestests.go
@@ -71,7 +71,7 @@ func configuringStateWhenPackageNameDoesNotExist(t *testing.T) {
 	// configuring phase with the expected message
 	expectedPhase := "Configuring"
 	expectedMessage := fmt.Sprintf("Unable to resolve the source - no source contains the requested package(s) [%s]", nonExistingPackageName)
-	err = helpers.WaitForExpectedPhaseAndMessage(test.Global.Client, cscName, namespace, expectedPhase, expectedMessage)
+	err = helpers.WaitForCscExpectedPhaseAndMessage(test.Global.Client, cscName, namespace, expectedPhase, expectedMessage)
 	assert.NoError(t, err, fmt.Sprintf("CatalogSourceConfig never reached expected phase/message, expected %v/%v", expectedPhase, expectedMessage))
 }
 
@@ -83,7 +83,7 @@ func childResourcesNotCreated(t *testing.T) {
 	require.NoError(t, err, "Could not get namespace")
 
 	// Check that the CatalogSourceConfig's child resources were not created.
-	err = helpers.CheckCscChildResourcesDeleted(test.Global.Client, cscName, namespace, namespace)
+	err = helpers.CheckChildResourcesDeleted(test.Global.Client, cscName, namespace, namespace)
 	assert.NoError(t, err, "Child resources of CatalogSourceConfig were unexpectedly created")
 }
 
@@ -108,7 +108,7 @@ func testOpSrcWithIdenticalPackages(t *testing.T) {
 	assert.NoError(t, err, "Could not create operator source")
 
 	// Check that the child resources were created.
-	err = helpers.CheckOpsrcChildResourcesCreated(client, opSrcName, namespace)
+	err = helpers.CheckChildResourcesCreated(client, opSrcName, namespace, namespace)
 	assert.NoError(t, err)
 
 	t.Run("resolved-multiple-sources", resolvedMultipleSources)
@@ -223,7 +223,7 @@ func runSourceTest(namespace, source, packages, expectedPhase, expectedMessage s
 
 	// Check that the CatalogSourceConfig with an non-existing targetNamespace eventually reaches the
 	// configuring phase with the expected message.
-	err = helpers.WaitForExpectedPhaseAndMessage(test.Global.Client, cscName, namespace, expectedPhase, expectedMessage)
+	err = helpers.WaitForCscExpectedPhaseAndMessage(test.Global.Client, cscName, namespace, expectedPhase, expectedMessage)
 	if err != nil {
 		return err
 	}


### PR DESCRIPTION
Currently there is no way to determine the Kind that owns a given
resource the operator creates. This commit propagates information
about the Kind to the label creation function in the each resource
builder. It also update the deletion function to use these updated
labels as labelSelectors.