### PR TITLE
Bug 1786037: Enable CGO in osbs build target

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -15,4 +15,4 @@ PROJECT_NAME="marketplace-operator"
 REPO_PATH="github.com/operator-framework/operator-marketplace/"
 BUILD_PATH="${REPO_PATH}/cmd/manager"
 echo "building "${PROJECT_NAME}"..."
-CGO_ENABLED=0 go build -ldflags "-X '${REPO_PATH}pkg/version.GitCommit=$(git rev-parse HEAD)'" -o ${BIN_DIR}/${PROJECT_NAME} $BUILD_PATH
+CGO_ENABLED=1 CGO_DEBUG=1 go build -ldflags "-X '${REPO_PATH}pkg/version.GitCommit=$(git rev-parse HEAD)'" -o ${BIN_DIR}/${PROJECT_NAME} $BUILD_PATH


### PR DESCRIPTION
Problem:
In OpenShift clusters using Kuryr SDN a load balancer that does not
support UDP is required. In this case, Kuryr attempts to force disable
UDP on all pods by injecting a flag into the resolv.conf file of all
pods to force TCP use. However, this does not work in go programs
that have CGO disabled.

Solution:
Enable CGO and CGO_DEBUG

https://bugzilla.redhat.com/show_bug.cgi?id=1786037

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
