### PR TITLE
Bug 1721537: Fix degraded status on upgrade

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"context"
 	"flag"
 	"net/http"
 	"os"
@@ -16,6 +17,7 @@ import (
 	"github.com/operator-framework/operator-marketplace/pkg/registry"
 	"github.com/operator-framework/operator-marketplace/pkg/status"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
+	"github.com/operator-framework/operator-sdk/pkg/leader"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
 	log "github.com/sirupsen/logrus"
 	_ "k8s.io/client-go/plugin/pkg/client/auth/gcp"
@@ -88,6 +90,15 @@ func main() {
 		w.WriteHeader(http.StatusOK)
 	})
 	go http.ListenAndServe(":8080", nil)
+
+	// Wait until this instance becomes the leader.
+	log.Info("Waiting to become leader.")
+	err = leader.Become(context.TODO(), "marketplace-operator-lock")
+	if err != nil {
+		log.Error(err, "Failed to retry for leader lock")
+		os.Exit(1)
+	}
+	log.Info("Elected leader.")
 
 	log.Print("Starting the Cmd.")
 	stopCh := signals.SetupSignalHandler()

--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -55,6 +55,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "marketplace-operator"
             - name: "RELEASE_VERSION"

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -63,6 +63,19 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/deploy/upstream/05_role.yaml
+++ b/deploy/upstream/05_role.yaml
@@ -54,6 +54,19 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/deploy/upstream/08_operator.yaml
+++ b/deploy/upstream/08_operator.yaml
@@ -40,5 +40,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "marketplace-operator"

--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -63,6 +63,19 @@ rules:
   - list
   - watch
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/manifests/10_operator.yaml
+++ b/manifests/10_operator.yaml
@@ -55,6 +55,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "marketplace-operator"
             - name: "RELEASE_VERSION"

