### PR TITLE
Bug 1862481: Correctly count  non-default Marketplace CRs

### DIFF
--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -147,12 +147,7 @@ func GetRoundTripper() http.RoundTripper {
 	return roundTripper
 }
 
-// RegisterCustomResource increases the count of the custom_resource_total metric
-func RegisterCustomResource(resourceType string) {
-	customResourceGaugeVec.With(prometheus.Labels{ResourceTypeLabel: resourceType}).Inc()
-}
-
-// DeregisterCustomResource decreases the count of the custom_resource_total metric
-func DeregisterCustomResource(resourceType string) {
-	customResourceGaugeVec.With(prometheus.Labels{ResourceTypeLabel: resourceType}).Dec()
+// RegisterCustomResource sets the count of the custom_resource_total metric to the provided value.
+func RegisterCustomResource(resourceType string, count float64) {
+	customResourceGaugeVec.With(prometheus.Labels{ResourceTypeLabel: resourceType}).Set(count)
 }

--- a/pkg/operatorsource/deleted.go
+++ b/pkg/operatorsource/deleted.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/operator-framework/operator-marketplace/pkg/grpccatalog"
-	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/shared"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
@@ -65,9 +64,6 @@ func (r *deletedReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource
 	// Otherwise this phase has been requeued because the garbage collector hasn't
 	// finished its work yet.
 	if in.HasFinalizer() {
-		if !defaults.IsDefaultSource(in.Name) {
-			metrics.DeregisterCustomResource(metrics.ResourceTypeOpsrc)
-		}
 		// Delete the operator source manifests.
 		r.datastore.RemoveOperatorSource(out.UID)
 		grpcCatalog := grpccatalog.New(r.logger, nil, r.client)

--- a/pkg/operatorsource/initial.go
+++ b/pkg/operatorsource/initial.go
@@ -6,8 +6,6 @@ import (
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/shared"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
-	"github.com/operator-framework/operator-marketplace/pkg/defaults"
-	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
 	log "github.com/sirupsen/logrus"
 )
@@ -46,9 +44,6 @@ func (r *initialReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource
 	if in.GetCurrentPhaseName() != phase.Initial {
 		err = phase.ErrWrongReconcilerInvoked
 		return
-	}
-	if !defaults.IsDefaultSource(in.Name) {
-		metrics.RegisterCustomResource(metrics.ResourceTypeOpsrc)
 	}
 	out = in.DeepCopy()
 


### PR DESCRIPTION
Problem: It is possible for the marketplace operator to report that
deprecated CRs are present on cluster despite no CRs being present.

Solution: Marketplace already searches for non-default CRs on cluster
when reporting status. Marketplace will now use this search to report
the number of deprecated CRs on cluster.