### PR TITLE
[e2e] Remove hardcoded namespace

### DIFF
--- a/test/testsuites/packagestests.go
+++ b/test/testsuites/packagestests.go
@@ -199,7 +199,7 @@ func runSourceTest(namespace, source, packages, expectedPhase, expectedMessage s
 	// Get global framework variables.
 	client := test.Global.Client
 
-	// Create a new CatalogSourceConfig with a non-existing targetNamespace.
+	// Create a new CatalogSourceConfig.
 	csc := &v2.CatalogSourceConfig{
 		TypeMeta: metav1.TypeMeta{
 			Kind: v2.CatalogSourceConfigKind,
@@ -209,7 +209,7 @@ func runSourceTest(namespace, source, packages, expectedPhase, expectedMessage s
 		},
 		Spec: v2.CatalogSourceConfigSpec{
 			Source:          source,
-			TargetNamespace: "openshift-marketplace",
+			TargetNamespace: namespace,
 			Packages:        packages,
 		}}
 


### PR DESCRIPTION
Problem: One of the e2e tests create a CatalogSourceConfig in the openshift-marketplace namespace. This breaks e2e tests on vanilla kubernetes.

Solution: Replace the hardcoded namespace with the namespace that the e2e-tests are being ran in.