--- a/pkg/catalogsourceconfig/handler.go
+++ b/pkg/catalogsourceconfig/handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
+	operatorstatus "github.com/operator-framework/operator-marketplace/pkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -72,6 +73,9 @@ func (h *catalogsourceconfighandler) Handle(ctx context.Context, in *v2.CatalogS
 	// case, we need to update the modified CatalogSourceConfig object.
 	if updateErr := h.client.Update(ctx, out); updateErr != nil {
 		log.Errorf("Failed to update object - %v", updateErr)
+
+		// Error updating the object - report a failed sync.
+		operatorstatus.SendSyncMessage(updateErr)
 
 		if err == nil {
 			// No reconciliation err, but update of object has failed!

--- a/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
+++ b/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
@@ -84,16 +84,9 @@ func (r *ReconcileCatalogSourceConfig) Reconcile(request reconcile.Request) (rec
 	// Reconcile kicked off, message Sync Channel
 	status.SendSyncMessage(nil)
 
-	// If err is not nil at the end of this function message the syncCh channel
-	var err error
-	defer func() {
-		if err != nil {
-			status.SendSyncMessage(err)
-		}
-	}()
 	// Fetch the CatalogSourceConfig instance
 	instance := &v2.CatalogSourceConfig{}
-	err = r.client.Get(context.TODO(), request.NamespacedName, instance)
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -101,7 +94,8 @@ func (r *ReconcileCatalogSourceConfig) Reconcile(request reconcile.Request) (rec
 			// Return and don't requeue
 			return reconcile.Result{}, nil
 		}
-		// Error reading the object - requeue the request.
+		// Error reading the object - report a failed sync and requeue the request.
+		status.SendSyncMessage(err)
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/operatorsource/operatorsource_controller.go
+++ b/pkg/controller/operatorsource/operatorsource_controller.go
@@ -67,16 +67,9 @@ func (r *ReconcileOperatorSource) Reconcile(request reconcile.Request) (reconcil
 	// Reconcile kicked off, message Sync Channel with sync event
 	status.SendSyncMessage(nil)
 
-	// If err is not nil at the end of this function message the syncCh channel
-	var err error
-	defer func() {
-		if err != nil {
-			status.SendSyncMessage(err)
-		}
-	}()
 	// Fetch the OperatorSource instance
 	instance := &v1.OperatorSource{}
-	err = r.client.Get(context.TODO(), request.NamespacedName, instance)
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -84,7 +77,8 @@ func (r *ReconcileOperatorSource) Reconcile(request reconcile.Request) (reconcil
 			// Return and don't requeue
 			return reconcile.Result{}, nil
 		}
-		// Error reading the object - requeue the request.
+		// Error reading the object - report a failed sync and requeue the request.
+		status.SendSyncMessage(err)
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/operatorsource/handler.go
+++ b/pkg/operatorsource/handler.go
@@ -8,6 +8,7 @@ import (
 	"github.com/operator-framework/operator-marketplace/pkg/appregistry"
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
+	"github.com/operator-framework/operator-marketplace/pkg/status"
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -110,6 +111,9 @@ func (h *operatorsourcehandler) transition(ctx context.Context, logger *log.Entr
 	// In either case, we need to update the modified OperatorSource object.
 	if updateErr := h.client.Update(ctx, opsrc); updateErr != nil {
 		logger.Errorf("Failed to update object - %v", updateErr)
+
+		// Error updating the object - report a failed sync.
+		status.SendSyncMessage(updateErr)
 
 		if reconciliationErr == nil {
 			// No reconciliation err, but update of object has failed!

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -331,9 +331,8 @@ func (s *status) monitorClusterStatus() {
 	for {
 		select {
 		case <-s.stopCh:
-			// If the stopCh is closed, the operator will exit and CO should
-			// be set to degraded.
-			msg := "The operator has exited and is no longer reporting status."
+			// If the stopCh is closed, set all ClusterOperatorStatus conditions to false.
+			msg := "The operator has exited"
 			conditionListBuilder := clusterStatusListBuilder()
 			conditionListBuilder(configv1.OperatorProgressing, configv1.ConditionFalse, msg)
 			conditionListBuilder(configv1.OperatorAvailable, configv1.ConditionFalse, msg)

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -332,11 +332,12 @@ func (s *status) monitorClusterStatus() {
 		select {
 		case <-s.stopCh:
 			// If the stopCh is closed, set all ClusterOperatorStatus conditions to false.
+			reason := "OperatorExited"
 			msg := "The operator has exited"
 			conditionListBuilder := clusterStatusListBuilder()
-			conditionListBuilder(configv1.OperatorProgressing, configv1.ConditionFalse, msg)
-			conditionListBuilder(configv1.OperatorAvailable, configv1.ConditionFalse, msg)
-			statusConditions := conditionListBuilder(configv1.OperatorDegraded, configv1.ConditionFalse, msg)
+			conditionListBuilder(configv1.OperatorProgressing, configv1.ConditionFalse, msg, reason)
+			conditionListBuilder(configv1.OperatorAvailable, configv1.ConditionFalse, msg, reason)
+			statusConditions := conditionListBuilder(configv1.OperatorDegraded, configv1.ConditionFalse, msg, reason)
 			statusErr := s.setStatus(statusConditions)
 			if statusErr != nil {
 				log.Error("[status] " + statusErr.Error())
@@ -356,11 +357,12 @@ func (s *status) monitorClusterStatus() {
 			// Create the ClusterOperator in the progressing state if it does not exist
 			// or if it is the first report.
 			if s.clusterOperator == nil {
+				reason := "OperatorStarting"
 				conditionListBuilder := clusterStatusListBuilder()
-				conditionListBuilder(configv1.OperatorProgressing, configv1.ConditionTrue, fmt.Sprintf("Progressing towards release version: %s", s.version))
+				conditionListBuilder(configv1.OperatorProgressing, configv1.ConditionTrue, fmt.Sprintf("Progressing towards release version: %s", s.version), reason)
 				msg := fmt.Sprintf("Determining status")
-				conditionListBuilder(configv1.OperatorAvailable, configv1.ConditionFalse, msg)
-				statusConditions := conditionListBuilder(configv1.OperatorDegraded, configv1.ConditionFalse, msg)
+				conditionListBuilder(configv1.OperatorAvailable, configv1.ConditionFalse, msg, reason)
+				statusConditions := conditionListBuilder(configv1.OperatorDegraded, configv1.ConditionFalse, msg, reason)
 				statusErr = s.setStatus(statusConditions)
 				break
 			}
@@ -374,9 +376,10 @@ func (s *status) monitorClusterStatus() {
 
 			// Report that marketplace is available after meeting minimal syncs.
 			if cohelpers.IsStatusConditionFalse(s.clusterOperator.Status.Conditions, configv1.OperatorAvailable) {
+				reason := "OperatorAvailable"
 				conditionListBuilder := clusterStatusListBuilder()
-				conditionListBuilder(configv1.OperatorProgressing, configv1.ConditionFalse, fmt.Sprintf("Successfully progressed to release version: %s", s.version))
-				statusConditions := conditionListBuilder(configv1.OperatorAvailable, configv1.ConditionTrue, fmt.Sprintf("Available release version: %s", s.version))
+				conditionListBuilder(configv1.OperatorProgressing, configv1.ConditionFalse, fmt.Sprintf("Successfully progressed to release version: %s", s.version), reason)
+				statusConditions := conditionListBuilder(configv1.OperatorAvailable, configv1.ConditionTrue, fmt.Sprintf("Available release version: %s", s.version), reason)
 				statusErr = s.setStatus(statusConditions)
 				break
 			}
@@ -387,9 +390,9 @@ func (s *status) monitorClusterStatus() {
 				var statusConditions []configv1.ClusterOperatorStatusCondition
 				conditionListBuilder := clusterStatusListBuilder()
 				if isSucceeding {
-					statusConditions = conditionListBuilder(configv1.OperatorDegraded, configv1.ConditionFalse, fmt.Sprintf("Current CR sync ratio (%g) meets the expected success ratio (%g)", *ratio, successRatio))
+					statusConditions = conditionListBuilder(configv1.OperatorDegraded, configv1.ConditionFalse, fmt.Sprintf("Current CR sync ratio (%g) meets the expected success ratio (%g)", *ratio, successRatio), "OperandTransitionsSucceeding")
 				} else {
-					statusConditions = conditionListBuilder(configv1.OperatorDegraded, configv1.ConditionTrue, fmt.Sprintf("Current CR sync ratio (%g) does not meet the expected success ratio (%g)", *ratio, successRatio))
+					statusConditions = conditionListBuilder(configv1.OperatorDegraded, configv1.ConditionTrue, fmt.Sprintf("Current CR sync ratio (%g) does not meet the expected success ratio (%g)", *ratio, successRatio), "OperandTransitionsFailing")
 				}
 				statusErr = s.setStatus(statusConditions)
 				break

--- a/pkg/status/syncutils.go
+++ b/pkg/status/syncutils.go
@@ -39,14 +39,15 @@ func compareClusterOperatorStatusConditions(a configv1.ClusterOperatorStatusCond
 	return false
 }
 
-func clusterStatusListBuilder() func(conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus, conditionMessage string) []configv1.ClusterOperatorStatusCondition {
+func clusterStatusListBuilder() func(conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus, conditionMessage, reason string) []configv1.ClusterOperatorStatusCondition {
 	time := v1.Now()
 	list := []configv1.ClusterOperatorStatusCondition{}
-	return func(conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus, conditionMessage string) []configv1.ClusterOperatorStatusCondition {
+	return func(conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus, conditionMessage, reason string) []configv1.ClusterOperatorStatusCondition {
 		list = append(list, configv1.ClusterOperatorStatusCondition{
 			Type:               conditionType,
 			Status:             conditionStatus,
 			Message:            conditionMessage,
+			Reason:             reason,
 			LastTransitionTime: time,
 		})
 		return list


### PR DESCRIPTION
Bug 1721537: Fix Degraded status on upgrade

Problem: There are three bugs that should be addressed within this bugzilla:
1. During an upgrade, multiple marketplace operators are running and updating the ClusterOperatorStatus at the same time, making it difficult to identify the actual state of the marketplace operator.
2. The marketplace operator is reporting degraded while it is upgrading. The marketplace operator reports degraded when the number of failed syncs surpases some threshold of total syncs. The marketplace operator currently reports a failed sync whenever an error is encountered while reconciling an operand (OperatorSources or CatalogSourceConfigs). This allows network issues or invalid operands to drive the marketplace operator to a degraded state.
3. It is difficult to identify why a ClusterOperatorStatus condition is in a given state via telemetry. Marketplace currently does not set a reason when setting conditions and telemetry only includes the state and reason.

Solution: Three changes need to be made to address the bugzilla:
1. Implement leader election using the functions provided by the Operator-SDK to prevent multiple marketplace operators from updating the ClusterOperatorStatus at the same time.
2. Rather than reporting a failed sync whenever an error is encountered while reconciling an operand, report a failed sync when the marketplace operator is unable to get or update an existing operand.
3. Update marketplace to include a reason when setting a condition that indicates why the condition is being set.
