### PR TITLE
Bug 1801294: Alert to make custom opsrc/csc users aware of deprecation

### DIFF
--- a/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
+++ b/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
@@ -91,6 +91,7 @@ type ReconcileCatalogSourceConfig struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileCatalogSourceConfig) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	log.Printf("Reconciling CatalogSourceConfig %s/%s\n", request.Namespace, request.Name)
+	log.Warning("DEPRECATION NOTICE: The CatalogSourceConfig API is deprecated in future versions. Please visit this link for futher details: https://docs.openshift.com/container-platform/4.4/release_notes/ocp-4-4-release-notes.html#ocp-4-4-marketplace-apis-deprecated")
 	// Reconcile kicked off, message Sync Channel
 	r.syncSender.SendSyncMessage(nil)
 

--- a/pkg/controller/operatorsource/operatorsource_controller.go
+++ b/pkg/controller/operatorsource/operatorsource_controller.go
@@ -77,6 +77,9 @@ type ReconcileOperatorSource struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileOperatorSource) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	log.Printf("Reconciling OperatorSource %s/%s\n", request.Namespace, request.Name)
+	if !defaults.IsDefaultSource(request.Name) {
+		log.Warning("DEPRECATION NOTICE: The OperatorSource API is deprecated in future versions. Please visit this link for futher details: https://docs.openshift.com/container-platform/4.4/release_notes/ocp-4-4-release-notes.html#ocp-4-4-marketplace-apis-deprecated")
+	}
 	// Reconcile kicked off, message Sync Channel with sync event
 	r.syncSender.SendSyncMessage(nil)
 

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -39,6 +39,10 @@ const (
 	// the CreateOperatorSource function.
 	TestOperatorSourceName string = "test-operators"
 
+	// TestOpsrcNameForClusterOperator is the name of an OperatorSource that is created
+	// for testing ClusterOperator status on custom OperatorSource creation
+	TestOpsrcNameForClusterOperator string = "test-operators-for-co"
+
 	// TestOperatorSourceLabelKey is a label key added to the opeator source returned
 	// by the CreateOperatorSource function.
 	TestOperatorSourceLabelKey string = "opsrc-group"
@@ -49,6 +53,10 @@ const (
 
 	// TestCatalogSourceConfigName is the name of the test CatalogSourceConfig.
 	TestCatalogSourceConfigName string = "test-csc"
+
+	// TestCscNameForClusterOperator is the name of a CatalogSourceConfig that is created
+	// for testing ClusterOperator status on CatalogSourceConfig creation
+	TestCscNameForClusterOperator string = "test-csc-for-co"
 
 	// TestNoHyphenCatalogSourceConfigName is the name of a non-hyphenated test CatalogSourceConfig.
 	TestNoHyphenCatalogSourceConfigName string = "testcsc"

--- a/test/testgroups/clusteroperatortests.go
+++ b/test/testgroups/clusteroperatortests.go
@@ -1,13 +1,67 @@
 package testgroups
 
 import (
+	"context"
 	"testing"
 
+	"github.com/operator-framework/operator-marketplace/test/helpers"
 	"github.com/operator-framework/operator-marketplace/test/testsuites"
+	"github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/stretchr/testify/require"
+	apps "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
 )
 
 // ClusterOperatorTestGroup runs test suites that check the status of the Cluster Operator
 func ClusterOperatorTestGroup(t *testing.T) {
-	// Run the test suites.
+
+	// Run start-up test suite
 	t.Run("cluster-operator-status-on-startup-test-suite", testsuites.ClusterOperatorStatusOnStartup)
+
+	// Create a ctx that is used to create and eventually delete the OperatorSource and CatalogSourceConfig at the completion of this function.
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	// Get test namespace.
+	namespace, err := ctx.GetNamespace()
+	require.NoError(t, err, "Could not get namespace")
+
+	// We are assuming that the marketplace deployment is available. This is only
+	// the case if not running operator-sdk up local.
+	err = test.Global.Client.Get(context.TODO(), types.NamespacedName{Name: "marketplace-operator", Namespace: namespace}, &apps.Deployment{})
+	if err != nil {
+		t.Logf("Failed to find deployment operator-marketplace")
+		return
+	}
+
+	// Create the OperatorSource.
+	opsrcDefinition := helpers.CreateOperatorSourceDefinition(helpers.TestOpsrcNameForClusterOperator, namespace)
+	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, opsrcDefinition)
+	require.NoError(t, err, "Could not create OperatorSource")
+
+	// Run opsrc creation related test suites.
+	t.Run("cluster-operator-status-on-custom-opsrc-creation-test-suite", testsuites.ClusterOperatorStatusOnCustomResourceCreation)
+
+	// Delete the OperatorSource.
+	err = helpers.DeleteRuntimeObject(test.Global.Client, opsrcDefinition)
+	require.NoError(t, err, "Could not delete OperatorSource")
+
+	// Run opsrc deletion releated test suites.
+	t.Run("cluster-operator-status-on-custom-opsrc-deletion-test-suite", testsuites.ClusterOperatorStatusOnCustomResourceDeletion)
+
+	// Create the CatalogSourceConfig
+	cscDefinition := helpers.CreateCatalogSourceConfigDefinition(
+		helpers.TestCscNameForClusterOperator, namespace, helpers.TestCatalogSourceConfigTargetNamespace)
+	err = helpers.CreateRuntimeObject(test.Global.Client, ctx, cscDefinition)
+	require.NoError(t, err, "Could not create CatalogSourceConfig")
+
+	// Run csc creation related test suites.
+	t.Run("cluster-operator-status-on-csc-creation-test-suite", testsuites.ClusterOperatorStatusOnCustomResourceCreation)
+
+	// Delete the CatalogSourceConfig.
+	err = helpers.DeleteRuntimeObject(test.Global.Client, cscDefinition)
+	require.NoError(t, err, "Could not delete CatalogSourceConfig")
+
+	// Run opsrc deletion releated test suites.
+	t.Run("cluster-operator-status-on-csc-deletion-test-suite", testsuites.ClusterOperatorStatusOnCustomResourceDeletion)
 }

--- a/test/testsuites/clusteroperatorstatustests.go
+++ b/test/testsuites/clusteroperatorstatustests.go
@@ -83,3 +83,100 @@ func ClusterOperatorStatusOnStartup(t *testing.T) {
 	}
 	assert.ElementsMatch(t, result.Status.RelatedObjects, expectedRelatedObjects, "ClusterOperator did not list the exepcted RelatedObjects")
 }
