### PR TITLE
Bug 1717509: [status] Populate RelatedObjects

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -9,9 +9,11 @@ import (
 	configclient "github.com/openshift/client-go/config/clientset/versioned/typed/config/v1"
 	cohelpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	operatorhelpers "github.com/openshift/library-go/pkg/operator/v1helpers"
+	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	log "github.com/sirupsen/logrus"
 	apierrors "k8s.io/apimachinery/pkg/api/errors"
-	"k8s.io/apimachinery/pkg/apis/meta/v1"
+	metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 	"k8s.io/client-go/discovery"
 	"k8s.io/client-go/kubernetes"
@@ -156,7 +158,7 @@ func new(cfg *rest.Config, mgr manager.Manager, namespace string, version string
 // cluster
 func (s *status) ensureClusterOperator() error {
 	var err error
-	s.clusterOperator, err = s.configClient.ClusterOperators().Get(clusterOperatorName, v1.GetOptions{})
+	s.clusterOperator, err = s.configClient.ClusterOperators().Get(clusterOperatorName, metav1.GetOptions{})
 
 	if err == nil {
 		log.Debug("[status] Found existing ClusterOperator")
@@ -167,12 +169,15 @@ func (s *status) ensureClusterOperator() error {
 		return fmt.Errorf("Error %v getting ClusterOperator", err)
 	}
 
-	s.clusterOperator, err = s.configClient.ClusterOperators().Create(&configv1.ClusterOperator{
-		ObjectMeta: v1.ObjectMeta{
+	clusterOperator := &configv1.ClusterOperator{
+		ObjectMeta: metav1.ObjectMeta{
 			Name:      clusterOperatorName,
 			Namespace: s.namespace,
 		},
-	})
+	}
+	s.setRelatedObjects()
+
+	s.clusterOperator, err = s.configClient.ClusterOperators().Create(clusterOperator)
 	if err != nil {
 		return fmt.Errorf("Error %v creating ClusterOperator", err)
 	}
@@ -242,6 +247,9 @@ func (s *status) updateStatus(previousStatus *configv1.ClusterOperatorStatus) er
 			}
 		}
 
+		// Always update RelatedObjects to account for the upgrade case.
+		s.setRelatedObjects()
+
 		_, err := s.configClient.ClusterOperators().UpdateStatus(s.clusterOperator)
 		if err != nil {
 			return fmt.Errorf("Error %v updating ClusterOperator", err)
@@ -253,6 +261,36 @@ func (s *status) updateStatus(previousStatus *configv1.ClusterOperatorStatus) er
 		}
 	}
 	return err
+}
+
+// setRelatedObjects populates RelatedObjects in the ClusterOperator.Status.
+// RelatedObjects are consumed by https://github.com/openshift/must-gather
+func (s *status) setRelatedObjects() {
+	objectReferences := []configv1.ObjectReference{
+		// Add the operator's namespace which will result in core resources
+		// being gathered
+		{
+			Resource: "namespaces",
+			Name:     s.namespace,
+		},
+		// Add the non-core resources we care about
+		{
+			Group:     v1.SchemeGroupVersion.Group,
+			Resource:  v1.OperatorSourceKind,
+			Namespace: s.namespace,
+		},
+		{
+			Group:     v1.SchemeGroupVersion.Group,
+			Resource:  v1.CatalogSourceConfigKind,
+			Namespace: s.namespace,
+		},
+		{
+			Group:     olm.GroupName,
+			Resource:  olm.CatalogSourceKind,
+			Namespace: s.namespace,
+		},
+	}
+	s.clusterOperator.Status.RelatedObjects = objectReferences
 }
 
 // syncChannelReceiver will listen on the sync channel and update the status

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	configv1 "github.com/openshift/api/config/v1"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-marketplace/pkg/apis"
 	marketplace "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
@@ -23,6 +24,7 @@ func TestMarketplace(t *testing.T) {
 	initTestingFramework(t)
 
 	// Run Test Groups
+	t.Run("cluster-operator-status-test-group", testgroups.ClusterOperatorTestGroup)
 	t.Run("operator-source-test-group", testgroups.OperatorSourceTestGroup)
 	t.Run("no-setup-test-group", testgroups.NoSetupTestGroup)
 }
@@ -63,5 +65,17 @@ func initTestingFramework(t *testing.T) {
 	err = test.AddToFrameworkScheme(olm.AddToScheme, catalogSource)
 	if err != nil {
 		t.Fatalf("failed to add CatalogSource custom resource scheme to framework: %v", err)
+	}
+	// Add (configv1) ClusterOperator to framework scheme
+	clusterOperator := &configv1.ClusterOperator{
+		TypeMeta: metav1.TypeMeta{
+			Kind: "ClusterOperator",
+			APIVersion: fmt.Sprintf("%s/%s",
+				configv1.SchemeGroupVersion.Group, configv1.SchemeGroupVersion.Version),
+		},
+	}
+	err = test.AddToFrameworkScheme(configv1.Install, clusterOperator)
+	if err != nil {
+		t.Fatalf("failed to add ClusterOperator custom resource scheme to framework: %v", err)
 	}
 }

--- a/test/testgroups/clusteroperatortests.go
+++ b/test/testgroups/clusteroperatortests.go
@@ -1,0 +1,13 @@
+package testgroups
+
+import (
+	"testing"
+
+	"github.com/operator-framework/operator-marketplace/test/testsuites"
+)
+
+// ClusterOperatorTestGroup runs test suites that check the status of the Cluster Operator
+func ClusterOperatorTestGroup(t *testing.T) {
+	// Run the test suites.
+	t.Run("cluster-operator-status-on-startup-test-suite", testsuites.ClusterOperatorStatusOnStartup)
+}

--- a/test/testsuites/clusteroperatorstatustests.go
+++ b/test/testsuites/clusteroperatorstatustests.go
@@ -1,0 +1,56 @@
+package testsuites
+
+import (
+	"context"
+	"fmt"
+	"testing"
+	"time"
+
+	configv1 "github.com/openshift/api/config/v1"
+	"github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"k8s.io/apimachinery/pkg/types"
+	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+// ClusterOperatorStatusOnStartup is a test suite that ensures the ClusterOperator resource which
+// defines the status of the marketplace operator has the correct status upon initialization
+func ClusterOperatorStatusOnStartup(t *testing.T) {
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	// Get global framework variables.
+	client := test.Global.Client
+
+	// Get namespace
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	require.NoError(t, err, "Could not get namespace")
+
+	// Check that the ClusterOperator resource has the correct status
+	clusterOperatorName := "marketplace"
+	expectedTypeStatus := map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{
+		configv1.OperatorProgressing: configv1.ConditionFalse,
+		configv1.OperatorAvailable:   configv1.ConditionTrue,
+		configv1.OperatorDegraded:    configv1.ConditionFalse}
+
+	// Poll to ensure ClusterOperator is present and has the correct status
+	// i.e. ConditionType has a ConditionStatus matching expectedTypeStatus
+	namespacedName := types.NamespacedName{Name: clusterOperatorName, Namespace: namespace}
+	result := &configv1.ClusterOperator{}
+	RetryInterval := time.Second * 5
+	Timeout := time.Minute * 5
+	err = wait.PollImmediate(RetryInterval, Timeout, func() (done bool, err error) {
+		err = client.Get(context.TODO(), namespacedName, result)
+		if err != nil {
+			return false, err
+		}
+		for _, condition := range result.Status.Conditions {
+			if expectedTypeStatus[condition.Type] != condition.Status {
+				return false, fmt.Errorf("Expecting condition type %v of status %v but got %v", condition.Type, expectedTypeStatus[condition.Type], condition.Status)
+			}
+		}
+		return true, nil
+	})
+	assert.NoError(t, err, "ClusterOperator never reached expected status")
+}

--- a/test/testsuites/clusteroperatorstatustests.go
+++ b/test/testsuites/clusteroperatorstatustests.go
@@ -7,6 +7,8 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
+	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -15,7 +17,8 @@ import (
 )
 
 // ClusterOperatorStatusOnStartup is a test suite that ensures the ClusterOperator resource which
-// defines the status of the marketplace operator has the correct status upon initialization
+// defines the status of the marketplace operator has the correct status upon initialization. It
+// also confirms that the ClusterOperator's RelatedObjects contains the expected list of objects.
 func ClusterOperatorStatusOnStartup(t *testing.T) {
 	ctx := test.NewTestCtx(t)
 	defer ctx.Cleanup()
@@ -53,4 +56,28 @@ func ClusterOperatorStatusOnStartup(t *testing.T) {
 		return true, nil
 	})
 	assert.NoError(t, err, "ClusterOperator never reached expected status")
+
+	// Check if the expected default ObjectReferences are present in RelatedObjects
+	expectedRelatedObjects := []configv1.ObjectReference{
+		{
+			Resource: "namespaces",
+			Name:     namespace,
+		},
+		{
+			Group:     v1.SchemeGroupVersion.Group,
+			Resource:  v1.OperatorSourceKind,
+			Namespace: namespace,
+		},
+		{
+			Group:     v1.SchemeGroupVersion.Group,
+			Resource:  v1.CatalogSourceConfigKind,
+			Namespace: namespace,
+		},
+		{
+			Group:     olm.GroupName,
+			Resource:  olm.CatalogSourceKind,
+			Namespace: namespace,
+		},
+	}
+	assert.ElementsMatch(t, result.Status.RelatedObjects, expectedRelatedObjects, "ClusterOperator did not list the exepcted RelatedObjects")
 }


### PR DESCRIPTION
Problem:
The must-gather tool is not able to gather enough information about the marketplace operator.

Solution:
The must-gather tool requires a field, RelatedObjects, in the ClusterOperator CR to be populated with ObjectReferences of the resources associated with the operator. This PR populates this field with the operator's namespace and the OperatorSource/CatalogSourceConfig/CatalogSource resources in the same namespace.

Reason for inclusion in 4.1.z:
Without having the RelatedObjects in the ClusterOperator CR, the CEE team will not be able to use the must-gather tool to collect information about the marketplace operator from customer. This makes it hard for them to provide engineering with enough information about issues found on production clusters. Having this fix in 4.1 will resolve this issue 

(based on #186, #205)