### PR TITLE
[opsrc] Fix IsEqual()

### DIFF
--- a/pkg/apis/operators/v1/operatorsource_types.go
+++ b/pkg/apis/operators/v1/operatorsource_types.go
@@ -115,7 +115,10 @@ func (s *OperatorSourceSpec) IsEqual(other *OperatorSourceSpec) bool {
 	}
 	if strings.EqualFold(s.Endpoint, other.Endpoint) &&
 		strings.EqualFold(s.RegistryNamespace, other.RegistryNamespace) &&
-		strings.EqualFold(s.Type, other.Type) {
+		strings.EqualFold(s.Type, other.Type) &&
+		strings.EqualFold(s.AuthorizationToken.SecretName, other.AuthorizationToken.SecretName) &&
+		strings.EqualFold(s.DisplayName, other.DisplayName) &&
+		strings.EqualFold(s.Publisher, other.Publisher) {
 		return true
 	}
 	return false


### PR DESCRIPTION
IsEqual() was ignoring AuthorizationToken, Publisher and SecretName. This PR fixes that.