### PR TITLE
Bug 1833207: Ensure correct registry image

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -153,6 +153,9 @@ func (r *registry) ensureDeployment(appRegistries []string, needServiceAccount b
 		if len(deployment.Spec.Template.Spec.Containers) == 0 {
 			deployment.Spec.Template = r.newPodTemplateSpec(registryCommand, needServiceAccount)
 		} else {
+			// Ensure that the registry image is up to date
+			deployment.Spec.Template.Spec.Containers[0].Image = r.image
+
 			// Update the command passed to the registry to account for packages being added and removed
 			// from Quay
 			deployment.Spec.Template.Spec.Containers[0].Command = registryCommand


### PR DESCRIPTION
Check to ensure that the podtemplatespec associated with
the registry image matches the value passed in from the env
variable defined on the marketplace operator