### PR TITLE
Bug 1831818: Remove Obsolete default OperatorSource

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -198,6 +198,10 @@ func main() {
 		exit(err)
 	}
 
+	err = defaults.RemoveObsoleteOpsrc(clientGo)
+	if err != nil {
+		log.Error(err, "[defaults] Could not remove obsolete default OperatorSource/s")
+	}
 	// statusReportingDoneCh will be closed after the operator has successfully stopped reporting ClusterOperator status.
 	statusReportingDoneCh := statusReporter.StartReporting()
 


### PR DESCRIPTION
In #300, the OperatorHub API was enhanced to accept both OperatorSource
and CatalogSource as defaults. However, when an existing OperatorSource
in a cluster was switched to a CatalogSource, the old OperatorSource
persisted. This PR fixes the issue, and removes the obsolete OperatorSource,
so that there's only one source for a catalog of operators.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
