### PR TITLE
Bug 1874751: Add OKD-specific Dockerfile

### DIFF
--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -1,0 +1,22 @@
+
+FROM registry.svc.ci.openshift.org/openshift/release:golang-1.10 AS builder
+WORKDIR /go/src/github.com/operator-framework/operator-marketplace
+COPY . .
+RUN make osbs-build
+
+FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
+RUN useradd marketplace-operator
+USER marketplace-operator
+COPY --from=builder /go/src/github.com/operator-framework/operator-marketplace/build/_output/bin/marketplace-operator /usr/bin
+ADD manifests /manifests
+ADD defaults /defaults
+RUN sed -i 's;registry.redhat.io;registry.access.redhat.com;' /defaults/03_community_operators.yaml
+
+LABEL io.k8s.display-name="OpenShift Marketplace Operator" \
+      io.k8s.description="This is a component of OpenShift Container Platform and manages the OpenShift Marketplace." \
+      io.openshift.tags="openshift,marketplace" \
+      io.openshift.release.operator=true \
+      maintainer="AOS Marketplace <aos-marketplace@redhat.com>"
+
+# entrypoint specified in operator.yaml as `marketplace-operator`
+CMD ["/usr/bin/marketplace-operator"]


### PR DESCRIPTION
Create a Dockerfile which builds marketplace operator for OKD payloads. 
It ensures Community operator index can be fetched by unauthenticated 
client (as OKD can be installed without a pull secret).

/cc @ecordell @shawn-hurley 

Later I'll create openshift/release PR to build it and promote to `origin` namespace so that it would land in OKD only
