### PR TITLE
Bug 1740824: Fix degraded status on upgrade

### DIFF
--- a/deploy/operator.yaml
+++ b/deploy/operator.yaml
@@ -55,6 +55,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "marketplace-operator"
             - name: "RELEASE_VERSION"

--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -62,6 +62,19 @@ rules:
   - update
   - list
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/deploy/upstream/05_role.yaml
+++ b/deploy/upstream/05_role.yaml
@@ -53,6 +53,19 @@ rules:
   - update
   - list
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/deploy/upstream/08_operator.yaml
+++ b/deploy/upstream/08_operator.yaml
@@ -40,5 +40,9 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "marketplace-operator"

--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -62,6 +62,19 @@ rules:
   - update
   - list
 - apiGroups:
+  - ""
+  resources:
+  - configmaps
+  verbs:
+  - get
+  - create
+- apiGroups:
+  - ""
+  resources:
+  - pods
+  verbs:
+  - get
+- apiGroups:
   - apps
   resources:
   - deployments

--- a/manifests/10_operator.yaml
+++ b/manifests/10_operator.yaml
@@ -55,6 +55,10 @@ spec:
               valueFrom:
                 fieldRef:
                   fieldPath: metadata.namespace
+            - name: POD_NAME
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.name
             - name: OPERATOR_NAME
               value: "marketplace-operator"
             - name: "RELEASE_VERSION"

--- a/pkg/catalogsourceconfig/handler.go
+++ b/pkg/catalogsourceconfig/handler.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
+	operatorstatus "github.com/operator-framework/operator-marketplace/pkg/status"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
 
