### PR TITLE
Bug 1731338: OPSRC and CSC deployment name collision

### DIFF
--- a/pkg/grpccatalog/grpccatalog.go
+++ b/pkg/grpccatalog/grpccatalog.go
@@ -96,12 +96,13 @@ func (r *GrpcCatalog) EnsureResources(key types.NamespacedName, displayName, pub
 // newCatalogSource returns a CatalogSource object.
 func newCatalogSource(labels map[string]string, key types.NamespacedName, displayName, publisher, namespace, address, owner string) *olm.CatalogSource {
 	builder := new(builders.CatalogSourceBuilder).
-		WithMeta(key.Name, key.Namespace).
 		WithSpec(olm.SourceTypeGrpc, address, displayName, publisher)
 	if owner == v1.OperatorSourceKind {
-		builder.WithOpsrcOwnerLabel(key.Name, namespace)
+		builder.WithMeta(registry.OperatorSourceDepPrefix+key.Name, key.Namespace).
+			WithOpsrcOwnerLabel(key.Name, namespace)
 	} else if owner == v2.CatalogSourceConfigKind {
-		builder.WithCscOwnerLabel(key.Name, namespace)
+		builder.WithMeta(registry.CatalogSourceConfigDepPrefix+key.Name, key.Namespace).
+			WithCscOwnerLabel(key.Name, namespace)
 	}
 	// Check if the operatorsource.DatastoreLabel is "true" which indicates that
 	// the CatalogSource is the datastore for an OperatorSource. This is a hint

--- a/test/testsuites/operatorhubtests.go
+++ b/test/testsuites/operatorhubtests.go
@@ -312,7 +312,7 @@ func checkOpSrcAndChildrenArePresent(name, namespace string) error {
 // checkOpSrcAndChildrenAreDeleted checks if the OperatorSource and its child resources have been deleted.
 func checkOpSrcAndChildrenAreDeleted(name, namespace string) error {
 	client := test.Global.Client
-	err := helpers.CheckChildResourcesDeleted(client, name, namespace, namespace)
+	err := helpers.CheckChildResourcesDeleted(client, name, namespace, namespace, v1.OperatorSourceKind)
 	if err != nil {
 		return err
 	}

--- a/test/testsuites/opsrccreationtests.go
+++ b/test/testsuites/opsrccreationtests.go
@@ -34,13 +34,16 @@ func testOperatorSourceGeneratesExpectedObjects(t *testing.T) {
 	namespace, err := test.NewTestCtx(t).GetNamespace()
 	require.NoError(t, err, "Could not get namespace")
 
+	// Determine resource name
+	resourceName := helpers.AddChildResourcePrefix(helpers.TestOperatorSourceName, v1.OperatorSourceKind)
+
 	// Check for child resources.
 	err = helpers.CheckChildResourcesCreated(test.Global.Client, helpers.TestOperatorSourceName, namespace, namespace, v1.OperatorSourceKind)
 	require.NoError(t, err)
 
 	// Check that the CatalogSource has the expected labels.
 	resultCatalogSource := &olm.CatalogSource{}
-	err = helpers.WaitForResult(test.Global.Client, resultCatalogSource, namespace, helpers.TestOperatorSourceName)
+	err = helpers.WaitForResult(test.Global.Client, resultCatalogSource, namespace, resourceName)
 	require.NoError(t, err)
 	labels := resultCatalogSource.GetLabels()
 	groupGot, ok := labels[helpers.TestOperatorSourceLabelKey]
@@ -61,6 +64,9 @@ func testRegistryDeploymentRetainsChanges(t *testing.T) {
 	namespace, err := test.NewTestCtx(t).GetNamespace()
 	require.NoError(t, err, "Could not get namespace")
 
+	// Determine resource name
+	resourceName := helpers.AddChildResourcePrefix(helpers.TestOperatorSourceName, v1.OperatorSourceKind)
+
 	// Check for child resources.
 	err = helpers.CheckChildResourcesCreated(test.Global.Client, helpers.TestOperatorSourceName, namespace, namespace,
 		v1.OperatorSourceKind)
@@ -69,7 +75,7 @@ func testRegistryDeploymentRetainsChanges(t *testing.T) {
 	client := test.Global.Client
 
 	// Get the registry deployment of the test OperatorSource
-	deployment := getRegistryDeployment(t, helpers.TestOperatorSourceName, namespace)
+	deployment := getRegistryDeployment(t, resourceName, namespace)
 	require.NotNil(t, deployment)
 
 	// Add an annotation to the pod template and update the deployment
@@ -97,7 +103,7 @@ func testRegistryDeploymentRetainsChanges(t *testing.T) {
 	require.NoError(t, err)
 
 	// Get the registry deployment again
-	deployment = getRegistryDeployment(t, helpers.TestOperatorSourceName, namespace)
+	deployment = getRegistryDeployment(t, resourceName, namespace)
 	require.NotNil(t, deployment)
 
 	// Check that the annotation was present after the OperatorSource update

--- a/test/testsuites/opsrcdeletetests.go
+++ b/test/testsuites/opsrcdeletetests.go
@@ -43,6 +43,6 @@ func testDeleteOpSrc(t *testing.T) {
 
 	// Now let's wait until the OperatorSource is successfully deleted and the
 	// child resources are removed.
-	err = helpers.CheckChildResourcesDeleted(test.Global.Client, testOperatorSource.Name, namespace, namespace)
+	err = helpers.CheckChildResourcesDeleted(test.Global.Client, testOperatorSource.Name, namespace, namespace, v1.OperatorSourceKind)
 	require.NoError(t, err, "Could not ensure child resources were deleted.")
 }

--- a/test/testsuites/packagestests.go
+++ b/test/testsuites/packagestests.go
@@ -84,7 +84,7 @@ func childResourcesNotCreated(t *testing.T) {
 	require.NoError(t, err, "Could not get namespace")
 
 	// Check that the CatalogSourceConfig's child resources were not created.
-	err = helpers.CheckChildResourcesDeleted(test.Global.Client, cscName, namespace, namespace)
+	err = helpers.CheckChildResourcesDeleted(test.Global.Client, cscName, namespace, namespace, v2.CatalogSourceConfigKind)
 	assert.NoError(t, err, "Child resources of CatalogSourceConfig were unexpectedly created")
 }
 

--- a/test/testsuites/proxytests.go
+++ b/test/testsuites/proxytests.go
@@ -6,6 +6,8 @@ import (
 	"testing"
 
 	apiconfigv1 "github.com/openshift/api/config/v1"
+	v1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	v2 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
 	"github.com/operator-framework/operator-marketplace/test/helpers"
 	"github.com/operator-framework/operator-sdk/pkg/test"
 	"github.com/stretchr/testify/assert"
@@ -26,14 +28,16 @@ func ProxyTests(t *testing.T) {
 // created by an OperatorSource has the appropriate proxy environment
 // variables set.
 func testOpSrcRegistryIncludesProxyVars(t *testing.T) {
-	assert.NoError(t, checkDeploymentIncludesProxyVars(t, helpers.TestOperatorSourceName))
+	resourceName := helpers.AddChildResourcePrefix(helpers.TestOperatorSourceName, v1.OperatorSourceKind)
+	assert.NoError(t, checkDeploymentIncludesProxyVars(t, resourceName))
 }
 
 // testCsdRegistry ensures that the Operator Registry deployment
 // created by an OperatorSource has the appropriate proxy environment
 // variables set.
 func testCscRegistryIncludesProxyVars(t *testing.T) {
-	assert.NoError(t, checkDeploymentIncludesProxyVars(t, helpers.TestCatalogSourceConfigName))
+	resourceName := helpers.AddChildResourcePrefix(helpers.TestCatalogSourceConfigName, v2.CatalogSourceConfigKind)
+	assert.NoError(t, checkDeploymentIncludesProxyVars(t, resourceName))
 }
 
 // checkDeploymentIncludesProxyVars checks if the deployment has the appropriate

--- a/test/testsuites/watchtests.go
+++ b/test/testsuites/watchtests.go
@@ -87,13 +87,15 @@ func deleteCheckRestoreChild(t *testing.T, child string, owner string) error {
 	client := test.Global.Client
 
 	var obj runtime.Object
-	var name, targetNamespace string
+	var name, targetNamespace, resourceName string
 
 	switch owner {
 	case v2.CatalogSourceConfigKind:
+		resourceName = helpers.AddChildResourcePrefix(helpers.TestCatalogSourceConfigName, owner)
 		name = helpers.TestCatalogSourceConfigName
 		targetNamespace = helpers.TestCatalogSourceConfigTargetNamespace
 	case v1.OperatorSourceKind:
+		resourceName = helpers.AddChildResourcePrefix(helpers.TestOperatorSourceName, owner)
 		name = helpers.TestOperatorSourceName
 		targetNamespace = namespace
 	default:
@@ -101,7 +103,7 @@ func deleteCheckRestoreChild(t *testing.T, child string, owner string) error {
 	}
 
 	objMeta := meta.ObjectMeta{
-		Name:      name,
+		Name:      resourceName,
 		Namespace: namespace,
 	}
 
@@ -112,7 +114,7 @@ func deleteCheckRestoreChild(t *testing.T, child string, owner string) error {
 				Kind: olm.CatalogSourceKind,
 			},
 			ObjectMeta: meta.ObjectMeta{
-				Name:      name,
+				Name:      resourceName,
 				Namespace: targetNamespace,
 			},
 		}


### PR DESCRIPTION
Add a prefix to deployment's name to distinguish the deployments from
catalog source config and operator source.

Signed-off-by: Vu Dinh <vdinh@redhat.com>