### PR TITLE
Bug 1731338: OPSRC and CSC child resources name conflict

### DIFF
--- a/pkg/operatorsource/configuring_test.go
+++ b/pkg/operatorsource/configuring_test.go
@@ -9,7 +9,6 @@ import (
 	corev1 "k8s.io/api/core/v1"
 
 	// metav1 "k8s.io/apimachinery/pkg/apis/meta/v1"
-	"k8s.io/apimachinery/pkg/runtime/schema"
 
 	gomock "github.com/golang/mock/gomock"
 	"github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -20,7 +19,6 @@ import (
 	mocks "github.com/operator-framework/operator-marketplace/pkg/mocks/operatorsource_mocks"
 	"github.com/operator-framework/operator-marketplace/pkg/operatorsource"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
-	k8s_errors "k8s.io/apimachinery/pkg/api/errors"
 )
 
 // Use Case: Registry returns a non-empty list of metadata
@@ -282,75 +280,4 @@ func TestReconcile_CatalogSourceConfigAlreadyExists_Updated(t *testing.T) {
 	assert.Equal(t, opsrcIn, opsrcGot)
 	assert.Equal(t, nextPhaseWant, nextPhaseGot)
 	assert.Equal(t, requeueWant, requeueGot)
-}
-
-// Use Case: Update of existing CatalogSourceConfig object fails.
-// Expected Result: The object is moved to "Failed" phase.
-func TestReconcile_UpdateError_MovedToFailedPhase(t *testing.T) {
-	controller := gomock.NewController(t)
-	defer controller.Finish()
-
-	namespace, name := "marketplace", "foo"
-
-	updateError := k8s_errors.NewServerTimeout(schema.GroupResource{}, "operation", 1)
-	nextPhaseWant := &shared.Phase{
-		Name:    phase.Configuring,
-		Message: updateError.Error(),
-	}
-
-	requeueWant := false
-
-	writer := mocks.NewDatastoreWriter(controller)
-	reader := mocks.NewDatastoreReader(controller)
-	factory := mocks.NewAppRegistryClientFactory(controller)
-	registryClient := mocks.NewAppRegistryClient(controller)
-	refresher := mocks.NewSyncerPackageRefreshNotificationSender(controller)
-	kubeclient := mocks.NewClient(controller)
-
-	reconciler := operatorsource.NewConfiguringReconcilerWithClientInterface(helperGetContextLogger(), factory, writer, reader, kubeclient, refresher)
-
-	ctx := context.TODO()
-	opsrcIn := helperNewOperatorSourceWithPhase(namespace, name, phase.Configuring)
-
-	optionsWant := appregistry.Options{Source: opsrcIn.Spec.Endpoint}
-	factory.EXPECT().New(optionsWant).Return(registryClient, nil).Times(1)
-
-	// We expect the remote registry to return a non-empty list of manifest(s).
-	manifestExpected := []*datastore.RegistryMetadata{
-		&datastore.RegistryMetadata{
-			Namespace:  "redhat",
-			Repository: "myapp",
-			Release:    "1.0.0",
-			Digest:     "abcdefgh",
-		},
-	}
-	registryClient.EXPECT().ListPackages(opsrcIn.Spec.RegistryNamespace).Return(manifestExpected, nil).Times(1)
-
-	// We expect the datastore to save downloaded manifest(s) returned by the registry.
-	writer.EXPECT().Write(opsrcIn, manifestExpected).Return(1, nil)
-
-	// The first time we ask for the packages from the datastore, we expect to get nothing.
-	writer.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID()).Return("")
-
-	// Then we expect to call send refresh, because the package list was empty.
-	refresher.EXPECT().SendRefresh(gomock.Any())
-
-	writer.EXPECT().GetPackageIDsByOperatorSource(opsrcIn.GetUID())
-
-	// Then we expect to read the packages
-	reader.EXPECT().CheckPackages(gomock.Any(), gomock.Any()).Return(nil)
-
-	// Then we expect a read to the datastore
-	reader.EXPECT().Read(gomock.Any(), gomock.Any()).Return(&datastore.OpsrcRef{}, nil).AnyTimes()
-
-	// replicas := int32(1)
-	kubeclient.EXPECT().Get(context.TODO(), gomock.Any(), gomock.Any()).Return(nil)
-	kubeclient.EXPECT().Update(context.TODO(), gomock.Any()).Return(updateError)
-
-	_, nextPhaseGot, requeueWant, errGot := reconciler.Reconcile(ctx, opsrcIn)
-
-	assert.Error(t, errGot)
-	assert.Equal(t, updateError, errGot)
-	assert.Equal(t, nextPhaseWant, nextPhaseGot)
-	assert.Equal(t, requeueWant, requeueWant)
 }


### PR DESCRIPTION
Currently, if opsrc and csc with the same name are created, both
are created with Succeeded status despite the latter one doesn't
have a deployment for registry pod as marketplace reclaims the
existitng deployment with the same name that belongs to opsrc/csc
that is created first.

By adding ownership validation via labels, child resource such as
deployment cannot be reclaimed unless it is owned by a correct
opsrc/csc. As a result, whichever opsrc/csc is created latter will
fail to reach Succeeded state as it is unable to create child resouces
due to name conflicts nor reclaim those resources as it doesn't own
those resources.

Signed-off-by: Vu Dinh <vdinh@redhat.com>