### PR TITLE
Updating the links to crd files

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ In order to deploy the Marketplace Operator, you must:
 ## Using the Marketplace Operator
 
 ### Description
-The operator manages two CRDs: [OperatorSource](./deploy/crds/operators_v1_operatorsource_crd.yaml) and [CatalogSourceConfig](./deploy/crds/operators_v2_catalogsourceconfig_crd.yaml).
+The operator manages two CRDs: [OperatorSource](./deploy/upstream/03_operatorsource.crd.yaml) and [CatalogSourceConfig](./deploy/upstream/02_catalogsourceconfig.crd.yaml).
 
 #### OperatorSource
 


### PR DESCRIPTION


**Description of the change:**

The links to two of the CRD files were deprecated. So, this change is to update those links to the correct files


**Motivation for the change:**

Correcting the documentation, so as to ease the reference for future readers or users


