### PR TITLE
Bug 1696726: Don't replace pod spec on updates

### DIFF
--- a/pkg/operatorsource/configuring_test.go
+++ b/pkg/operatorsource/configuring_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	appsv1 "k8s.io/api/apps/v1"
 	corev1 "k8s.io/api/core/v1"
+	// metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
 	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	gomock "github.com/golang/mock/gomock"
@@ -327,6 +328,7 @@ func TestReconcile_UpdateError_MovedToFailedPhase(t *testing.T) {
 	// Then we expect a read to the datastore
 	reader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(&datastore.OpsrcRef{}, nil).AnyTimes()
 
+	// replicas := int32(1)
 	kubeclient.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).Return(nil)
 	kubeclient.EXPECT().Update(context.TODO(), gomock.Any()).Return(updateError)
 

--- a/test/testsuites/opsrccreationtests.go
+++ b/test/testsuites/opsrccreationtests.go
@@ -1,6 +1,7 @@
 package testsuites
 
 import (
+	"context"
 	"fmt"
 	"testing"
 
@@ -10,12 +11,16 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apps "k8s.io/api/apps/v1"
+	meta "k8s.io/apimachinery/pkg/apis/meta/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // OpSrcCreation is a test suite that ensures that the expected kubernetets resources are
 // created by marketplace after the creation of an OperatorSource.
 func OpSrcCreation(t *testing.T) {
 	t.Run("operator-source-generates-expected-objects", testOperatorSourceGeneratesExpectedObjects)
+	t.Run("registry-deployment-retains-changes", testRegistryDeploymentRetainsChanges)
 }
 
 // testOperatorSourceGeneratesExpectedObjects ensures that after creating an OperatorSource that the
@@ -47,4 +52,68 @@ func testOperatorSourceGeneratesExpectedObjects(t *testing.T) {
 			helpers.TestOperatorSourceLabelKey,
 			helpers.TestOperatorSourceLabelValue,
 			groupGot))
+}
+
+// testRegistryDeploymentRetainsChanges ensures that changes likes annotations mades to the pod spec of the registry
+// deployment associated with an OperatorSource is reatain across updates.
+func testRegistryDeploymentRetainsChanges(t *testing.T) {
+	// Get test namespace
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	require.NoError(t, err, "Could not get namespace")
+
+	// Check for child resources.
+	err = helpers.CheckChildResourcesCreated(test.Global.Client, helpers.TestOperatorSourceName, namespace, namespace,
+		v1.OperatorSourceKind)
+	require.NoError(t, err)
+
+	client := test.Global.Client
+
+	// Get the registry deployment of the test OperatorSource
+	deployment := getRegistryDeployment(t, helpers.TestOperatorSourceName, namespace)
+	require.NotNil(t, deployment)
+
+	// Add an annotation to the pod template and update the deployment
+	annotationName := "always-here"
+	meta.SetMetaDataAnnotation(&deployment.Spec.Template.ObjectMeta, annotationName, "test")
+	err = client.Update(context.TODO(), deployment)
+	require.NoError(t, err)
+
+	err = helpers.WaitForSuccessfulDeployment(client, *deployment)
+	require.NoError(t, err)
+
+	// Get the test OperatorSource
+	testOpSrc := &v1.OperatorSource{}
+	namespacedName := types.NamespacedName{Name: helpers.TestOperatorSourceName, Namespace: namespace}
+	err = client.Get(context.TODO(), namespacedName, testOpSrc)
+	require.NoError(t, err)
+
+	// Force an update
+	testOpSrc.Status = v1.OperatorSourceStatus{}
+	err = client.Update(context.TODO(), testOpSrc)
+	require.NoError(t, err)
+
+	// Check for child resources.
+	err = helpers.CheckChildResourcesCreated(test.Global.Client, helpers.TestOperatorSourceName, namespace, namespace, v1.OperatorSourceKind)
+	require.NoError(t, err)
+
+	// Get the registry deployment again
+	deployment = getRegistryDeployment(t, helpers.TestOperatorSourceName, namespace)
+	require.NotNil(t, deployment)
+
+	// Check that the annotation was present after the OperatorSource update
+	assert.True(t, meta.HasAnnotation(deployment.Spec.Template.ObjectMeta, annotationName),
+		"Annotation was not retained in pod template")
+
+}
+
+// getRegistryDeployment returns the deployment object for the given OperatorSource
+func getRegistryDeployment(t *testing.T, name, namespace string) *apps.Deployment {
+	// Get the registry deployment of the test OperatorSource
+	deployment := &apps.Deployment{}
+	namespacedName := types.NamespacedName{Name: name, Namespace: namespace}
+	err := test.Global.Client.Get(context.TODO(), namespacedName, deployment)
+	if err != nil {
+		return nil
+	}
+	return deployment
 }


### PR DESCRIPTION
**Problem**
Customers would like to add nodeSelectors to the registry pods. However we replace the pod template spec in the registry deployment on updates causing such additions to be lost.

**Solution**
Instead of replacing the pod template spec only update the required fields like command service accounts.