### PR TITLE
Bug 1732160: Degrade when default opsrc fails

### DIFF
--- a/deploy/crds/operators_v1_operatorsource_crd.yaml
+++ b/deploy/crds/operators_v1_operatorsource_crd.yaml
@@ -45,6 +45,10 @@ spec:
     type: string
     description: Message associated with the current status
     JSONPath: .status.currentPhase.phase.message
+  - name: Reason
+    type: string
+    description: Reason is a Pascal Case string that highlights why the OperatorSource has failed to reach the succeeded phase.
+    JSONPath: .status.currentPhase.phase.reason
   - name: Age
     type: date
     JSONPath: .metadata.creationTimestamp

--- a/pkg/apis/operators/shared/phase.go
+++ b/pkg/apis/operators/shared/phase.go
@@ -1,9 +1,10 @@
 package shared
 
 // NewPhase returns a Phase object with the given name and message
-func NewPhase(name string, message string) *Phase {
+func NewPhase(name string, message string, reason string) *Phase {
 	return &Phase{
 		Name:    name,
 		Message: message,
+		Reason:  reason,
 	}
 }

--- a/pkg/apis/operators/shared/phase_types.go
+++ b/pkg/apis/operators/shared/phase_types.go
@@ -9,6 +9,9 @@ type Phase struct {
 
 	// A human readable message indicating why the object is in this phase
 	Message string `json:"message,omitempty"`
+
+	// A pacal case string indicating why the object has not reached the succeeded phase
+	Reason string `json:"reason,omitempty"`
 }
 
 // ObjectPhase describes the phase of a Marketplace object is in along with the

--- a/pkg/certificateauthority/caconfigmap.go
+++ b/pkg/certificateauthority/caconfigmap.go
@@ -2,6 +2,7 @@ package certificateauthority
 
 import (
 	"io/ioutil"
+	"os"
 	"path/filepath"
 
 	corev1 "k8s.io/api/core/v1"
@@ -57,4 +58,11 @@ func MountCaConfigMap(template *corev1.PodTemplateSpec) {
 // array or returns the error encountered when attempting to do so.
 func getCaOnDisk() ([]byte, error) {
 	return ioutil.ReadFile(filepath.Join(trustedCaMountPath, caBundlePath))
+}
+
+// IsCaBundlePresentOnDisk returns true if the expected Certificate Authority bundle
+// is present on disk.
+func IsCaBundlePresentOnDisk() bool {
+	_, err := os.Stat(filepath.Join(trustedCaMountPath, caBundlePath))
+	return !os.IsNotExist(err)
 }

--- a/pkg/operatorhub/operatorhub.go
+++ b/pkg/operatorhub/operatorhub.go
@@ -43,7 +43,16 @@ func GetSingleton() OperatorHub {
 func (o *operatorhub) Get() map[string]bool {
 	o.lock.Lock()
 	defer o.lock.Unlock()
-	return o.current
+
+	// Create a map to return.
+	clone := make(map[string]bool)
+
+	// Populate the newly created map.
+	for key, value := range o.current {
+		clone[key] = value
+	}
+
+	return clone
 }
 
 // Set sets the current configuration based on the spec. If the spec is empty,

--- a/pkg/operatorsource/configuring_test.go
+++ b/pkg/operatorsource/configuring_test.go
@@ -121,6 +121,7 @@ func TestReconcile_OperatorSourceReturnsEmptyManifestList_Failed(t *testing.T) {
 	nextPhaseWant := &shared.Phase{
 		Name:    phase.Failed,
 		Message: errGot.Error(),
+		Reason:  "AppRegistryMetadataEmptyError",
 	}
 
 	assert.Equal(t, opsrcIn, opsrcGot)
@@ -284,6 +285,7 @@ func TestReconcile_UpdateError_MovedToFailedPhase(t *testing.T) {
 	nextPhaseWant := &shared.Phase{
 		Name:    phase.Configuring,
 		Message: updateError.Error(),
+		Reason:  "EnsureResourcesError",
 	}
 
 	writer := mocks.NewDatastoreWriter(controller)

--- a/pkg/phase/phase.go
+++ b/pkg/phase/phase.go
@@ -70,10 +70,15 @@ func GetMessage(phaseName string) string {
 
 // GetNext returns a Phase object with the given phase name and default message
 func GetNext(name string) *shared.Phase {
-	return shared.NewPhase(name, GetMessage(name))
+	return shared.NewPhase(name, GetMessage(name), "")
 }
 
 // GetNextWithMessage returns a Phase object with the given phase name and default message
 func GetNextWithMessage(name string, message string) *shared.Phase {
-	return shared.NewPhase(name, message)
+	return shared.NewPhase(name, message, "")
+}
+
+// GetNextWithMessageAndReason returns a Phase object with the given phase name, message, and reason
+func GetNextWithMessageAndReason(name string, message string, reason string) *shared.Phase {
+	return shared.NewPhase(name, message, reason)
 }

--- a/pkg/phase/transitioner.go
+++ b/pkg/phase/transitioner.go
@@ -49,6 +49,7 @@ func (t *transitioner) TransitionInto(currentPhase *shared.ObjectPhase, nextPhas
 	now := metav1.NewTime(t.clock.Now())
 	currentPhase.LastUpdateTime = now
 	currentPhase.Message = nextPhase.Message
+	currentPhase.Reason = nextPhase.Reason
 
 	if currentPhase.Name != nextPhase.Name {
 		currentPhase.LastTransitionTime = now
@@ -64,7 +65,7 @@ func (t *transitioner) TransitionInto(currentPhase *shared.ObjectPhase, nextPhas
 // If both Phase and Message are equal, the function will return false
 // indicating no change. Otherwise, the function will return true.
 func hasPhaseChanged(currentPhase *shared.ObjectPhase, nextPhase *shared.Phase) bool {
-	if currentPhase.Name == nextPhase.Name && currentPhase.Message == nextPhase.Message {
+	if currentPhase.Name == nextPhase.Name && currentPhase.Message == nextPhase.Message && currentPhase.Reason == nextPhase.Reason {
 		return false
 	}
 

--- a/pkg/status/statuserrorreason.go
+++ b/pkg/status/statuserrorreason.go
@@ -1,0 +1,31 @@
+package status
+
+const (
+	// AppRegistryMetadataEmptyError captures when OperatorSource endpoint returns
+	// an empty manifest list while reconciling an enabled default OperatorSource.
+	AppRegistryMetadataEmptyError string = "AppRegistryMetadataEmptyError"
+
+	// AppRegistryOptionsError captures when there is an error building an AppRegistry
+	// Options object while reconciling an enabled default OperatorSource.
+	AppRegistryOptionsError string = "AppRegistryOptionsError"
+
+	// AppRegistryFactoryError captures when there is an error creating a new AppRegistry
+	// client using the AppRegistryFactory while reconciling an enabled default OperatorSource.
+	AppRegistryFactoryError string = "AppRegistryFactoryError"
+
+	// AppRegistryListPackagesError captures when there is an error returned by the AppRegistry
+	// client ListPackages function while reconciling an enabled default OperatorSource.
+	AppRegistryListPackagesError string = "AppRegistryListPackagesError"
+
+	// DataStoreWriteError captures when there is an error writing Operator metadata to the
+	// datastore while reconciling an enabled default OperatorSource.
+	DataStoreWriteError string = "DataStoreWriteError"
+
+	// EnsureResourcesError captures when there is an error ensuring that all GRPC resources
+	// exist.
+	EnsureResourcesError string = "EnsureResourcesError"
+
+	// DefaultError captures when there is an unknown error. This is a default value returned
+	// when the cause for a failing enabled default OperatorSource is unknown.
+	DefaultError string = ""
+)

--- a/test/e2e/main_test.go
+++ b/test/e2e/main_test.go
@@ -4,6 +4,7 @@ import (
 	"fmt"
 	"testing"
 
+	networkv1 "github.com/openshift/api/network/v1"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-marketplace/pkg/apis"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
@@ -68,6 +69,18 @@ func initTestingFramework(t *testing.T) {
 	err = test.AddToFrameworkScheme(olm.AddToScheme, catalogSource)
 	if err != nil {
 		t.Fatalf("failed to add CatalogSource custom resource scheme to framework: %v", err)
+	}
+
+	// Add Egress API to framework scheme.
+	egressNetworkPolicy := &networkv1.EgressNetworkPolicy{
+		TypeMeta: metav1.TypeMeta{
+			Kind:       "EgressNetworkPolicy",
+			APIVersion: networkv1.GroupName + "/" + networkv1.GroupVersion.Version,
+		},
+	}
+	err = test.AddToFrameworkScheme(networkv1.AddToScheme, egressNetworkPolicy)
+	if err != nil {
+		t.Fatalf("failed to add EgressNetworkPolicy scheme to framework: %v", err)
 	}
 
 	_, err = helpers.EnsureConfigAPIIsAvailable()

--- a/test/testgroups/clusteroperatortests.go
+++ b/test/testgroups/clusteroperatortests.go
@@ -10,4 +10,5 @@ import (
 func ClusterOperatorTestGroup(t *testing.T) {
 	// Run the test suites.
 	t.Run("cluster-operator-status-on-startup-test-suite", testsuites.ClusterOperatorStatusOnStartup)
+	t.Run("failing-enabled-default-operator-sources", testsuites.FailingEnabledDefaultOperatorSources)
 }

--- a/test/testsuites/clusteroperatorstatustests.go
+++ b/test/testsuites/clusteroperatorstatustests.go
@@ -7,14 +7,21 @@ import (
 	"time"
 
 	configv1 "github.com/openshift/api/config/v1"
+	cohelpers "github.com/openshift/library-go/pkg/config/clusteroperator/v1helpers"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
+	"github.com/operator-framework/operator-marketplace/test/helpers"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 	"k8s.io/apimachinery/pkg/types"
 	"k8s.io/apimachinery/pkg/util/wait"
+)
+
+const (
+	// clusterOperatorName is the name of the ClusterOperator associated with marketplace.
+	clusterOperatorName = "marketplace"
 )
 
 // ClusterOperatorStatusOnStartup is a test suite that ensures the ClusterOperator resource which
@@ -32,7 +39,6 @@ func ClusterOperatorStatusOnStartup(t *testing.T) {
 	require.NoError(t, err, "Could not get namespace")
 
 	// Check that the ClusterOperator resource has the correct status
-	clusterOperatorName := "marketplace"
 	expectedTypeStatus := map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{
 		configv1.OperatorUpgradeable: configv1.ConditionTrue,
 		configv1.OperatorProgressing: configv1.ConditionFalse,
@@ -82,4 +88,57 @@ func ClusterOperatorStatusOnStartup(t *testing.T) {
 		},
 	}
 	assert.ElementsMatch(t, result.Status.RelatedObjects, expectedRelatedObjects, "ClusterOperator did not list the exepcted RelatedObjects")
+}
+
+// FailingEnabledDefaultOperatorSources is a test suite that ensures that the ClusterOperator resource
+// reports degraded when default enabled OperstorSources are failing.
+func FailingEnabledDefaultOperatorSources(t *testing.T) {
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	// Get namespace.
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	require.NoError(t, err, "Could not get namespace")
+
+	// Get the client.
+	client := test.Global.Client
+
+	// Create the EgressNetworkPolicy without an error.
+	egress := helpers.CreateEgressNetworkPolicyDefinition(namespace)
+	err = helpers.CreateRuntimeObjectNoCleanup(client, egress)
+	require.NoError(t, err, "Unable to create EgressNetworkPolicy")
+
+	// Reconcile existing OperatorSources.
+	err = helpers.ReconcileOperatorSources(client, ctx)
+	assert.NoError(t, err, "Unable to update OperatorSources")
+
+	// Wait for the marketplace operator to report that it has degraded.
+	err = pollForClusterStatusCondition(client, namespace, configv1.OperatorDegraded, configv1.ConditionTrue)
+	assert.NoError(t, err, "ClusterOperator never reached expected status")
+
+	// Delete the EgressNetworkPolicy without an error.
+	err = helpers.DeleteRuntimeObject(client, egress)
+	require.NoError(t, err, "Unable to delete EgressNetworkPolicy")
+
+	// Wait for the marketplace operator to report that it is not degraded.
+	err = pollForClusterStatusCondition(client, namespace, configv1.OperatorDegraded, configv1.ConditionFalse)
+	assert.NoError(t, err, "ClusterOperator never reached expected status")
+}
+
+// pollForClusterStatusCondition polls the marketplace ClusterOperator to check if the given
+// ClusterStatusConditionType's status matches the provided ConditionStatus.
+func pollForClusterStatusCondition(client test.FrameworkClient, namespace string, conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus) error {
+	namespacedName := types.NamespacedName{Name: clusterOperatorName, Namespace: namespace}
+	result := &configv1.ClusterOperator{}
+	return wait.PollImmediate(helpers.RetryInterval, helpers.Timeout, func() (done bool, err error) {
+		err = client.Get(context.TODO(), namespacedName, result)
+		if err != nil {
+			return false, err
+		}
+
+		if conditionStatus == cohelpers.FindStatusCondition(result.Status.Conditions, conditionType).Status {
+			return true, nil
+		}
+		return false, nil
+	})
 }


### PR DESCRIPTION
This PR introduces a change so the marketplace operator will report
that it has degraded when one of the the enabled default
OperatorSources are unable to reach the succeeded phase.