### PR TITLE
Bug 1708503: Fix missing openapi CRD descriptions

### DIFF
--- a/deploy/crds/operators_v1_catalogsourceconfig_crd.yaml
+++ b/deploy/crds/operators_v1_catalogsourceconfig_crd.yaml
@@ -30,6 +30,7 @@ spec:
     JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
+      description: CatalogSourceConfig is used to enable an operator present in the OperatorSource to your cluster. Behind the scenes, it will configure an OLM CatalogSource so that the operator can then be managed by OLM.
       properties:
         spec:
           type: object

--- a/deploy/crds/operators_v1_operatorsource_crd.yaml
+++ b/deploy/crds/operators_v1_operatorsource_crd.yaml
@@ -50,6 +50,7 @@ spec:
     JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
+      description: OperatorSource is used to define the external datastore we are using to store operator bundles.
       properties:
         spec:
           type: object

--- a/deploy/upstream/02_catalogsourceconfig.crd.yaml
+++ b/deploy/upstream/02_catalogsourceconfig.crd.yaml
@@ -30,6 +30,7 @@ spec:
     JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
+      description: CatalogSourceConfig is used to enable an operator present in the OperatorSource to your cluster. Behind the scenes, it will configure an OLM CatalogSource so that the operator can then be managed by OLM.
       properties:
         spec:
           type: object

--- a/deploy/upstream/03_operatorsource.crd.yaml
+++ b/deploy/upstream/03_operatorsource.crd.yaml
@@ -50,6 +50,7 @@ spec:
     JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
+      description: OperatorSource is used to define the external datastore we are using to store operator bundles.
       properties:
         spec:
           type: object

--- a/manifests/02_catalogsourceconfig.crd.yaml
+++ b/manifests/02_catalogsourceconfig.crd.yaml
@@ -30,6 +30,7 @@ spec:
     JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
+      description: CatalogSourceConfig is used to enable an operator present in the OperatorSource to your cluster. Behind the scenes, it will configure an OLM CatalogSource so that the operator can then be managed by OLM.
       properties:
         spec:
           type: object

--- a/manifests/03_operatorsource.crd.yaml
+++ b/manifests/03_operatorsource.crd.yaml
@@ -50,6 +50,7 @@ spec:
     JSONPath: .metadata.creationTimestamp
   validation:
     openAPIV3Schema:
+      description: OperatorSource is used to define the external datastore we are using to store operator bundles.
       properties:
         spec:
           type: object


### PR DESCRIPTION
Problem:
The CatalogSourceConfig and OperatorSource Custom Resource Definitions
(CRD) are missing the openapi definition fields.

Solution:
Update the CRDs with the `spec.validation.openAPIV3Schema.description`
field.

Fixes https://bugzilla.redhat.com/show_bug.cgi?id=1708503