### PR TITLE
Bug 1739562: [migration] Don't kill due to invalid subscription

### DIFF
--- a/test/testgroups/migrationtests.go
+++ b/test/testgroups/migrationtests.go
@@ -35,12 +35,16 @@ func MigrationTestGroup(t *testing.T) {
 	}
 
 	// Create the UI Subscription
-	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateSubscriptionDefinition(helpers.TestUISubscriptionName, namespace, true))
+	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateSubscriptionDefinition(helpers.TestUISubscriptionName, namespace, helpers.TestInstalledCscPublisherName, true))
 	require.NoError(t, err, "Could not create UI Subscription")
 
 	// Create the User Subscription
-	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateSubscriptionDefinition(helpers.TestUserCreatedSubscriptionName, namespace, false))
+	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateSubscriptionDefinition(helpers.TestUserCreatedSubscriptionName, namespace, helpers.TestInstalledCscPublisherName, false))
 	require.NoError(t, err, "Could not create User Subscription")
+
+	// Create a Subscription that points to a non existent CatalogSourceConfig
+	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateSubscriptionDefinition(helpers.TestInvalidSubscriptionName, namespace, helpers.TestInvalidCscName, false))
+	require.NoError(t, err, "Could not create Invalid Subscription")
 
 	// Create a CatalogSourceConfig.
 	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, helpers.CreateCatalogSourceConfigDefinition(helpers.TestCatalogSourceConfigName, namespace, namespace))


### PR DESCRIPTION
Currently, the migration code (to move objects from 4.1 -> 4.2 by
removing the catalogsourceconfig from the install path of OLM) iterates
over each subscription and attempts find a valid catalog source to
associate it with. Right now however, there is logic to abort starting
the operator if there are errors finding an association during this
process.

This seems problematic, given that it is entirely possible that any
given subscription can be generated by the user and may be invalid.
Instead we should do a best effort to attempt to create this association
and in the case that we cannot find a suitable one we simply log a
warning and continue as usual.

Additionally, this pr fixes an issue where, in the case where the
subscription points to a specific catalog source config (through labels)
and the package listed is invalid (or is just not set) that a null pointer
exception could occur and the marketplace would crash.

Associated bugzilla:
https://bugzilla.redhat.com/show_bug.cgi?id=1739562