### PR TITLE
Bug 1872880: Correctly count  non-default Marketplace CRs

### DIFF
--- a/pkg/catalogsourceconfig/deleted.go
+++ b/pkg/catalogsourceconfig/deleted.go
@@ -4,10 +4,9 @@ import (
 	"context"
 
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/shared"
-	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
+	v2 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
 	wrapper "github.com/operator-framework/operator-marketplace/pkg/client"
 	"github.com/operator-framework/operator-marketplace/pkg/grpccatalog"
-	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
 	log "github.com/sirupsen/logrus"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -58,7 +57,6 @@ type deletedReconciler struct {
 func (r *deletedReconciler) Reconcile(ctx context.Context, in *v2.CatalogSourceConfig) (out *v2.CatalogSourceConfig, nextPhase *shared.Phase, err error) {
 	out = in
 
-	metrics.DeregisterCustomResource(metrics.ResourceTypeCSC)
 	// Evict the catalogsourceconfig data from the cache.
 	r.cache.Evict(out)
 

--- a/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
+++ b/pkg/controller/catalogsourceconfig/catalogsourceconfig_controller.go
@@ -6,7 +6,6 @@ import (
 	v2 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v2"
 	catalogsourceconfighandler "github.com/operator-framework/operator-marketplace/pkg/catalogsourceconfig"
 	"github.com/operator-framework/operator-marketplace/pkg/controller/options"
-	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 	"github.com/operator-framework/operator-marketplace/pkg/status"
 	"github.com/operator-framework/operator-marketplace/pkg/watches"
 	log "github.com/sirupsen/logrus"
@@ -93,7 +92,6 @@ type ReconcileCatalogSourceConfig struct {
 func (r *ReconcileCatalogSourceConfig) Reconcile(request reconcile.Request) (reconcile.Result, error) {
 	log.Printf("Reconciling CatalogSourceConfig %s/%s\n", request.Namespace, request.Name)
 	log.Warning("DEPRECATION NOTICE: The CatalogSourceConfig API is deprecated in future versions. Please visit this link for futher details: https://docs.openshift.com/container-platform/4.4/release_notes/ocp-4-4-release-notes.html#ocp-4-4-marketplace-apis-deprecated")
-	metrics.RegisterCustomResource(metrics.ResourceTypeCSC)
 	// Reconcile kicked off, message Sync Channel
 	r.syncSender.SendSyncMessage(nil)
 

--- a/pkg/metrics/metrics.go
+++ b/pkg/metrics/metrics.go
@@ -150,12 +150,7 @@ func GetRoundTripper() http.RoundTripper {
 	return roundTripper
 }
 
-// RegisterCustomResource increases the count of the custom_resource_total metric
-func RegisterCustomResource(resourceType string) {
-	customResourceGaugeVec.With(prometheus.Labels{ResourceTypeLabel: resourceType}).Inc()
-}
-
-// DeregisterCustomResource decreases the count of the custom_resource_total metric
-func DeregisterCustomResource(resourceType string) {
-	customResourceGaugeVec.With(prometheus.Labels{ResourceTypeLabel: resourceType}).Dec()
+// RegisterCustomResource sets the count of the custom_resource_total metric to the provided value.
+func RegisterCustomResource(resourceType string, count float64) {
+	customResourceGaugeVec.With(prometheus.Labels{ResourceTypeLabel: resourceType}).Set(count)
 }

--- a/pkg/operatorsource/deleted.go
+++ b/pkg/operatorsource/deleted.go
@@ -4,7 +4,6 @@ import (
 	"context"
 
 	"github.com/operator-framework/operator-marketplace/pkg/grpccatalog"
-	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/shared"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
@@ -65,9 +64,6 @@ func (r *deletedReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource
 	// Otherwise this phase has been requeued because the garbage collector hasn't
 	// finished its work yet.
 	if in.HasFinalizer() {
-		if !defaults.IsDefaultSource(in.Name) {
-			metrics.DeregisterCustomResource(metrics.ResourceTypeOpsrc)
-		}
 		// Delete the operator source manifests.
 		r.datastore.RemoveOperatorSource(out.UID)
 		grpcCatalog := grpccatalog.New(r.logger, nil, r.client)

--- a/pkg/operatorsource/initial.go
+++ b/pkg/operatorsource/initial.go
@@ -6,8 +6,6 @@ import (
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/shared"
 	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	"github.com/operator-framework/operator-marketplace/pkg/datastore"
-	"github.com/operator-framework/operator-marketplace/pkg/defaults"
-	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 	"github.com/operator-framework/operator-marketplace/pkg/phase"
 	log "github.com/sirupsen/logrus"
 )
@@ -46,9 +44,6 @@ func (r *initialReconciler) Reconcile(ctx context.Context, in *v1.OperatorSource
 	if in.GetCurrentPhaseName() != phase.Initial {
 		err = phase.ErrWrongReconcilerInvoked
 		return
-	}
-	if !defaults.IsDefaultSource(in.Name) {
-		metrics.RegisterCustomResource(metrics.ResourceTypeOpsrc)
 	}
 	out = in.DeepCopy()
 


### PR DESCRIPTION
Problem: It is possible for the marketplace operator to report that
deprecated CRs are present on cluster despite no CRs being present.

Solution: Marketplace already searches for non-default CRs on cluster
when reporting status. Marketplace will now use this search to report
the number of deprecated CRs on cluster.
