### PR TITLE
Bug 1732577: Handle delete events while operator is restarting

### DIFF
--- a/pkg/apis/operators/shared/shared.go
+++ b/pkg/apis/operators/shared/shared.go
@@ -37,6 +37,19 @@ func RemoveFinalizer(objectMeta *metav1.ObjectMeta, deletingFinalizer string) {
 	return
 }
 
+// HasFinalizer checks to see if the finalizer exists in the object's ObjectMeta.
+func HasFinalizer(objectMeta *metav1.ObjectMeta, expectedFinalizer string) bool {
+	finalizerExists := false
+	for _, finalizer := range objectMeta.Finalizers {
+		if finalizer == expectedFinalizer {
+			finalizerExists = true
+			break
+		}
+	}
+
+	return finalizerExists
+}
+
 // IsObjectInOtherNamespace returns true if the namespace is not the watched
 // namespace of the operator. An false, error will be returned if there was an
 // error getting the watched namespace.

--- a/pkg/apis/operators/v1/operatorsource_types.go
+++ b/pkg/apis/operators/v1/operatorsource_types.go
@@ -148,6 +148,13 @@ func (s *OperatorSource) EnsureFinalizer() {
 	shared.EnsureFinalizer(&s.ObjectMeta, OpSrcFinalizer)
 }
 
