### PR TITLE
Bug 1796414: Add cluster role with aggregation for reading operatorhub config

### DIFF
--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -131,3 +131,19 @@ rules:
   - create
   - delete
   - update
+---
+kind: ClusterRole
+apiVersion: rbac.authorization.k8s.io/v1
+metadata:
+  name: operatorhub-config-reader
+  labels:
+    rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
+rules:
+- apiGroups:
+  - config.openshift.io
+  resources:
+  - operatorhubs
+  verbs:
+  - get
+  - list
+  - watch


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This adds a new ClusterRole that can read the operatorhub config api, with appropriate labels to aggregate it to the cluster reader role. 

**Motivation for the change:**
Users with cluster-reader should be able to view operatorhub config.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
