### PR TITLE
Bug 1801294: Alert to make custom opsrc/csc users aware of deprecation

### DIFF
--- a/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
+++ b/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
@@ -91,6 +91,7 @@ type ReconcileCatalogSourceConfig struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileCatalogSourceConfig) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	log.Printf("Reconciling CatalogSourceConfig %s/%s\n", request.Namespace, request.Name)
+	log.Warning("DEPRECATION NOTICE: The CatalogSourceConfig API is deprecated in future versions. Please visit this link for futher details: https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-marketplace-apis-deprecated")
 	// Reconcile kicked off, message Sync Channel
 	r.syncSender.SendSyncMessage(nil)
 

--- a/pkg/controller/operatorsource/operatorsource_controller.go
+++ b/pkg/controller/operatorsource/operatorsource_controller.go
@@ -77,6 +77,7 @@ type ReconcileOperatorSource struct {
 // Result.Requeue is true, otherwise upon completion it will remove the work from the queue.
 func (r *ReconcileOperatorSource) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	log.Printf("Reconciling OperatorSource %s/%s\n", request.Namespace, request.Name)
+	log.Warning("DEPRECATION NOTICE: The OperatorSource API is deprecated in future versions. Please visit this link for futher details: https://docs.openshift.com/container-platform/4.5/release_notes/ocp-4-5-release-notes.html#ocp-4-5-marketplace-apis-deprecated")
 	// Reconcile kicked off, message Sync Channel with sync event
 	r.syncSender.SendSyncMessage(nil)
 


### PR DESCRIPTION
In 4.5 we are deprecating the OperatorSource and CatalogSourceConfig APIs.
This PR introduces an alert in the logs, and also blocks upgrade to future
versions in presence of Opsrcs/CSCs by sending a Upgradeable: False message
to CVO.