+// HasFinalizer checks to see if the OpSrc finalizer
+// exists on the OpSrc. Returns true if the finalizer
+// can be found on the Opsrc's ObjectMeta.Finalizers list.
+func (s *OperatorSource) HasFinalizer() bool {
+	return shared.HasFinalizer(&s.ObjectMeta, OpSrcFinalizer)
+}
+
 func init() {
 	SchemeBuilder.Register(&OperatorSource{}, &OperatorSourceList{})
 }

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -240,7 +240,7 @@ func ensureAbsent(client wrapper.Client, def v1.OperatorSource, cluster *v1.Oper
 // ensurePresent ensure that that the default OperatorSource is present on the cluster
 func ensurePresent(client wrapper.Client, def v1.OperatorSource, cluster *v1.OperatorSource) error {
 	// Create if not present or is deleted
-	if cluster.Name == "" || !cluster.ObjectMeta.DeletionTimestamp.IsZero() {
+	if cluster.Name == "" || (!cluster.ObjectMeta.DeletionTimestamp.IsZero() && len(cluster.Finalizers) == 0) {
 		err := client.Create(context.TODO(), &def)
 		if err != nil {
 			return err

--- a/pkg/operatorsource/configuring.go
+++ b/pkg/operatorsource/configuring.go
@@ -68,7 +68,7 @@ type configuringReconciler struct {
 //
 // If the corresponding CatalogSourceConfig object already exists
 // then no further action is taken.
-func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, err error) {
+func (r *configuringReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, requeue bool, err error) {
 	if in.GetCurrentPhaseName() != phase.Configuring {
 		err = phase.ErrWrongReconcilerInvoked
 		return

--- a/pkg/operatorsource/failed.go
+++ b/pkg/operatorsource/failed.go
@@ -34,7 +34,7 @@ type failedReconciler struct {
 //
 // nextPhase represents the next desired phase for the given OperatorSource
 // object. If nil is returned, it implies that no phase transition is expected.
-func (r *failedReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, err error) {
+func (r *failedReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, requeue bool, err error) {
 	if in.GetCurrentPhaseName() != phase.Failed {
 		err = phase.ErrWrongReconcilerInvoked
 		return
@@ -44,5 +44,5 @@ func (r *failedReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource)
 
 	r.logger.Info("No action taken, already in failed state")
 
-	return out, nil, nil
+	return out, nil, false, nil
 }

--- a/pkg/operatorsource/initial.go
+++ b/pkg/operatorsource/initial.go
@@ -40,7 +40,7 @@ type initialReconciler struct {
 // object. If nil is returned, it implies that no phase transition is expected.
 //
 // Upon success, it returns "Validating" as the next desired phase.
-func (r *initialReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, err error) {
+func (r *initialReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, requeue bool, err error) {
 	if in.GetCurrentPhaseName() != phase.Initial {
 		err = phase.ErrWrongReconcilerInvoked
 		return

--- a/pkg/operatorsource/otherns.go
+++ b/pkg/operatorsource/otherns.go
@@ -29,7 +29,7 @@ type otherNamespaceReconciler struct {
 // Reconcile reconciles a OperatorSource object created in a namespace other
 // than the operator namespace. It returns "Failed" as the next desired phase
 // unless the objects is already in the "Failed" phase.
-func (r *otherNamespaceReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, err error) {
+func (r *otherNamespaceReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, requeue bool, err error) {
 	// Do nothing as this object has already been placed in the failed phase.
 	if in.Status.CurrentPhase.Name == phase.Failed {
 		return

--- a/pkg/operatorsource/outofsync.go
+++ b/pkg/operatorsource/outofsync.go
@@ -48,7 +48,7 @@ type outOfSyncCacheReconciler struct {
 //
 // nextPhase represents the next desired phase for the given OperatorSource
 // object. If nil is returned, it implies that no phase transition is expected.
-func (r *outOfSyncCacheReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, err error) {
+func (r *outOfSyncCacheReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, requeue bool, err error) {
 	objectInOtherNamespace, err := shared.IsObjectInOtherNamespace(in.GetNamespace())
 	if err != nil {
 		return

--- a/pkg/operatorsource/purging.go
+++ b/pkg/operatorsource/purging.go
@@ -55,7 +55,7 @@ type purgingReconciler struct {
 // field and trigger reconciliation anew from "Validating" phase.
 //
 // If the purge fails the OperatorSource object is moved to "Failed" phase.
-func (r *purgingReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, err error) {
+func (r *purgingReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, requeue bool, err error) {
 	if in.GetCurrentPhaseName() != phase.OperatorSourcePurging {
 		err = phase.ErrWrongReconcilerInvoked
 		return

--- a/pkg/operatorsource/purging_test.go
+++ b/pkg/operatorsource/purging_test.go
@@ -30,6 +30,8 @@ func TestReconcileWithPurging(t *testing.T) {
 		Message: phase.GetMessage(phase.Initial),
 	}
 
+	requeueWant := false
+
 	datastore := mocks.NewDatastoreWriter(controller)
 	fakeclient := NewFakeClient()
 	reconciler := operatorsource.NewPurgingReconciler(helperGetContextLogger(), datastore, fakeclient)
@@ -37,9 +39,10 @@ func TestReconcileWithPurging(t *testing.T) {
 	// We expect the operator source to be removed from the datastore.
 	datastore.EXPECT().RemoveOperatorSource(opsrcIn.GetUID()).Times(1)
 
-	opsrcGot, nextPhaseGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
+	opsrcGot, nextPhaseGot, requeueGot, errGot := reconciler.Reconcile(ctx, opsrcIn)
 
 	assert.NoError(t, errGot)
 	assert.Equal(t, opsrcWant, opsrcGot)
 	assert.Equal(t, nextPhaseWant, nextPhaseGot)
+	assert.Equal(t, requeueWant, requeueGot)
 }

--- a/pkg/operatorsource/reconciler.go
+++ b/pkg/operatorsource/reconciler.go
@@ -33,5 +33,5 @@ import (
 // Reconcile operation is expected to be idempotent so that in the event of
 // multiple invocations there would be no adverse or side effect.
 type Reconciler interface {
-	Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, err error)
+	Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, requeue bool, err error)
 }

--- a/pkg/operatorsource/succeeded.go
+++ b/pkg/operatorsource/succeeded.go
@@ -42,7 +42,7 @@ type succeededReconciler struct {
 //
 // nextPhase represents the next desired phase for the given OperatorSource
 // object. If nil is returned, it implies that no phase transition is expected.
-func (r *succeededReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, err error) {
+func (r *succeededReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, requeue bool, err error) {
 	if in.GetCurrentPhaseName() != phase.Succeeded {
 		err = phase.ErrWrongReconcilerInvoked
 		return

--- a/pkg/operatorsource/validating.go
+++ b/pkg/operatorsource/validating.go
@@ -43,7 +43,7 @@ type validatingReconciler struct {
 //
 // On success, it returns "Configuring" as the next phase.
 // On error, it returns "Failed" as the next phase.
-func (r *validatingReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, err error) {
+func (r *validatingReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource) (out *v1.OperatorSource, nextPhase *shared.Phase, requeue bool, err error) {
 	if in.GetCurrentPhaseName() != phase.OperatorSourceValidating {
 		err = phase.ErrWrongReconcilerInvoked
 		return

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -10,4 +10,4 @@ fi
 
 # Run the tests through the operator-sdk
 echo "Running operator-sdk test"
-operator-sdk test local ./test/e2e/ --no-setup --go-test-flags -v --namespace $TEST_NAMESPACE
+operator-sdk test local ./test/e2e/ --no-setup --go-test-flags "-v -timeout 20m" --namespace $TEST_NAMESPACE

--- a/test/testsuites/defaultopsrctests.go
+++ b/test/testsuites/defaultopsrctests.go
@@ -10,6 +10,7 @@ import (
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
+	apps "k8s.io/api/apps/v1"
 	"k8s.io/apimachinery/pkg/types"
 )
 
@@ -26,6 +27,7 @@ func DefaultOpSrc(t *testing.T) {
 	t.Run("delete-default-operator-source", testDeleteDefaultOpSrc)
 	t.Run("update-default-operator-source", testUpdateDefaultOpSrc)
 	t.Run("update-default-registry-namespace-operator-source", testUpdateRegistryNamespaceDefaultOpSrc)
+	t.Run("delete-default-opsrc-while-stopped", testDeleteDefaultOpsrcWhileStopped)
 }
 
 // testDeleteDefaultOpSrc deletes a default OperatorSource and checks if it has
@@ -125,6 +127,60 @@ func testUpdateRegistryNamespaceDefaultOpSrc(t *testing.T) {
 	err = helpers.UpdateRuntimeObject(client, updateOpSrc)
 	require.NoError(t, err, "Default OperatorSource could not be deleted successfully")
 
+	// Ensure the OperatorSource phase is "Succeeded"
+	clusterOpSrc, err := helpers.WaitForOpSrcExpectedPhaseAndMessage(client, helpers.DefaultSources[0].Name, namespace, "Succeeded",
+		"The object has been successfully reconciled")
+	assert.NoError(t, err, "Default OperatorSource never reached the succeeded phase")
+
+	// Check for the child resources which implies that the OperatorSource was recreated
+	err = helpers.CheckChildResourcesCreated(client, helpers.DefaultSources[0].Name, namespace, namespace, v1.OperatorSourceKind)
+	assert.NoError(t, err, "Could not ensure that child resources were created")
+
+	assert.ObjectsAreEqualValues(helpers.DefaultSources[0].Spec, clusterOpSrc.Spec)
+}
+
+// testDeleteDefaultOpsrcWhileStopped turns off the operator, marks an operator source
+// for deletion, then starts the opeator back up. When it does it expects that the
+// operator source is correctly recreated.
+func testDeleteDefaultOpsrcWhileStopped(t *testing.T) {
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	// Get global framework variables
+	client := test.Global.Client
+
+	// Get test namespace
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	require.NoError(t, err, "Could not get namespace.")
+
+	// We are assuming that the marketplace deployment is available. This is only
+	// the case if not running operator-sdk up local.
+	err = test.Global.Client.Get(context.TODO(), types.NamespacedName{Name: "marketplace-operator", Namespace: namespace}, &apps.Deployment{})
+	if err != nil {
+		t.Logf("Failed to find deployment operator-marketplace")
+		return
+	}
+
+	// Scale down marketplace operator
+	err = helpers.ScaleMarketplace(test.Global.Client, namespace, int32(0))
+	require.NoError(t, err, "Could not scale down marketplace operator")
+
+	err = helpers.InitOpSrcDefinition()
+	require.NoError(t, err, "Could not get a default OperatorSource definition from disk")
+
+	// Now let's delete the OperatorSource
+	deleteOpSrc := *helpers.DefaultSources[0]
+	err = helpers.DeleteRuntimeObject(client, &deleteOpSrc)
+	require.NoError(t, err, "Default OperatorSource could not be deleted successfully")
+
+	err = helpers.WaitForOpsrcMarkedForDeletionWithFinalizer(client, deleteOpSrc.Name, deleteOpSrc.Namespace)
+	require.NoError(t, err, "Default OperatorSource was not successfully marked for deletion")
+
+	// Scale the marketplace operator back up
+	err = helpers.ScaleMarketplace(test.Global.Client, namespace, int32(1))
+	require.NoError(t, err, "Could not scale marketplace back up")
+
+	// Now check that it came back up successfully
 	// Ensure the OperatorSource phase is "Succeeded"
 	clusterOpSrc, err := helpers.WaitForOpSrcExpectedPhaseAndMessage(client, helpers.DefaultSources[0].Name, namespace, "Succeeded",
 		"The object has been successfully reconciled")


### PR DESCRIPTION
Problem:
An edge case bug was added when the default opsrc feature was added.
If a default opsrc was marked for deletion but the finalizer was
not removed by the operator before the operator restarted, then the
`defaults.EnsureAll()` method would attempt to create it. In that case,
the client would return an error and the operator would exit.

Solution:
When EnsureAll is called on startup, also ensure that there are no
finalizers still included on the operator source. If they are still
there, ignore it and allow the normal reconciliation cycle to take care
of deleting and recreating it.

Additionally, once the finalizer is removed at the end of the
reconciliation loop, wait for the opsrc to be cleaned up by the garbage
collector before recreating it.

https://bugzilla.redhat.com/show_bug.cgi?id=1732577