### PR TITLE
Bug 1873250: Recreate default CatalogSources if deleted/edited

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -150,6 +150,12 @@ func main() {
 		}
 	}
 
+	// Populate the global default OperatorSources definition and config
+	err = defaults.PopulateGlobals()
+	if err != nil {
+		exit(err)
+	}
+
 	// Setup all Controllers
 	if err := controller.AddToManager(mgr, options.ControllerOptions{}); err != nil {
 		exit(err)
@@ -182,12 +188,6 @@ func main() {
 	err = migrator.Migrate()
 	if err != nil {
 		log.Error(err, "[migration] Error in migrating Marketplace away from OperatorSource API")
-	}
-
-	// Populate the global default OperatorSources definition and config
-	err = defaults.PopulateGlobals()
-	if err != nil {
-		exit(err)
 	}
 
 	// Handle the defaults

--- a/pkg/controller/add_catalogsource.go
+++ b/pkg/controller/add_catalogsource.go
@@ -1,0 +1,8 @@
+package controller
+
+import "github.com/operator-framework/operator-marketplace/pkg/controller/catalogsource"
+
+func init() {
+	// AddToManagerFuncs is a list of functions to create controllers and add them to a manager.
+	AddToManagerFuncs = append(AddToManagerFuncs, catalogsource.Add)
+}

--- a/pkg/controller/catalogsource/catalogsource_controller.go
+++ b/pkg/controller/catalogsource/catalogsource_controller.go
@@ -1,0 +1,130 @@
+package catalogsource
+
+import (
+	"context"
+	"time"
+
+	olm "github.com/operator-framework/operator-marketplace/pkg/apis/olm/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/pkg/controller/options"
+	"github.com/operator-framework/operator-marketplace/pkg/defaults"
+	"github.com/operator-framework/operator-marketplace/pkg/operatorhub"
+	log "github.com/sirupsen/logrus"
+	"k8s.io/apimachinery/pkg/api/errors"
+	"sigs.k8s.io/controller-runtime/pkg/client"
+	"sigs.k8s.io/controller-runtime/pkg/controller"
+	"sigs.k8s.io/controller-runtime/pkg/event"
+	"sigs.k8s.io/controller-runtime/pkg/handler"
+	"sigs.k8s.io/controller-runtime/pkg/manager"
+	"sigs.k8s.io/controller-runtime/pkg/predicate"
+	"sigs.k8s.io/controller-runtime/pkg/reconcile"
+	"sigs.k8s.io/controller-runtime/pkg/source"
+)
+
+// Add creates a new CatalogSource Controller and adds it to the Manager. The Manager will set fields on the Controller
+// and Start it when the Manager is Started.
+func Add(mgr manager.Manager, _ options.ControllerOptions) error {
+	return add(mgr, newReconciler(mgr))
+}
+
+func newReconciler(mgr manager.Manager) reconcile.Reconciler {
+	client := mgr.GetClient()
+	return &ReconcileCatalogSource{
+		client: client,
+	}
+}
+
+func add(mgr manager.Manager, r reconcile.Reconciler) error {
+
+	c, err := controller.New("catalogsource-controller", mgr, controller.Options{Reconciler: r})
+	if err != nil {
+		return err
+	}
+
+	_, defaultCatalogsources := defaults.GetGlobalDefinitions()
+	pred := predicate.Funcs{
+		CreateFunc: func(e event.CreateEvent) bool {
+			return false
+		},
+		UpdateFunc: func(e event.UpdateEvent) bool {
+			if _, ok := defaultCatalogsources[e.MetaOld.GetName()]; ok {
+				return true
+			}
+			return false
+		},
+		DeleteFunc: func(e event.DeleteEvent) bool {
+			if _, ok := defaultCatalogsources[e.Meta.GetName()]; ok {
+				// If DeleteStateUnknown is true it implies that the Delete event was missed
+				// and we can ignore it.
+				if e.DeleteStateUnknown {
+					return false
+				}
+				return true
+			}
+			return false
+		},
+		GenericFunc: func(e event.GenericEvent) bool {
+			if _, ok := defaultCatalogsources[e.Meta.GetName()]; ok {
+				return true
+			}
+			return false
+		},
+	}
+
+	err = c.Watch(&source.Kind{Type: &olm.CatalogSource{}}, &handler.EnqueueRequestForObject{}, pred)
+	if err != nil {
+		return err
+	}
+
+	return nil
+}
+
+// blank assignment to verify that ReconcileOperatorHub implements reconcile.Reconciler
+var _ reconcile.Reconciler = &ReconcileCatalogSource{}
+
+// ReconcileCatalogSource reconciles a CatalogSource object
+type ReconcileCatalogSource struct {
+	// This client, initialized using mgr.Client() above, is a split client
+	// that reads objects from the cache and writes to the apiserver
+	client client.Client
+}
+
+func (r *ReconcileCatalogSource) Reconcile(request reconcile.Request) (reconcile.Result, error) {
+	log.Infof("Reconciling default CatalogSource %s", request.Name)
+
+	_, defaultCatalogsources := defaults.GetGlobalDefinitions()
+	defaultCatsrcDef := defaultCatalogsources[request.Name]
+	// Fetch the CatalogSource instance
+	instance := &olm.CatalogSource{}
+	err := r.client.Get(context.TODO(), request.NamespacedName, instance)
+	if err != nil {
+		if errors.IsNotFound(err) {
+			if !operatorhub.GetSingleton().Get()[defaultCatsrcDef.Name] {
+				createNewCatsrcInstance(r.client, defaultCatsrcDef)
+			}
+			return reconcile.Result{}, nil
+		}
+		// Error reading the object - requeue the request.
+		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 5}, err
+	}
+
+	if instance.DeletionTimestamp != nil {
+		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
+	}
+
+	if !defaults.AreCatsrcSpecsEqual(&defaultCatsrcDef.Spec, &instance.Spec) {
+		if err := r.client.Delete(context.TODO(), instance); err != nil {
+			log.Warnf("Could not set default CatalogSource %s's spec back to desired default state. Error in deleting updated CatalogSource: %s", defaultCatsrcDef.GetName(), err.Error())
+		}
+		return reconcile.Result{Requeue: true, RequeueAfter: time.Second * 5}, nil
+	}
+	return reconcile.Result{}, nil
+}
+
+func createNewCatsrcInstance(client client.Client, catsrc olm.CatalogSource) error {
+	err := client.Create(context.TODO(), &catsrc)
+	if err != nil {
+		log.Warnf("Could not recreate default CatalogSource %s. Error: %s", catsrc.GetName(), err.Error())
+		return err
+	}
+	return nil
+}

--- a/test/testgroups/nosetuptests.go
+++ b/test/testgroups/nosetuptests.go
@@ -13,5 +13,6 @@ func NoSetupTestGroup(t *testing.T) {
 	// Run the test suites.
 	if isConfigAPIPresent, _ := helpers.EnsureConfigAPIIsAvailable(); isConfigAPIPresent == true {
 		t.Run("operatorhub-test-suite", testsuites.OperatorHubTests)
+		t.Run("default-catalogsource-test-suite", testsuites.DefaultCatsrc)
 	}
 }

--- a/test/testsuites/defaultcatsrctests.go
+++ b/test/testsuites/defaultcatsrctests.go
@@ -1,0 +1,114 @@
+package testsuites
+
+import (
+	"context"
+	"io/ioutil"
+	"testing"
+
+	olm "github.com/operator-framework/operator-marketplace/pkg/apis/olm/v1alpha1"
+	"github.com/operator-framework/operator-marketplace/test/helpers"
+	"github.com/operator-framework/operator-sdk/pkg/test"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	apps "k8s.io/api/apps/v1"
+	"k8s.io/apimachinery/pkg/types"
+)
+
+// DefaultCatsrc tests that the default CatalogSources are restored when updated
+// or deleted
+func DefaultCatsrc(t *testing.T) {
+	require.DirExists(t, helpers.DefaultsDir, "Defaults directory was not present")
+
+	fileInfos, err := ioutil.ReadDir(helpers.DefaultsDir)
+	require.NoError(t, err, "Error reading default directory")
+	require.True(t, len(fileInfos) > 0, "No default OperatorSources present")
+
+	t.Run("delete-default-catalogsource", testDeleteDefaultCatsrc)
+	t.Run("update-default-catalogsource", testUpdateDefaultCatsrc)
+	t.Run("delete-default-catsrc-while-stopped", testDeleteDefaultCatsrcWhileStopped)
+}
+
+func testDeleteDefaultCatsrc(t *testing.T) {
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	client := test.Global.Client
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	require.NoError(t, err, "Could not get namespace.")
+
+	err = helpers.InitCatSrcDefinition()
+	require.NoError(t, err, "Could not get a default CatalogSource definitions from disk")
+
+	deleteCatsrc := *helpers.DefaultSources[0]
+	err = helpers.DeleteRuntimeObject(client, &deleteCatsrc)
+	require.NoError(t, err, "Default CatalogSource could not be deleted successfully")
+
+	clusterCatSrc := &olm.CatalogSource{}
+	err = helpers.WaitForResult(client, clusterCatSrc, namespace, helpers.DefaultSources[0].Name)
+	assert.NoError(t, err, "Default CatalogSource was never created")
+
+	assert.ObjectsAreEqualValues(helpers.DefaultSources[0].Spec, clusterCatSrc.Spec)
+}
+
+// testUpdateDefaultCatsrc changes a default CatalogSource and checks if it has
+// been restored correctly.
+func testUpdateDefaultCatsrc(t *testing.T) {
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	client := test.Global.Client
+
+	err := helpers.InitCatSrcDefinition()
+	require.NoError(t, err, "Could not get a default CatalogSource definition from disk")
+
+	testCatsrc := helpers.DefaultSources[0]
+	updateCatsrc := &olm.CatalogSource{}
+	err = client.Get(context.TODO(), types.NamespacedName{Name: testCatsrc.Name, Namespace: testCatsrc.Namespace}, updateCatsrc)
+
+	updateCatsrc.Spec.Publisher = "Random"
+	err = helpers.UpdateRuntimeObject(client, updateCatsrc)
+	require.NoError(t, err, "Default CatalogSource could not be updated successfully")
+
+	err = helpers.WaitForExpectedSpec(client, testCatsrc.Name, testCatsrc.Namespace, testCatsrc)
+	assert.NoError(t, err, "Default CatalogSource never reached the expected Spec")
+}
+
+// testDeleteDefaultCatsrcWhileStopped turns off the operator, marks a default CatalogSource
+// for deletion, then starts the operator back up. When it does it expects that the
+// CatalogSource is correctly recreated.
+func testDeleteDefaultCatsrcWhileStopped(t *testing.T) {
+	ctx := test.NewTestCtx(t)
+	defer ctx.Cleanup()
+
+	client := test.Global.Client
+	namespace, err := test.NewTestCtx(t).GetNamespace()
+	require.NoError(t, err, "Could not get namespace.")
+
+	err = test.Global.Client.Get(context.TODO(), types.NamespacedName{Name: "marketplace-operator", Namespace: namespace}, &apps.Deployment{})
+	if err != nil {
+		t.Logf("Failed to find deployment operator-marketplace")
+		return
+	}
+
+	err = helpers.ScaleMarketplace(test.Global.Client, namespace, int32(0))
+	require.NoError(t, err, "Could not scale down marketplace operator")
+
+	err = helpers.InitCatSrcDefinition()
+	require.NoError(t, err, "Could not get default CatalogSource definitions from disk")
+
+	deleteCatsrc := *helpers.DefaultSources[0]
+	err = helpers.DeleteRuntimeObject(client, &deleteCatsrc)
+	require.NoError(t, err, "Default CatalogSource could not be deleted successfully")
+
+	err = helpers.WaitForCatsrcMarkedForDeletion(client, deleteCatsrc.Name, deleteCatsrc.Namespace)
+	require.NoError(t, err, "Default CatalogSource was not successfully deleted")
+
+	err = helpers.ScaleMarketplace(test.Global.Client, namespace, int32(1))
+	require.NoError(t, err, "Could not scale marketplace back up")
+
+	clusterCatSrc := &olm.CatalogSource{}
+	err = helpers.WaitForResult(client, clusterCatSrc, namespace, helpers.DefaultSources[0].Name)
+	assert.NoError(t, err, "Default CatalogSource was never created")
+
+	assert.ObjectsAreEqualValues(helpers.DefaultSources[0].Spec, clusterCatSrc.Spec)
+}


### PR DESCRIPTION
**Description of the change:**

This PR implementes a watch for default CatalogSources, to recreate them
if they are deleted or edited.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
