### PR TITLE
Bug 1768483: Limit Cardinality of Marketplace quay metrics

### DIFF
--- a/deploy/prometheus_rule.yaml
+++ b/deploy/prometheus_rule.yaml
@@ -8,11 +8,60 @@ metadata:
     role: alert-rules
 spec:
   groups:
-    - name: marketplace.rules
+    - name: marketplace.community_operators.rules
       rules:
-        - alert: community-operators-alert
-          expr: increase(app_registry_request_total{code!="200",opsrc="community-operators"}[10m]) > 10
-        - alert: certified-operators-alert
-          expr: increase(app_registry_request_total{code!="200",opsrc="certified-operators"}[10m]) > 10
-        - alert: redhat-operators-alert
-          expr: increase(app_registry_request_total{code!="200",opsrc="redhat-operators"}[10m]) > 10
+        - record: app_registry:community_operators:1xx_response
+          expr: sum(app_registry_request_total{code=~"1..",opsrc="community-operators"})
+        - record: app_registry:community_operators:2xx_response
+          expr: sum(app_registry_request_total{code=~"2..",opsrc="community-operators"})
+        - record: app_registry:community_operators:3xx_response
+          expr: sum(app_registry_request_total{code=~"3..",opsrc="community-operators"})
+        - record: app_registry:community_operators:4xx_response
+          expr: sum(app_registry_request_total{code=~"4..",opsrc="community-operators"})
+        - record: app_registry:community_operators:5xx_response
+          expr: sum(app_registry_request_total{code=~"5..",opsrc="community-operators"})
+        - alert: CommunityOperatorConnectionErrors
+          annotations:
+            message: Unable to connect to the default OperatorSource community-operators AppRegistry for {{ $value }}% of requests.
+          expr: rate(app_registry_request_total{code!~"2..",opsrc="community-operators"}[5m]) / rate(app_registry_request_total{opsrc="community-operators"}[5m]) >= 0.5
+          for: 15m
+          labels:
+            severity: warning
+    - name: marketplace.certified_operators.rules
+      rules:
+        - record: app_registry:certified_operators:1xx_response
+          expr: sum(app_registry_request_total{code=~"1..",opsrc="certified-operators"})
+        - record: app_registry:certified_operators:2xx_response
+          expr: sum(app_registry_request_total{code=~"2..",opsrc="certified-operators"})
+        - record: app_registry:certified_operators:3xx_response
+          expr: sum(app_registry_request_total{code=~"3..",opsrc="certified-operators"})
+        - record: app_registry:certified_operators:4xx_response
+          expr: sum(app_registry_request_total{code=~"4..",opsrc="certified-operators"})
+        - record: app_registry:certified_operators:5xx_response
+          expr: sum(app_registry_request_total{code=~"5..",opsrc="certified-operators"})
+        - alert: CertifiedOperatorConnectionErrors
+          annotations:
+            message: Unable to connect to the default OperatorSource certified-operators AppRegistry for {{ $value }}% of requests.
+          expr: rate(app_registry_request_total{code!~"2..",opsrc="certified-operators"}[5m]) / rate(app_registry_request_total{opsrc="certified-operators"}[5m]) >= 0.5
+          for: 15m
+          labels:
+            severity: warning
+    - name: marketplace.redhat_operators.rules
+      rules:
+        - record: app_registry:redhat_operators:1xx_response
+          expr: sum(app_registry_request_total{code=~"1..",opsrc="redhat-operators"})
+        - record: app_registry:redhat_operators:2xx_response
+          expr: sum(app_registry_request_total{code=~"2..",opsrc="redhat-operators"})
+        - record: app_registry:redhat_operators:3xx_response
+          expr: sum(app_registry_request_total{code=~"3..",opsrc="redhat-operators"})
+        - record: app_registry:redhat_operators:4xx_response
+          expr: sum(app_registry_request_total{code=~"4..",opsrc="redhat-operators"})
+        - record: app_registry:redhat_operators:5xx_response
+          expr: sum(app_registry_request_total{code=~"5..",opsrc="redhat-operators"})
+        - alert: RedhatOperatorConnectionErrors
+          annotations:
+            message: Unable to connect to the default OperatorSource redhat-operators AppRegistry for {{ $value }}% of requests.
+          expr: rate(app_registry_request_total{code!~"2..",opsrc="redhat-operators"}[5m]) / rate(app_registry_request_total{opsrc="redhat-operators"}[5m]) >= 0.5
+          for: 15m
+          labels:
+            severity: warning

