### PR TITLE
Bug 1851213: Set Resource to plural in CSV RelatedObjects field

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -204,12 +204,12 @@ func (r *reporter) setRelatedObjects() {
 		// Add the non-core resources we care about
 		{
 			Group:     v1.SchemeGroupVersion.Group,
-			Resource:  v1.OperatorSourceKind,
+			Resource:  "operatorsources",
 			Namespace: r.namespace,
 		},
 		{
 			Group:     olm.GroupName,
-			Resource:  olm.CatalogSourceKind,
+			Resource:  "catalogsources",
 			Namespace: r.namespace,
 		},
 	}

--- a/test/testsuites/clusteroperatorstatustests.go
+++ b/test/testsuites/clusteroperatorstatustests.go
@@ -66,16 +66,16 @@ func ClusterOperatorStatusOnStartup(t *testing.T) {
 		},
 		{
 			Group:     v1.SchemeGroupVersion.Group,
-			Resource:  v1.OperatorSourceKind,
+			Resource:  "operatorsources",
 			Namespace: namespace,
 		},
 		{
 			Group:     olm.GroupName,
-			Resource:  olm.CatalogSourceKind,
+			Resource:  "catalogsources",
 			Namespace: namespace,
 		},
 	}
-	assert.ElementsMatch(t, result.Status.RelatedObjects, expectedRelatedObjects, "ClusterOperator did not list the exepcted RelatedObjects")
+	assert.ElementsMatch(t, result.Status.RelatedObjects, expectedRelatedObjects, "ClusterOperator did not list the expected RelatedObjects")
 }
 
 // ClusterOperatorStatusOnCustomResourceCreation is a test suite that ensures the ClusterOperator


### PR DESCRIPTION
**Description of the change:**
The Resource property in RelatedObjects field of ClusterServiceVersionStatus is meant to be the lowercase plural value, but were being populated with the Kind instead. Made modifications in this PR to switch all Kind values in Resource to the expected format.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
