### PR TITLE
Bug 1750654: The phase message of csc won't change when the env changed

### DIFF
--- a/pkg/catalogsourceconfig/configuring.go
+++ b/pkg/catalogsourceconfig/configuring.go
@@ -74,7 +74,8 @@ func (r *configuringReconciler) Reconcile(ctx context.Context, in *v2.CatalogSou
 		}
 		out.Spec.Source = newSource
 	} else if !r.reader.DoesSourceExist(out.Spec.Source) {
-		nextPhase = phase.GetNextWithMessage(phase.Configuring, fmt.Sprintf("Provided source (%s) does not exist", out.Spec.Source))
+		err = fmt.Errorf("Provided source (%s) does not exist", out.Spec.Source)
+		nextPhase = phase.GetNextWithMessage(phase.Configuring, err.Error())
 		return
 	}
 

--- a/test/testsuites/csctargetnamespacetests.go
+++ b/test/testsuites/csctargetnamespacetests.go
@@ -70,7 +70,7 @@ func configuringStateWhenTargetNamespaceDoesNotExist(t *testing.T) {
 	namespace, err := test.NewTestCtx(t).GetNamespace()
 	require.NoError(t, err, "Could not get namespace")
 
-	// Check that the CatalogSourceConfig with an non-existing targetNamespace eventually reaches the
+	// Check that the CatalogSourceConfig with an non-existent targetNamespace eventually reaches the
 	// configuring phase with the expected message.
 	expectedPhase := "Configuring"
 	expectedMessage := fmt.Sprintf("namespaces \"%s\" not found", targetNamespace)


### PR DESCRIPTION
Problem:
If a CatalogSourceConfig specifies a source that does not exist the
CatalogSourceConfig will get stuck in the configuring phase. This error
is encountered because the Reconcile method for the CatalogSourceConfig
is not returning an error, causing the handler not to reconcile the
CatalogSourceConfig.

Solution:
Update the CatalogSourceConfig Configuring Reconcile method to return an
error. Also adds e2e tests to prevent regressions in the future.