### PR TITLE
Bug 1757099: Assume available status is true without defaults

### DIFF
--- a/pkg/operatorhub/operatorhub.go
+++ b/pkg/operatorhub/operatorhub.go
@@ -32,6 +32,7 @@ type operatorhub struct {
 type OperatorHub interface {
 	Get() map[string]bool
 	Set(spec configv1.OperatorHubSpec)
+	Disabled() bool
 }
 
 // GetSingleton returns the singleton instance of HubConfig
@@ -44,6 +45,19 @@ func (o *operatorhub) Get() map[string]bool {
 	o.lock.Lock()
 	defer o.lock.Unlock()
 	return o.current
+}
+
+// Disabled returns true if all defaults are disabled
+func (o *operatorhub) Disabled() bool {
+	o.lock.Lock()
+	defer o.lock.Unlock()
+
+	for _, disabled := range o.current {
+		if disabled == false {
+			return false
+		}
+	}
+	return true
 }
 
 // Set sets the current configuration based on the spec. If the spec is empty,

--- a/test/testsuites/operatorhubtests.go
+++ b/test/testsuites/operatorhubtests.go
@@ -269,6 +269,8 @@ func testClusterStatusDefaultsDisabled(t *testing.T) {
 		return true, nil
 	})
 	assert.NoError(t, err, "ClusterOperator never reached expected status")
+
+	resetClusterOperatorHub(t, namespace)
 }
 
 // testSomeClusterStatusDefaultsDisabled tests that, when some default operator sources are disabled,
@@ -325,6 +327,8 @@ func testSomeClusterStatusDefaultsDisabled(t *testing.T) {
 		return true, nil
 	})
 	assert.NoError(t, err, "ClusterOperator never reached expected status")
+
+	resetClusterOperatorHub(t, namespace)
 }
 
 // getClusterOperatorHub gets the "cluster" OperatorHub resource


### PR DESCRIPTION
Problem:
The cluster operator status is never set to Available=True when
there are no default operator sources set. This is because it relies on
a set of reconciliations to return successfully and determines a ratio
based on that value. When no default operator sources are set, there are
no reconciliation events taking place and therefore the ratio is always
set to zero.

Solution:
When no default operator sources are set and no events are firing, set
the Available status to true.

https://bugzilla.redhat.com/show_bug.cgi?id=1757099

/cc @ecordell @kevinrizza 