### PR TITLE
Bug 1871987: Update 03_community_operators.yaml

### DIFF
--- a/defaults/03_community_operators.yaml
+++ b/defaults/03_community_operators.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "openshift-marketplace"
 spec:
   sourceType: grpc
-  image: quay.io/openshift-community-operators/catalog:latest
+  image: registry.redhat.io/redhat/community-operator-index:latest
   displayName: "Community Operators"
   publisher: "Red Hat"
   updateStrategy:


### PR DESCRIPTION
the location of the index has changed

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
The community operator image is no longer in quay.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
