### PR TITLE
Fix broken links - OLM Documentation was replaced by doc

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ $ oc apply -f deploy/operator.yaml
 
 ## Marketplace-operator on vanilla Kubernetes
 
-- To set up marketplace-operator on vanilla Kubernetes, [install Operator-Lifecycle-Manager(OLM)](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/install/install.md) in a Kubernetes Cluster. 
+- To set up marketplace-operator on vanilla Kubernetes, [install Operator-Lifecycle-Manager(OLM)](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md) in a Kubernetes Cluster. 
 - `cd` into the marketplace-operator repository and install the marketplace-operator using 
 ```
 $ kubectl apply -f deploy/upstream

--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ Marketplace is a conduit to bring off-cluster operators to your cluster.
 
 ## Prerequisites
 In order to deploy the Marketplace Operator, you must:
-1. Have an OKD or a Kubernetes cluster with Operator Lifecycle Manager (OLM) [installed](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/install/install.md).
+1. Have an OKD or a Kubernetes cluster with Operator Lifecycle Manager (OLM) [installed](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md).
 2. Be logged in as a user with Cluster Admin role.
 
 ## Using the Marketplace Operator
@@ -59,7 +59,7 @@ Please note that the Marketplace operator uses `CatalogSourceConfigs` and `Catal
 The Marketplace Operator is deployed by default with OKD and no further steps are required.
 
 ### Deploying the Marketplace Operator with Kubernetes
-First ensure that the [Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/install/install.md#install-the-latest-released-version-of-olm-for-upstream-kubernetes) is installed on your cluster.
+First ensure that the [Operator Lifecycle Manager](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/install/install.md#install-the-latest-released-version-of-olm-for-upstream-kubernetes) is installed on your cluster.
 
 #### Deploying the Marketplace Operator
 ```bash

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -2,7 +2,7 @@
 
 This document lists out some common failures related to the Marketplace Operator a user might encounter, along with ways to troubleshoot the failures. If you encouter a failure related to the Marketplace Operator that is not listed in this document, but should be, please open an issue or a PR to have the failure appended to this document. 
 
-The troubleshooting steps listed here are for Marketplace resources like OperatorSource and CatalogSourceConfig. To troubleshoot [Operator-lifecycle-manager(OLM)](https://github.com/operator-framework/operator-lifecycle-manager) defined resources like ClusterServiceVersion, InstallPlan, Subscription etc, refer to the [OLM troubleshooting guide](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/Documentation/design/debugging.md).
+The troubleshooting steps listed here are for Marketplace resources like OperatorSource and CatalogSourceConfig. To troubleshoot [Operator-lifecycle-manager(OLM)](https://github.com/operator-framework/operator-lifecycle-manager) defined resources like ClusterServiceVersion, InstallPlan, Subscription etc, refer to the [OLM troubleshooting guide](https://github.com/operator-framework/operator-lifecycle-manager/blob/master/doc/design/debugging.md).
 
 Note that all examples in this doc are are meant to be ran against an OpenShift cluster. All examples (except for the ones involving the UI) should work with `kubectl` and with the appropriate namespaces substituted in them.   
 


### PR DESCRIPTION
**Description of the change:**
The Dir of docs in OLM was changed from Documentation to doc. This change is to fix the broken links. 

**Motivation for the change:**

- https://github.com/operator-framework/operator-sdk/issues/1887
