### PR TITLE
Status

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -51,6 +51,10 @@ const (
 	// Marketplace is always upgradeable and should include this message in the Upgradeable
 	// ClusterOperatorStatus condition.
 	upgradeableMessage = "Marketplace is upgradeable"
+
+	// coSleep is the amount of time marketplace will sleep betwee reporting its status
+	// once it reports available.
+	coSleepDuration = 5 * time.Minute
 )
 
 // status will be a singleton
@@ -394,6 +398,7 @@ func (s *status) monitorClusterStatus() {
 				if err != nil {
 					log.Error("[status] " + err.Error())
 				}
+				time.Sleep(coSleepDuration)
 				break
 			}
 		}


### PR DESCRIPTION
[status] CO status improvements

This PR introduces a number of small changes to the ClusterOperator Status reporting:

1. Currently the marketplace operator reports the status every twenty seconds. Once marketplace becomes available, there is no longer a need to update the status that frequently. This PR introduces a change so the marketplace operator only reports status once every 5 minutes once starts processing syncs.

2. If the marketplace ClusterOperator is deleted after the marketplace operator has deployed, the available and progressing conditions may be missing. This commit introduces a change that updates all status conditions once the marketplace starts processing syncs.

3. The status package currently has a defer statement that is called within a loop that runs for the life of the operator which can introduce memory issues. This PR introduces a change to remove the defer from the status package.
