### PR TITLE
Bug 1752063: increase initial delay for appregistry pods

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -397,8 +397,8 @@ func (r *registry) newPodTemplateSpec(registryCommand []string, needServiceAccou
 								Command: action,
 							},
 						},
-						InitialDelaySeconds: 5,
-						FailureThreshold:    30,
+						InitialDelaySeconds: 30,
+						FailureThreshold:    10,
 					},
 					LivenessProbe: &core.Probe{
 						Handler: core.Handler{
@@ -406,8 +406,8 @@ func (r *registry) newPodTemplateSpec(registryCommand []string, needServiceAccou
 								Command: action,
 							},
 						},
-						InitialDelaySeconds: 5,
-						FailureThreshold:    30,
+						InitialDelaySeconds: 30,
+						FailureThreshold:    10,
 					},
 					Resources: core.ResourceRequirements{
 						Requests: core.ResourceList{

--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -10,4 +10,4 @@ fi
 
 # Run the tests through the operator-sdk
 echo "Running operator-sdk test"
-operator-sdk test local ./test/e2e/ --no-setup --go-test-flags "-v -timeout 20m" --namespace $TEST_NAMESPACE
+operator-sdk test local ./test/e2e/ --no-setup --go-test-flags "-v -timeout 50m" --namespace $TEST_NAMESPACE


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This increases the initial delay for the readiness and liveness probes for the appregistry pods. 

**Motivation for the change:**
As more entries are added to appregistry, it takes longer to download them on startup. Since we are moving away from appregistry, we're mitigating the issue by increasing the startup time, rather than coming up with solutions that report ready faster.

Before merging, I would like to take a look at the ci cluster and ensure that the pods are not emitting events that signal an error for readiness probes.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
