### PR TITLE
Bug 1732164: Rename marketplace rules

### DIFF
--- a/deploy/prometheus_rule.yaml
+++ b/deploy/prometheus_rule.yaml
@@ -8,7 +8,7 @@ metadata:
     role: alert-rules
 spec:
   groups:
-    - name: ./marketplace.rules
+    - name: marketplace.rules
       rules:
         - alert: community-operators-alert
           expr: increase(app_registry_request_total{code!="200",opsrc="community-operators"}[10m]) > 10

--- a/manifests/12_prometheus_rule.yaml
+++ b/manifests/12_prometheus_rule.yaml
@@ -8,7 +8,7 @@ metadata:
     role: alert-rules
 spec:
   groups:
-    - name: ./marketplace.rules
+    - name: marketplace.rules
       rules:
         - alert: community-operators-alert
           expr: increase(app_registry_request_total{code!="200",opsrc="community-operators"}[10m]) > 10


### PR DESCRIPTION
This commit introduces a change that renames the  marketplace rule
group from "./marketplace.rules" to  "marketplace.rules". This change
is meant to keep marketplace inline with the conventions followed by
other OpenShift operators.