### PR TITLE
Bug 1722096:  fix panic when scale down of registry deployment fails

### DIFF
--- a/pkg/catalogsourceconfig/registry.go
+++ b/pkg/catalogsourceconfig/registry.go
@@ -126,7 +126,7 @@ func (r *registry) ensureDeployment(appRegistries []string, needServiceAccount b
 
 		// Wait for the deployment to scale down. We need to get the latest version of the object after
 		// the update, so we use the object returned here for scaling up.
-		if deployment, err = r.waitForDeploymentScaleDown(2*time.Second, 1*time.Minute); err != nil {
+		if _, err = r.waitForDeploymentScaleDown(2*time.Second, 1*time.Minute); err != nil {
 			r.log.Errorf("Failed to scale down Deployment %s : %v", deployment.GetName(), err)
 			return err
 		}


### PR DESCRIPTION
This should prevent the panic - `deployment` was being shadowed, and on timeout will be set to `nil`. This removes the shadowing so that the name comes from the non-nil `deployment` defined above.

I would typically add an e2e but I would need to rewrite a chunk of this to do that (otherwise the e2e test will always take 1+ minutes), and this section seems to have changed significantly between 4.1 and 4.2. But if anyone sees a convenient way to test this for 4.1, I'm all ears :)