### PR TITLE
Bug 1826372: Tigger alert for invalid CSC

### DIFF
--- a/pkg/catalogsourceconfig/initial.go
+++ b/pkg/catalogsourceconfig/initial.go
@@ -5,7 +5,6 @@ import (
 
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/shared"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
-	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
 	"github.com/sirupsen/logrus"
 )
@@ -34,7 +33,6 @@ func (r *initialReconciler) Reconcile(ctx context.Context, in *v2.CatalogSourceC
 		return
 	}
 
-	metrics.RegisterCustomResource(metrics.ResourceTypeCSC)
 	out = in.DeepCopy()
 
 	// When a csc is created, make sure the csc finalizer is included

--- a/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
+++ b/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
@@ -6,6 +6,7 @@ import (
 	v2 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
 	catalogsourceconfighandler "github.com/operator-framework/operator-marketplace/pkg/catalogsourceconfig"
 	"github.com/operator-framework/operator-marketplace/pkg/controller/options"
+	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 	"github.com/operator-framework/operator-marketplace/pkg/status"
 	"github.com/operator-framework/operator-marketplace/pkg/watches"
 	log "github.com/sirupsen/logrus"
@@ -92,6 +93,7 @@ type ReconcileCatalogSourceConfig struct {
 func (r *ReconcileCatalogSourceConfig) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	log.Printf("Reconciling CatalogSourceConfig %s/%s\n", request.Namespace, request.Name)
 	log.Warning("DEPRECATION NOTICE: The CatalogSourceConfig API is deprecated in future versions. Please visit this link for futher details: https://docs.openshift.com/container-platform/4.4/release_notes/ocp-4-4-release-notes.html#ocp-4-4-marketplace-apis-deprecated")
+	metrics.RegisterCustomResource(metrics.ResourceTypeCSC)
 	// Reconcile kicked off, message Sync Channel
 	r.syncSender.SendSyncMessage(nil)
 


### PR DESCRIPTION
**Description of the change:**

This PR triggers a prometheus alert as soon as the
CSC reconclier is called, instead of waiting for the
CSC to reach the "Initial" phase.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