+
+// ClusterOperatorStatusOnCustomResourceCreation is a test suite that ensures the ClusterOperator
+// status of the marketplace operator is set to Upgradeable: False on creation of a custom
+// OperatorSource/any CatalogSourceConfig.
+func ClusterOperatorStatusOnCustomResourceCreation(t *testing.T) {
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	// Get global framework variables.
+	client := test.Global.Client
+
+	// Get namespace
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	require.NoError(t, err, "Could not get namespace")
+
+	// Check that the ClusterOperator resource has the correct status
+	clusterOperatorName := "marketplace"
+	expectedTypeStatus := map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{
+		configv1.OperatorUpgradeable: configv1.ConditionFalse,
+		configv1.OperatorProgressing: configv1.ConditionFalse,
+		configv1.OperatorAvailable:   configv1.ConditionTrue,
+		configv1.OperatorDegraded:    configv1.ConditionFalse}
+
+	// Poll to ensure ClusterOperator is present and has the correct status
+	// i.e. ConditionType has a ConditionStatus matching expectedTypeStatus
+	namespacedName := types.NamespacedName{Name: clusterOperatorName, Namespace: namespace}
+	result := &configv1.ClusterOperator{}
+	RetryInterval := time.Second * 5
+	Timeout := time.Minute * 5
+	err = wait.PollImmediate(RetryInterval, Timeout, func() (done bool, err error) {
+		err = client.Get(context.TODO(), namespacedName, result)
+		if err != nil {
+			return false, err
+		}
+		noOfConditionsMatching := 0
+		for _, condition := range result.Status.Conditions {
+			if expectedTypeStatus[condition.Type] != condition.Status {
+				return false, nil
+			}
+			noOfConditionsMatching = noOfConditionsMatching + 1
+		}
+		if noOfConditionsMatching == 4 {
+			return true, nil
+		}
+		return false, nil
+	})
+	assert.NoError(t, err, "ClusterOperator never reached expected status")
+
+}
+
+// ClusterOperatorStatusOnCustomResourceDeletion confirms that the ClusterOperator's status is set back to
+// Upgradeable: True once the cusom OperatorSource/a CatalogSourceConfig is deleted.
+func ClusterOperatorStatusOnCustomResourceDeletion(t *testing.T) {
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	// Get global framework variables.
+	client := test.Global.Client
+
+	// Get namespace
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	require.NoError(t, err, "Could not get namespace")
+
+	// Check that the ClusterOperator resource has the correct status
+	clusterOperatorName := "marketplace"
+	expectedTypeStatus := map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{
+		configv1.OperatorUpgradeable: configv1.ConditionTrue,
+		configv1.OperatorProgressing: configv1.ConditionFalse,
+		configv1.OperatorAvailable:   configv1.ConditionTrue,
+		configv1.OperatorDegraded:    configv1.ConditionFalse}
+
+	// Poll to ensure ClusterOperator is present and has the correct status
+	// i.e. ConditionType has a ConditionStatus matching expectedTypeStatus
+	namespacedName := types.NamespacedName{Name: clusterOperatorName, Namespace: namespace}
+	result := &configv1.ClusterOperator{}
+	RetryInterval := time.Second * 5
+	Timeout := time.Minute * 5
+	err = wait.PollImmediate(RetryInterval, Timeout, func() (done bool, err error) {
+		err = client.Get(context.TODO(), namespacedName, result)
+		if err != nil {
+			return false, err
+		}
+		noOfConditionsMatching := 0
+		for _, condition := range result.Status.Conditions {
+			if expectedTypeStatus[condition.Type] != condition.Status {
+				return false, nil
+			}
+			noOfConditionsMatching = noOfConditionsMatching + 1
+		}
+		if noOfConditionsMatching == 4 {
+			return true, nil
+		}
+		return false, nil
+	})
+	assert.NoError(t, err, "ClusterOperator never reached expected status")
+
+}

