### PR TITLE
Bug 1775245: Schedule registry pods onto linux nodes only

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -32,6 +32,8 @@ const (
 	portNumber                 = 50051
 	portName                   = "grpc"
 	deploymentUpdateAnnotation = "openshift-marketplace-update-hash"
+	linuxNodeSelectorKey       = "beta.kubernetes.io/os"
+	linuxNodeSelectorValue     = "linux"
 )
 
 var action = []string{"grpc_health_probe", "-addr=localhost:50051"}
@@ -414,6 +416,9 @@ func (r *registry) newPodTemplateSpec(registryCommand []string, needServiceAccou
 						},
 					},
 				},
+			},
+			NodeSelector: map[string]string{
+				linuxNodeSelectorKey: linuxNodeSelectorValue,
 			},
 		},
 	}

--- a/pkg/registry/registry_test.go
+++ b/pkg/registry/registry_test.go
@@ -1,0 +1,20 @@
+package registry
+
+import (
+	"k8s.io/apimachinery/pkg/types"
+	"testing"
+)
+
+// TestRegistryDeploymentNodeSelector confirms the PodTemplate used in the registry deployment contains a NodeSelector
+// that limits registry pods to be scheduled to linux nodes only.
+func TestRegistryDeploymentNodeSelector(t *testing.T) {
+	reg := NewRegistry(nil, nil, nil, types.NamespacedName{Name: "hi", Namespace: "hins"},
+		"", "", "", "")
+	r := reg.(*registry)
+
+	podTemplate := r.newPodTemplateSpec(nil, false)
+
+	if podTemplate.Spec.NodeSelector[linuxNodeSelectorKey] != linuxNodeSelectorValue {
+		t.Error("linux node selectors not found on registry pod spec")
+	}
+}


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adds NodeSelector to all registry pods that ensures they will get scheduled to linux nodes only.

**Motivation for the change:**
Bugs reporting different registry pods being scheduled to windows nodes in mixed clusters and failing to start

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
