### PR TITLE
Bug 1732760: Ensure cscs not deleted on operator restart

### DIFF
--- a/test/testgroups/migrationtests.go
+++ b/test/testgroups/migrationtests.go
@@ -42,6 +42,10 @@ func MigrationTestGroup(t *testing.T) {
 	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateSubscriptionDefinition(helpers.TestUserCreatedSubscriptionName, namespace, false))
 	require.NoError(t, err, "Could not create User Subscription")
 
+	// Create a CatalogSourceConfig.
+	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateCatalogSourceConfigDefinition(helpers.TestCatalogSourceConfigName, namespace, namespace))
+	require.NoError(t, err, "Could not create CatalogSourceConfig")
+
 	// Create the installed CatalogSourceConfig.
 	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateInstalledCscDefinition(namespace))
 	require.NoError(t, err, "Could not create installed CatalogSourceConfig")


### PR DESCRIPTION
CatalogSourceConfigs that were not created by an OperatorSource or by
the UI as part of the 4.1 install flow are deleted on operator restart.
This is because a labelSelector was malformed and hence ignored. This
fixes that issue and adds a test case for this scenario.