### PR TITLE
[deprecation] Prometheus alert for custom resources

### DIFF
--- a/manifests/12_prometheus_rule.yaml
+++ b/manifests/12_prometheus_rule.yaml
@@ -65,3 +65,13 @@ spec:
           for: 15m
           labels:
             severity: warning
+    - name: custom-resource-detected
+      rules:
+        - alert: CustomResourceDetected
+          annotations:
+            summary: Indicates the presence of a custom OperatorSource or a CatalogSourceConifg in the cluster
+            message: The cluster has custom OperatorSource/CatalogSourceConfig, which are deprecated from OCP 4.5. Upgrade to OCP 4.5 will not be possible unless those resources are removed. Please visit https://docs.openshift.com/container-platform/4.4/release_notes/ocp-4-4-release-notes.html#ocp-4-4-marketplace-apis-deprecated for further details.
+          expr: |
+            custom_resource_total > 0
+          labels:
+            severity: warning

--- a/pkg/catalogsourceconfig/deleted.go
+++ b/pkg/catalogsourceconfig/deleted.go
@@ -7,6 +7,7 @@ import (
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
 	wrapper "github.com/operator-framework/operator-marketplace/pkg/client"
 	"github.com/operator-framework/operator-marketplace/pkg/grpccatalog"
+	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -57,6 +58,7 @@ type deletedReconciler struct {
 func (r *deletedReconciler) Reconcile(ctx context.Context, in *v2.CatalogSourceConfig) (out *v2.CatalogSourceConfig, nextPhase *shared.Phase, err error) {
 	out = in
 
+	metrics.DeregisterCustomResource(metrics.ResourceTypeCSC)
 	// Evict the catalogsourceconfig data from the cache.
 	r.cache.Evict(out)
 

--- a/pkg/catalogsourceconfig/initial.go
+++ b/pkg/catalogsourceconfig/initial.go
@@ -5,6 +5,7 @@ import (
 
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/shared"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
+	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
 	"github.com/sirupsen/logrus"
 )
@@ -33,6 +34,7 @@ func (r *initialReconciler) Reconcile(ctx context.Context, in *v2.CatalogSourceC
 		return
 	}
 
+	metrics.RegisterCustomResource(metrics.ResourceTypeCSC)
 	out = in.DeepCopy()
 
 	// When a csc is created, make sure the csc finalizer is included

--- a/pkg/operatorsource/deleted.go
+++ b/pkg/operatorsource/deleted.go
@@ -4,6 +4,7 @@ import (
 	"context"
 
 	"github.com/operator-framework/operator-marketplace/pkg/grpccatalog"
+	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/shared"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
@@ -64,6 +65,9 @@ func (r *deletedReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource
 	// Otherwise this phase has been requeued because the garbage collector hasn't
 	// finished its work yet.
 	if in.HasFinalizer() {
+		if !defaults.IsDefaultSource(in.Name) {
+			metrics.DeregisterCustomResource(metrics.ResourceTypeOpsrc)
+		}
 		// Delete the operator source manifests.
 		r.datastore.RemoveOperatorSource(out.UID)
 		grpcCatalog := grpccatalog.New(r.logger, nil, r.client)

--- a/pkg/operatorsource/initial.go
+++ b/pkg/operatorsource/initial.go
@@ -6,6 +6,8 @@ import (
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/shared"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
+	"github.com/operator-framework/operator-marketplace/pkg/defaults"
+	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
 	log "github.com/sirupsen/logrus"
 )
@@ -45,7 +47,9 @@ func (r *initialReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource
 		err = phase.ErrWrongReconcilerInvoked
 		return
 	}
-
+	if !defaults.IsDefaultSource(in.Name) {
+		metrics.RegisterCustomResource(metrics.ResourceTypeOpsrc)
+	}
 	out = in.DeepCopy()
 
 	// When an opsrc is created, make sure the opsrc finalizer is included


### PR DESCRIPTION
**Description of the change:**

This PR introduces a Promethues alert to acompany the log and the
CVO status update in presence of a custom OperatorSource
or any CatalogSourceConfig.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