--- a/manifests/12_prometheus_rule.yaml
+++ b/manifests/12_prometheus_rule.yaml
@@ -8,11 +8,60 @@ metadata:
     role: alert-rules
 spec:
   groups:
-    - name: marketplace.rules
+    - name: marketplace.community_operators.rules
       rules:
-        - alert: community-operators-alert
-          expr: increase(app_registry_request_total{code!="200",opsrc="community-operators"}[10m]) > 10
-        - alert: certified-operators-alert
-          expr: increase(app_registry_request_total{code!="200",opsrc="certified-operators"}[10m]) > 10
-        - alert: redhat-operators-alert
-          expr: increase(app_registry_request_total{code!="200",opsrc="redhat-operators"}[10m]) > 10
+        - record: app_registry:community_operators:1xx_response
+          expr: sum(app_registry_request_total{code=~"1..",opsrc="community-operators"})
+        - record: app_registry:community_operators:2xx_response
+          expr: sum(app_registry_request_total{code=~"2..",opsrc="community-operators"})
+        - record: app_registry:community_operators:3xx_response
+          expr: sum(app_registry_request_total{code=~"3..",opsrc="community-operators"})
+        - record: app_registry:community_operators:4xx_response
+          expr: sum(app_registry_request_total{code=~"4..",opsrc="community-operators"})
+        - record: app_registry:community_operators:5xx_response
+          expr: sum(app_registry_request_total{code=~"5..",opsrc="community-operators"})
+        - alert: CommunityOperatorConnectionErrors
+          annotations:
+            message: Unable to connect to the default OperatorSource community-operators AppRegistry for {{ $value }}% of requests.
+          expr: rate(app_registry_request_total{code!~"2..",opsrc="community-operators"}[5m]) / rate(app_registry_request_total{opsrc="community-operators"}[5m]) >= 0.5
+          for: 15m
+          labels:
+            severity: warning
+    - name: marketplace.certified_operators.rules
+      rules:
+        - record: app_registry:certified_operators:1xx_response
+          expr: sum(app_registry_request_total{code=~"1..",opsrc="certified-operators"})
+        - record: app_registry:certified_operators:2xx_response
+          expr: sum(app_registry_request_total{code=~"2..",opsrc="certified-operators"})
+        - record: app_registry:certified_operators:3xx_response
+          expr: sum(app_registry_request_total{code=~"3..",opsrc="certified-operators"})
+        - record: app_registry:certified_operators:4xx_response
+          expr: sum(app_registry_request_total{code=~"4..",opsrc="certified-operators"})
+        - record: app_registry:certified_operators:5xx_response
+          expr: sum(app_registry_request_total{code=~"5..",opsrc="certified-operators"})
+        - alert: CertifiedOperatorConnectionErrors
+          annotations:
+            message: Unable to connect to the default OperatorSource certified-operators AppRegistry for {{ $value }}% of requests.
+          expr: rate(app_registry_request_total{code!~"2..",opsrc="certified-operators"}[5m]) / rate(app_registry_request_total{opsrc="certified-operators"}[5m]) >= 0.5
+          for: 15m
+          labels:
+            severity: warning
+    - name: marketplace.redhat_operators.rules
+      rules:
+        - record: app_registry:redhat_operators:1xx_response
+          expr: sum(app_registry_request_total{code=~"1..",opsrc="redhat-operators"})
+        - record: app_registry:redhat_operators:2xx_response
+          expr: sum(app_registry_request_total{code=~"2..",opsrc="redhat-operators"})
+        - record: app_registry:redhat_operators:3xx_response
+          expr: sum(app_registry_request_total{code=~"3..",opsrc="redhat-operators"})
+        - record: app_registry:redhat_operators:4xx_response
+          expr: sum(app_registry_request_total{code=~"4..",opsrc="redhat-operators"})
+        - record: app_registry:redhat_operators:5xx_response
+          expr: sum(app_registry_request_total{code=~"5..",opsrc="redhat-operators"})
+        - alert: RedhatOperatorConnectionErrors
+          annotations:
+            message: Unable to connect to the default OperatorSource redhat-operators AppRegistry for {{ $value }}% of requests.
+          expr: rate(app_registry_request_total{code!~"2..",opsrc="redhat-operators"}[5m]) / rate(app_registry_request_total{opsrc="redhat-operators"}[5m]) >= 0.5
+          for: 15m
+          labels:
+            severity: warning


### PR DESCRIPTION
This commit introduces a series of record rules that lump http status codes returned by Default AppRegistries into buckets of 100.

**Reviewer Checklist**
- [x] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [x] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive

Solves #264