### PR TITLE
show the source commit id

### DIFF
--- a/build/build.sh
+++ b/build/build.sh
@@ -9,11 +9,7 @@ if ! which go > /dev/null; then
 	exit 1
 fi
 
-GIT_COMMIT=$(git rev-parse HEAD)
-
-if [ $SOURCE_GIT_COMMIT ]; then
-	GIT_COMMIT=$SOURCE_GIT_COMMIT
-fi
+GIT_COMMIT=${SOURCE_GIT_COMMIT:-$(git rev-parse HEAD)}
 
 BIN_DIR="$(pwd)/build/_output/bin"
 mkdir -p ${BIN_DIR}

--- a/build/build.sh
+++ b/build/build.sh
@@ -9,10 +9,16 @@ if ! which go > /dev/null; then
 	exit 1
 fi
 
+GIT_COMMIT=$(git rev-parse HEAD)
+
+if [ $SOURCE_GIT_COMMIT ]; then
+	GIT_COMMIT=$SOURCE_GIT_COMMIT
+fi
+
 BIN_DIR="$(pwd)/build/_output/bin"
 mkdir -p ${BIN_DIR}
 PROJECT_NAME="marketplace-operator"
 REPO_PATH="github.com/operator-framework/operator-marketplace/"
 BUILD_PATH="${REPO_PATH}/cmd/manager"
 echo "building "${PROJECT_NAME}"..."
-CGO_ENABLED=1 CGO_DEBUG=1 go build -ldflags "-X '${REPO_PATH}pkg/version.GitCommit=$(git rev-parse HEAD)'" -o ${BIN_DIR}/${PROJECT_NAME} $BUILD_PATH
+CGO_ENABLED=1 CGO_DEBUG=1 go build -ldflags "-X '${REPO_PATH}pkg/version.GitCommit=${GIT_COMMIT}'" -o ${BIN_DIR}/${PROJECT_NAME} $BUILD_PATH


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Now, the output of the `marketplace-operator --version` is the sha of the commit in dist-git, not the source commit digest. This PR will fix this issue. 
```console
[jzhang@dhcp-140-36 ~]$ oc exec marketplace-operator-f7d7689c9-rllgk -- marketplace-operator --version
Marketplace source git commit: fb0762cf5b386d783527d036e4666b4468a12aad
time="2020-03-12T13:54:55Z" level=info msg="[metrics] Registering marketplace metrics"
time="2020-03-12T13:54:55Z" level=info msg="[metrics] Creating marketplace metrics RoundTripperFunc"
time="2020-03-12T13:54:55Z" level=info msg="[metrics] Serving marketplace metrics"
time="2020-03-12T13:54:55Z" level=info msg="Go Version: go1.13.4"
time="2020-03-12T13:54:55Z" level=info msg="Go OS/Arch: linux/amd64"
time="2020-03-12T13:54:55Z" level=info msg="operator-sdk Version: v0.8.0"
```

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
