### PR TITLE
Bug 1873546: Increase registry delay for large payloads

### DIFF
--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -400,7 +400,7 @@ func (r *registry) newPodTemplateSpec(registryCommand []string, needServiceAccou
 								Command: action,
 							},
 						},
-						InitialDelaySeconds: 30,
+						InitialDelaySeconds: 60,
 						FailureThreshold:    10,
 					},
 					LivenessProbe: &core.Probe{
@@ -409,7 +409,7 @@ func (r *registry) newPodTemplateSpec(registryCommand []string, needServiceAccou
 								Command: action,
 							},
 						},
-						InitialDelaySeconds: 30,
+						InitialDelaySeconds: 60,
 						FailureThreshold:    10,
 					},
 					Resources: core.ResourceRequirements{

--- a/pkg/registry/registry.go
+++ b/pkg/registry/registry.go
@@ -409,7 +409,7 @@ func (r *registry) newPodTemplateSpec(registryCommand []string, needServiceAccou
 								Command: action,
 							},
 						},
-						InitialDelaySeconds: 60,
+						InitialDelaySeconds: 30,
 						FailureThreshold:    10,
 					},
 					Resources: core.ResourceRequirements{


### PR DESCRIPTION
Fixes community and certified operators pods crash looping because their startup time exceeds their readiness probe timeout. Increase that timeout from 30s to 60s.
