### PR TITLE
Bug 1732503: Restore default opsrc spec

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -31,6 +31,7 @@ var (
 type Defaults interface {
 	EnsureAll(client wrapper.Client) error
 	Ensure(client wrapper.Client, opsrcName string) error
+	RestoreSpecIfDefault(in *v1.OperatorSource)
 }
 
 type defaults struct {
@@ -39,6 +40,19 @@ type defaults struct {
 // New returns a the singleton defaults
 func New() Defaults {
 	return &defaults{}
+}
+
+// RestoreSpecIfDefault takes an operator source and, if it is one of the defaults,
+// sets the spec back to the expected spec in order to prevent any changes.
+func (d *defaults) RestoreSpecIfDefault(in *v1.OperatorSource) {
+	defOpsrc, present := defaultsTracker[in.Name]
+	if !present {
+		return
+	}
+
+	in.Spec = defOpsrc.Spec
+
+	return
 }
 
 // Ensure checks if the given OperatorSource source is one of the

--- a/pkg/operatorsource/handler.go
+++ b/pkg/operatorsource/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-marketplace/pkg/appregistry"
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
+	"github.com/operator-framework/operator-marketplace/pkg/defaults"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
 	"github.com/operator-framework/operator-marketplace/pkg/status"
 	log "github.com/sirupsen/logrus"
@@ -67,6 +68,8 @@ func (h *operatorsourcehandler) Handle(ctx context.Context, in *v1.OperatorSourc
 		"namespace": in.GetNamespace(),
 		"name":      in.GetName(),
 	})
+
+	defaults.New().RestoreSpecIfDefault(in)
 
 	outOfSyncCacheReconciler := h.newCacheReconciler(logger, h.datastore, h.client)
 	out, status, err := outOfSyncCacheReconciler.Reconcile(ctx, in)


### PR DESCRIPTION
Problem:
Currently, an issue exists where if a default opsrc is modified and that modification results in a reconciliation loop that puts the opsrc in a
failed state, it does not recover automatically.

Solution:
Rather than rely on the reconciliation loop to run erroneously on these opsrces and then returning them to their original state afterwards, add a filter to prevent updates to the spec that do not match the default. Do this by adding method to the defaults package `RestoreSpecIfDefault` that always overwrites the spec of any of the defaults to what is expected, and call that method at the beginning of the opsrc handler.