--- a/test/testsuites/operatorhubtests.go
+++ b/test/testsuites/operatorhubtests.go
@@ -248,7 +248,7 @@ func testClusterStatusDefaultsDisabled(t *testing.T) {
 	// Check that the ClusterOperator resource has the correct status
 	clusterOperatorName := "marketplace"
 	expectedTypeStatus := map[apiconfigv1.ClusterStatusConditionType]apiconfigv1.ConditionStatus{
-		apiconfigv1.OperatorUpgradeable: apiconfigv1.ConditionTrue,
+		apiconfigv1.OperatorUpgradeable: apiconfigv1.ConditionFalse,
 		apiconfigv1.OperatorProgressing: apiconfigv1.ConditionFalse,
 		apiconfigv1.OperatorAvailable:   apiconfigv1.ConditionTrue,
 		apiconfigv1.OperatorDegraded:    apiconfigv1.ConditionFalse}
@@ -277,7 +277,7 @@ func testClusterStatusDefaultsDisabled(t *testing.T) {
 }
 
 // testSomeClusterStatusDefaultsDisabled tests that, when some default operator sources are disabled,
-// the clusterstatus sets Available=false
+// the clusterstatus sets Available=True
 func testSomeClusterStatusDefaultsDisabled(t *testing.T) {
 	ctx := test.NewTestCtx(t)
 	defer ctx.Cleanup()
@@ -306,9 +306,9 @@ func testSomeClusterStatusDefaultsDisabled(t *testing.T) {
 	// Check that the ClusterOperator resource has the correct status
 	clusterOperatorName := "marketplace"
 	expectedTypeStatus := map[apiconfigv1.ClusterStatusConditionType]apiconfigv1.ConditionStatus{
-		apiconfigv1.OperatorUpgradeable: apiconfigv1.ConditionTrue,
+		apiconfigv1.OperatorUpgradeable: apiconfigv1.ConditionFalse,
 		apiconfigv1.OperatorProgressing: apiconfigv1.ConditionFalse,
-		apiconfigv1.OperatorAvailable:   apiconfigv1.ConditionFalse,
+		apiconfigv1.OperatorAvailable:   apiconfigv1.ConditionTrue,
 		apiconfigv1.OperatorDegraded:    apiconfigv1.ConditionFalse}
 
 	// Poll to ensure ClusterOperator is present and has the correct status


### PR DESCRIPTION
In 4.5 we are deprecating the OperatorSource and CatalogSourceConfig APIs.
This PR introduces an alert in the logs, and also blocks upgrade to future
versions in presence of Opsrcs/CSCs by sending a Upgradeable: False message
to CVO.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
