### PR TITLE
Use DNS for CatalogSource address

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -272,7 +272,7 @@ func (r *registry) ensureService() error {
 	}
 	r.log.Infof("Created Service %s", service.GetName())
 
-	r.address = service.Spec.ClusterIP + ":" + strconv.Itoa(int(service.Spec.Ports[0].Port))
+	r.address = fmt.Sprintf("%s.%s.svc:%s", service.Name, service.Namespace, strconv.Itoa(int(service.Spec.Ports[0].Port)))
 	return nil
 }
 


### PR DESCRIPTION
Problem:
Marketplace needs to support ipv6 clusters. Currently when creating
catalogsources, the marketplace points the catsrc to the clusterIP
address of the registry pod that it spins up. This cluster ip will not
work in an ipv6 only cluster.

Solution:
Use the dns address of the service to wire up the catalogsource to the
registry pod.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
