### PR TITLE
add version option

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -15,4 +15,4 @@ PROJECT_NAME="marketplace-operator"
 REPO_PATH="github.com/operator-framework/operator-marketplace/"
 BUILD_PATH="${REPO_PATH}/cmd/manager"
 echo "building "${PROJECT_NAME}"..."
-CGO_ENABLED=0 go build -o ${BIN_DIR}/${PROJECT_NAME} $BUILD_PATH
+CGO_ENABLED=0 go build -ldflags "-X '${REPO_PATH}pkg/version.GitCommit=$(git rev-parse HEAD)'" -o ${BIN_DIR}/${PROJECT_NAME} $BUILD_PATH

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -22,6 +22,7 @@ import (
 	"github.com/operator-framework/operator-marketplace/pkg/operatorsource"
 	"github.com/operator-framework/operator-marketplace/pkg/registry"
 	"github.com/operator-framework/operator-marketplace/pkg/status"
+	sourceCommit "github.com/operator-framework/operator-marketplace/pkg/version"
 	"github.com/operator-framework/operator-sdk/pkg/k8sutil"
 	"github.com/operator-framework/operator-sdk/pkg/leader"
 	sdkVersion "github.com/operator-framework/operator-sdk/version"
@@ -43,6 +44,8 @@ const (
 	updateNotificationSendWait = time.Duration(10) * time.Minute
 )
 
+var version = flag.Bool("version", false, "displays marketplace source commit info.")
+
 func printVersion() {
 	log.Printf("Go Version: %s", runtime.Version())
 	log.Printf("Go OS/Arch: %s/%s", runtime.GOOS, runtime.GOARCH)
@@ -58,6 +61,13 @@ func main() {
 	flag.StringVar(&defaults.Dir, "defaultsDir",
 		"", "the directory where the default OperatorSources are stored")
 	flag.Parse()
+
+	// Check if version flag was set
+	if *version {
+		fmt.Print(sourceCommit.String())
+		// Exit immediately
+		os.Exit(0)
+	}
 
 	namespace, err := k8sutil.GetWatchNamespace()
 	if err != nil {

--- a/pkg/version/version.go
+++ b/pkg/version/version.go
@@ -1,0 +1,11 @@
+package version
+
+import "fmt"
+
+// GitCommit indicates which git commit the binary was built from
+var GitCommit string
+
+// String returns a pretty string concatenation of GitCommit
+func String() string {
+	return fmt.Sprintf("Marketplace source git commit: %s\n", GitCommit)
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Add the `--version` option
**Motivation for the change:**
It would be great if the  `marketplace-operator` binary can display the source commit info.
```console
sh-4.2$ marketplace-operator --help
INFO[0000] [metrics] Registering marketplace metrics    
INFO[0000] [metrics] Creating marketplace metrics RoundTripperFunc 
INFO[0000] [metrics] Serving marketplace metrics        
INFO[0000] Go Version: go1.12.8                         
INFO[0000] Go OS/Arch: linux/amd64                      
INFO[0000] operator-sdk Version: v0.8.0                 
Usage of marketplace-operator:
  -defaultsDir string
    	the directory where the default OperatorSources are stored
  -kubeconfig string
    	Paths to a kubeconfig. Only required if out-of-cluster.
  -master string
    	The address of the Kubernetes API server. Overrides any value in kubeconfig. Only required if out-of-cluster.
  -registryServerImage string
    	the image to use for creating the operator registry pod (default "quay.io/openshift/origin-operator-registry")
```

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