@@ -72,6 +73,9 @@ func (h *catalogsourceconfighandler) Handle(ctx context.Context, in *marketplace
 	// case, we need to update the modified CatalogSourceConfig object.
 	if updateErr := h.client.Update(ctx, out); updateErr != nil {
 		log.Errorf("Failed to update object - %v", updateErr)
+
+		// Error updating the object - report a failed sync.
+		operatorstatus.SendSyncMessage(updateErr)
 
 		if err == nil {
 			// No reconciliation err, but update of object has failed!

--- a/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
+++ b/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
@@ -84,16 +84,9 @@ func (r *ReconcileCatalogSourceConfig) Reconcile(request reconcile.Request) (rec
 	// Reconcile kicked off, message Sync Channel
 	status.SendSyncMessage(nil)
 
-	// If err is not nil at the end of this function message the syncCh channel
-	var err error
-	defer func() {
-		if err != nil {
-			status.SendSyncMessage(err)
-		}
-	}()
 	// Fetch the CatalogSourceConfig instance
 	instance := &marketplace.CatalogSourceConfig{}
-	err = r.client.Get(context.TODO(), request.NamespacedName, instance)
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -101,7 +94,8 @@ func (r *ReconcileCatalogSourceConfig) Reconcile(request reconcile.Request) (rec
 			// Return and don't requeue
 			return reconcile.Result{}, nil
 		}
-		// Error reading the object - requeue the request.
+		// Error reading the object - report a failed sync and requeue the request.
+		status.SendSyncMessage(err)
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/controller/operatorsource/operatorsource_controller.go
+++ b/pkg/controller/operatorsource/operatorsource_controller.go
@@ -67,16 +67,9 @@ func (r *ReconcileOperatorSource) Reconcile(request reconcile.Request) (reconcil
 	// Reconcile kicked off, message Sync Channel with sync event
 	status.SendSyncMessage(nil)
 
-	// If err is not nil at the end of this function message the syncCh channel
-	var err error
-	defer func() {
-		if err != nil {
-			status.SendSyncMessage(err)
-		}
-	}()
 	// Fetch the OperatorSource instance
 	instance := &marketplace.OperatorSource{}
-	err = r.client.Get(context.TODO(), request.NamespacedName, instance)
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
 	if err != nil {
 		if errors.IsNotFound(err) {
 			// Request object not found, could have been deleted after reconcile request.
@@ -84,7 +77,8 @@ func (r *ReconcileOperatorSource) Reconcile(request reconcile.Request) (reconcil
 			// Return and don't requeue
 			return reconcile.Result{}, nil
 		}
-		// Error reading the object - requeue the request.
+		// Error reading the object - report a failed sync and requeue the request.
+		status.SendSyncMessage(err)
 		return reconcile.Result{}, err
 	}
 

--- a/pkg/operatorsource/handler.go
+++ b/pkg/operatorsource/handler.go
@@ -7,6 +7,7 @@ import (
 	"github.com/operator-framework/operator-marketplace/pkg/appregistry"
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
+	"github.com/operator-framework/operator-marketplace/pkg/status"
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
 	"sigs.k8s.io/controller-runtime/pkg/manager"
@@ -109,6 +110,9 @@ func (h *operatorsourcehandler) transition(ctx context.Context, logger *log.Entr
 	// In either case, we need to update the modified OperatorSource object.
 	if updateErr := h.client.Update(ctx, opsrc); updateErr != nil {
 		logger.Errorf("Failed to update object - %v", updateErr)
+
+		// Error updating the object - report a failed sync.
+		status.SendSyncMessage(updateErr)
 
 		if reconciliationErr == nil {
 			// No reconciliation err, but update of object has failed!

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -323,8 +323,7 @@ func (s *status) monitorClusterStatus() {
 	for {
 		select {
 		case <-s.stopCh:
-			// If the stopCh is closed, the operator will exit and CO should
-			// be set to degraded.
+			// If the stopCh is closed, set all ClusterOperatorStatus conditions to false.
 			conditionListBuilder := clusterStatusListBuilder()
 			conditionListBuilder(configv1.OperatorProgressing, configv1.ConditionFalse, "")
 			conditionListBuilder(configv1.OperatorAvailable, configv1.ConditionFalse, "The operator has exited and is no longer reporting status.")

--- a/pkg/status/syncutils.go
+++ b/pkg/status/syncutils.go
@@ -39,14 +39,15 @@ func compareClusterOperatorStatusConditions(a configv1.ClusterOperatorStatusCond
 	return false
 }
 
-func clusterStatusListBuilder() func(conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus, conditionMessage string) []configv1.ClusterOperatorStatusCondition {
+func clusterStatusListBuilder() func(conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus, conditionMessage, reason string) []configv1.ClusterOperatorStatusCondition {
 	time := v1.Now()
 	list := []configv1.ClusterOperatorStatusCondition{}
-	return func(conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus, conditionMessage string) []configv1.ClusterOperatorStatusCondition {
+	return func(conditionType configv1.ClusterStatusConditionType, conditionStatus configv1.ConditionStatus, conditionMessage, reason string) []configv1.ClusterOperatorStatusCondition {
 		list = append(list, configv1.ClusterOperatorStatusCondition{
 			Type:               conditionType,
 			Status:             conditionStatus,
 			Message:            conditionMessage,
+			Reason:             reason,
 			LastTransitionTime: time,
 		})
 		return list


### PR DESCRIPTION
Bug 1740824: Fix Degraded status on upgrade

Problem: There are three bugs that should be addressed within this bugzilla:

During an upgrade, multiple marketplace operators are running and updating the ClusterOperatorStatus at the same time, making it difficult to identify the actual state of the marketplace operator.
The marketplace operator is reporting degraded while it is upgrading. The marketplace operator reports degraded when the number of failed syncs surpasses some threshold of total syncs. The marketplace operator currently reports a failed sync whenever an error is encountered while reconciling an operand (OperatorSources or CatalogSourceConfigs). This allows network issues or invalid operands to drive the marketplace operator to a degraded state.
It is difficult to identify why a ClusterOperatorStatus condition is in a given state via telemetry. Marketplace currently does not set a reason when setting conditions and telemetry only includes the state and reason.
Solution: Three changes need to be made to address the bugzilla:

Implement leader election using the functions provided by the Operator-SDK to prevent multiple marketplace operators from updating the ClusterOperatorStatus at the same time.
Rather than reporting a failed sync whenever an error is encountered while reconciling an operand, report a failed sync when the marketplace operator is unable to get or update an existing operand.
Update marketplace to include a reason when setting a condition that indicates why the condition is being set.