### PR TITLE
Bug 1767547: Don't create invalid deployment

### DIFF
--- a/deploy/role.yaml
+++ b/deploy/role.yaml
@@ -6,6 +6,7 @@ rules:
 - apiGroups:
   - ""
   resources:
+  - namespaces
   - configmaps
   verbs:
   - get

--- a/deploy/upstream/05_role.yaml
+++ b/deploy/upstream/05_role.yaml
@@ -4,6 +4,14 @@ metadata:
   name: marketplace-operator
 rules:
 - apiGroups:
+  - ""
+  resources:
+  - namespaces
+  verbs:
+  - get
+  - list
+  - watch
+- apiGroups:
   - operators.coreos.com
   resources:
   - catalogsources

--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -7,6 +7,7 @@ rules:
   - ""
   resources:
   - configmaps
+  - namespaces
   verbs:
   - get
   - list

--- a/pkg/grpccatalog/grpccatalog.go
+++ b/pkg/grpccatalog/grpccatalog.go
@@ -53,6 +53,16 @@ func (r *GrpcCatalog) EnsureResources(key types.NamespacedName, displayName, pub
 		return err
 	}
 
+	// Check that the target namespace actually exists
+	namespaceKey := types.NamespacedName{
+		Name: targetNamespace,
+	}
+	err = r.client.Get(context.TODO(), namespaceKey, &core.Namespace{})
+	if err != nil {
+		r.log.Errorf("Unable to ensure Catalog resources : %v", err)
+		return err
+	}
+
 	// Ensure that a registry deployment is available
 	registry := registry.NewRegistry(r.log, r.client, r.reader, key, source, packages, registry.ServerImage, owner)
 	err = registry.Ensure()

--- a/pkg/operatorsource/helper_test.go
+++ b/pkg/operatorsource/helper_test.go
@@ -126,13 +126,13 @@ func NewFakeClientWithOpsrc(opsrc *v1.OperatorSource) client.Client {
 	return fake.NewFakeClientWithScheme(scheme, objs...)
 }
 
-func NewFakeClientWithChildResources(deployment *appsv1.Deployment, service *corev1.Service, cs *v1alpha1.CatalogSource) client.Client {
+func NewFakeClientWithChildResources(deployment *appsv1.Deployment, service *corev1.Service, namespace *corev1.Namespace, cs *v1alpha1.CatalogSource) client.Client {
 	objs := []runtime.Object{
 		deployment,
 	}
 
 	scheme := runtime.NewScheme()
-	scheme.AddKnownTypes(v1.SchemeGroupVersion, deployment, service, cs)
+	scheme.AddKnownTypes(v1.SchemeGroupVersion, deployment, service, namespace, cs)
 	apis.AddToScheme(scheme)
 
 	return fake.NewFakeClientWithScheme(scheme, objs...)


### PR DESCRIPTION
Problem Statement:
Replicasets are being constantly generated when the `targetNamespace`
of a CatalogSourceConfig does not exist on the cluster.
The reconciliation loop relies on the controller's exponential backoff
so that events are not constantly reconciled. However, because the
`EnsureResources()` function recreates the registry service in order to
generate a new ip address before attempting to create the catalogsource,
the previous child resource watch constantly forces a reconciliation.
This causes the failing deployment to update constantly without ever
succeeding, and replicasets are continuously spawned.

Solution:
Ensure that the `targetNamespace` exists before attempting to recreate
the service. If the namespace does not exist, log an error and return.
This will prevent the watch from firing and events will back off. When
the namespace is recreated, the controller will eventually pick up the
event.

https://bugzilla.redhat.com/show_bug.cgi?id=1769841

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
