### PR TITLE
Add marketplace default catalog sources

### DIFF
--- a/defaults/04_redhat_marketplace.yaml
+++ b/defaults/04_redhat_marketplace.yaml
@@ -1,0 +1,13 @@
+apiVersion: "operators.coreos.com/v1"
+kind: "OperatorSource"
+metadata:
+  name: "redhat-marketplace"
+  namespace: "openshift-marketplace"
+  labels:
+    opsrc-provider: marketplace
+spec:
+  type: appregistry
+  endpoint: "https://quay.io/cnr"
+  registryNamespace: "redhat-marketplace"
+  displayName: "Red Hat Marketplace"
+  publisher: "Red Hat"

--- a/test/testsuites/operatorhubtests.go
+++ b/test/testsuites/operatorhubtests.go
@@ -27,7 +27,7 @@ func OperatorHubTests(t *testing.T) {
 	t.Run("disable-enable-test", testDisableEnable)
 	t.Run("disable-non-default", testDisableNonDefault)
 	t.Run("disable-all-check-cluster-status", testClusterStatusDefaultsDisabled)
-	t.Run("disable-some-check-cluster-status",testSomeClusterStatusDefaultsDisabled)
+	t.Run("disable-some-check-cluster-status", testSomeClusterStatusDefaultsDisabled)
 }
 
 // testDisable tests disabling a default OperatorSource and ensures that it is not present on the cluster
@@ -67,10 +67,10 @@ func testDisableAll(t *testing.T) {
 	err = toggle(t, 0, true, true)
 	require.NoError(t, err, "Error updating cluster OperatorHub")
 
-	err = checkDeleted(3, namespace)
+	err = checkDeleted(4, namespace)
 	assert.NoError(t, err, "All default OperatorSource(s) have not been disabled")
 
-	err = checkClusterOperatorHub(t, 3)
+	err = checkClusterOperatorHub(t, 4)
 	assert.NoError(t, err, "Incorrect cluster OperatorHub")
 
 }
@@ -97,7 +97,10 @@ func testDisableAllEnableOne(t *testing.T) {
 	err = checkOpSrcAndChildrenAreDeleted(helpers.DefaultSources[2].Name, namespace)
 	assert.NoError(t, err, "Default OperatorSource has not been disabled")
 
-	err = checkClusterOperatorHub(t, 2)
+	err = checkOpSrcAndChildrenAreDeleted(helpers.DefaultSources[3].Name, namespace)
+	assert.NoError(t, err, "Default OperatorSource has not been disabled")
+
+	err = checkClusterOperatorHub(t, 3)
 	assert.NoError(t, err, "Incorrect cluster OperatorHub")
 
 }
@@ -229,13 +232,13 @@ func testClusterStatusDefaultsDisabled(t *testing.T) {
 	require.NoError(t, err, "Could not get namespace")
 
 	// First set the OperatorHub to disable all the default operator sources
-	err = toggle(t, 3, true, true)
+	err = toggle(t, 4, true, true)
 	require.NoError(t, err, "Error updating cluster OperatorHub")
 
-	err = checkDeleted(3, namespace)
+	err = checkDeleted(4, namespace)
 	assert.NoError(t, err, "All default OperatorSource(s) have not been disabled")
 
-	err = checkClusterOperatorHub(t, 3)
+	err = checkClusterOperatorHub(t, 4)
 	assert.NoError(t, err, "Incorrect cluster OperatorHub")
 
 	// Restart marketplace operator


### PR DESCRIPTION
OLM-1441

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This adds two new appregistry based operator sources.

**Motivation for the change:**
This allows the open marketplace catalog built by the container pipeline to be a default catalog.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
