### PR TITLE
[deploy] Sync deploy and manifest dirs

### DIFF
--- a/deploy/service_monitor.yaml
+++ b/deploy/service_monitor.yaml
@@ -14,3 +14,34 @@ spec:
   selector:
     matchLabels:
       name: marketplace-operator
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: RoleBinding
+metadata:
+  name: openshift-marketplace-metrics
+  namespace: openshift-marketplace
+roleRef:
+  apiGroup: rbac.authorization.k8s.io
+  kind: Role
+  name: openshift-marketplace-metrics
+subjects:
+- kind: ServiceAccount
+  name: prometheus-k8s
+  namespace: openshift-monitoring
+---
+apiVersion: rbac.authorization.k8s.io/v1
+kind: Role
+metadata:
+  name: openshift-marketplace-metrics
+  namespace: openshift-marketplace
+rules:
+- apiGroups:
+  - ""
+  resources:
+  - services
+  - endpoints
+  - pods
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
The ServiceMonitor yaml defined in the deploy dir did not contain
required  RBAC permissions for the prometheus-k8s ServiceAccount.
This commit introduces the missing RBAC permissions.