### PR TITLE
[opsrc] Add watches for deletion of child resources

### DIFF
--- a/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
+++ b/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
@@ -28,7 +28,7 @@ func Add(mgr manager.Manager) error {
 	return add(mgr, reconciler)
 }
 
-// newReconciler returns a new reconcile.Reconciler
+// newReconciler returns a new ReconcileCatalogSourceConfig
 func newReconciler(mgr manager.Manager) (*ReconcileCatalogSourceConfig, error) {
 	// The default client serves read requests from the cache which contains
 	// objects only from the namespace the operator is watching. Given we need
@@ -50,7 +50,7 @@ func newReconciler(mgr manager.Manager) (*ReconcileCatalogSourceConfig, error) {
 	}, nil
 }
 
-// add adds a new Controller to mgr with r as the reconcile.Reconciler
+// add adds a new Controller to mgr with r as the ReconcileCatalogSourceConfig
 func add(mgr manager.Manager, r *ReconcileCatalogSourceConfig) error {
 	// Create a new controller
 	c, err := controller.New("catalogsourceconfig-controller", mgr, controller.Options{Reconciler: r})

--- a/pkg/operatorsource/factory.go
+++ b/pkg/operatorsource/factory.go
@@ -79,7 +79,7 @@ func (s *phaseReconcilerFactory) GetPhaseReconciler(logger *log.Entry, opsrc *v1
 		return NewPurgingReconciler(logger, s.datastore, s.client), nil
 
 	case phase.Succeeded:
-		return NewSucceededReconciler(logger), nil
+		return NewSucceededReconciler(logger, s.client), nil
 
 	case phase.Failed:
 		return NewFailedReconciler(logger), nil

--- a/pkg/operatorsource/succeeded.go
+++ b/pkg/operatorsource/succeeded.go
@@ -6,14 +6,17 @@ import (
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/shared"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
+	"github.com/operator-framework/operator-marketplace/pkg/watches"
 	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
 )
 
 // NewSucceededReconciler returns a Reconciler that reconciles
 // an OperatorSource object in "Succeeded" phase.
-func NewSucceededReconciler(logger *log.Entry) Reconciler {
+func NewSucceededReconciler(logger *log.Entry, client client.Client) Reconciler {
 	return &succeededReconciler{
 		logger: logger,
+		client: client,
 	}
 }
 
@@ -21,6 +24,7 @@ func NewSucceededReconciler(logger *log.Entry) Reconciler {
 // reconciles an OperatorSource object in "Succeeded" phase.
 type succeededReconciler struct {
 	logger *log.Entry
+	client client.Client
 }
 
 // Reconcile reconciles an OperatorSource object that is in "Succeeded" phase.
@@ -45,7 +49,26 @@ func (r *succeededReconciler) Reconcile(ctx context.Context, in *v1.OperatorSour
 	// No change is being made, so return the OperatorSource object that was specified as is.
 	out = in
 
-	r.logger.Info("No action taken, the object has already been reconciled")
+	msg := "No action taken, the object has already been reconciled"
 
-	return out, nil, nil
+	secretIsPresent := r.isSecretPresent(in)
+
+	if watches.CheckChildResources(r.client, in.Name, in.Namespace, in.Namespace, secretIsPresent) {
+		// A child has been deleted. Drop the existing Status field so that reconciliation can start anew.
+		out.Status = v1.OperatorSourceStatus{}
+		nextPhase = phase.GetNext(phase.Configuring)
+		msg = "Child resource(s) have been deleted, scheduling for configuring"
+	}
+
+	r.logger.Info(msg)
+
+	return
+}
+
+// isSecretPresent checks if the OperatorSource contains an authorization token and returns true if it does.
+func (r *succeededReconciler) isSecretPresent(opsrc *v1.OperatorSource) bool {
+	if opsrc.Spec.AuthorizationToken.SecretName != "" {
+		return true
+	}
+	return false
 }

--- a/pkg/watches/opsrc_mapper.go
+++ b/pkg/watches/opsrc_mapper.go
@@ -1,0 +1,43 @@
+package watches
+
+import (
+	"context"
+
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	log "github.com/sirupsen/logrus"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+)
+
+type childResourceToOperatorSource struct {
+	client client.Client
+}
+
+func (m *childResourceToOperatorSource) Map(obj handler.MapObject) []reconcile.Request {
+	// We don't need to check if the key is nil as we are already doing that in the delete
+	// predicate function.
+	key := getOpSrcOwnerKey(obj.Meta.GetLabels())
+	opsrc := &v1.OperatorSource{}
+	err := m.client.Get(context.TODO(), *key, opsrc)
+	if err != nil {
+		return nil
+	}
+
+	log.Infof("Child resource %s/%s owned by a OperatorSource was deleted", obj.Meta.GetNamespace(), obj.Meta.GetName())
+
+	if !opsrc.GetDeletionTimestamp().IsZero() {
+		log.Infof("OperatorSource %s/%s was marked for deletion. No action taken.", opsrc.GetNamespace(), opsrc.GetName())
+		return nil
+	}
+
+	return []reconcile.Request{
+		reconcile.Request{NamespacedName: *key},
+	}
+}
+
+// ChildResourceToOperatorSource returns a mapper that returns a request for the
+// OperatorSource whose child resource has been deleted.
+func ChildResourceToOperatorSource(client client.Client) handler.Mapper {
+	return &childResourceToOperatorSource{client: client}
+}

--- a/test/testsuites/watchtests.go
+++ b/test/testsuites/watchtests.go
@@ -5,6 +5,7 @@ import (
 	"testing"
 
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
 	"github.com/operator-framework/operator-marketplace/test/helpers"
 	"github.com/operator-framework/operator-sdk/pkg/test"
@@ -17,7 +18,8 @@ import (
 )
 
 const (
-	cscErrMsg = "CatalogSourceConfig child resource(s) were not recreated"
+	cscErrMsg   = "CatalogSourceConfig child resource(s) were not recreated"
+	opsrcErrMsg = "OperatorSource child resource(s) were not recreated"
 )
 
 // WatchTests is a test suite that ensure that the watches for child resources
@@ -26,6 +28,9 @@ func WatchTests(t *testing.T) {
 	t.Run("restore-csc-catalogsource", testRestoreCscCs)
 	t.Run("restore-csc-deployment", testRestoreCscDeployment)
 	t.Run("restore-csc-service", testRestoreCscService)
+	t.Run("restore-opsrc-catalogsource", testRestoreOpSrcCs)
+	t.Run("restore-opsrc-deployment", testRestoreOpSrcDeployment)
+	t.Run("restore-opsrc-service", testRestoreOpSrcService)
 }
 
 // testRestoreCscCs tests that when a CatalogSource that is owned by a CatalogSourceConfig
@@ -49,6 +54,27 @@ func testRestoreCscService(t *testing.T) {
 	assert.NoError(t, err, cscErrMsg)
 }
 
+// testRestoreOpSrcCs tests that when a CatalogSource that is owned by an OperatorSource
+// is restored upon deletion.
+func testRestoreOpSrcCs(t *testing.T) {
+	err := deleteCheckRestoreChild(t, olm.CatalogSourceKind, v1.OperatorSourceKind)
+	assert.NoError(t, err, opsrcErrMsg)
+}
+
+// testRestoreOpSrcDeployment tests that when a Deployment that is owned by an OperatorSource
+// is restored upon deletion.
+func testRestoreOpSrcDeployment(t *testing.T) {
+	err := deleteCheckRestoreChild(t, "Deployment", v1.OperatorSourceKind)
+	assert.NoError(t, err, opsrcErrMsg)
+}
+
+// testRestoreOpSrcService tests that when a Service that is owned by an OperatorSourceKind
+// is restored upon deletion.
+func testRestoreOpSrcService(t *testing.T) {
+	err := deleteCheckRestoreChild(t, "Service", v1.OperatorSourceKind)
+	assert.NoError(t, err, opsrcErrMsg)
+}
+
 // deleteCheckRestoreChild constructs the child resource based on the object and
 // deletes it. It then checks if the child resources were recreated.
 func deleteCheckRestoreChild(t *testing.T, child string, owner string) error {
@@ -67,6 +93,9 @@ func deleteCheckRestoreChild(t *testing.T, child string, owner string) error {
 	case v2.CatalogSourceConfigKind:
 		name = helpers.TestCatalogSourceConfigName
 		targetNamespace = helpers.TestCatalogSourceConfigTargetNamespace
+	case v1.OperatorSourceKind:
+		name = helpers.TestOperatorSourceName
+		targetNamespace = namespace
 	default:
 		return fmt.Errorf("Unknown owner %s", owner)
 	}


### PR DESCRIPTION
Watch for deletion of CatalogSources, Deployments, Services, ServiceAccounts, Roles and RoleBindings and recreate them if they belong to a OperatorSource.
- Add a watch that uses EnqueueRequestsFromMapFunc with a predicate that filters out non-deletion events
- Deletion predicate function only returns true if the event belongs to a child resource
- Add a mapper function that figures out the reconciliation request given the resource being deleted
- Make newReconciler return *ReconcileOperatorSource to allow the mapper to have access to the client
- Update the succeeded reconciler to check if the child resources have been deleted and set the phase to configuring if it has