### PR TITLE
Bug 1874751: Dockerfile.okd: switch to root user when updating manifests

### DIFF
--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -10,7 +10,9 @@ USER marketplace-operator
 COPY --from=builder /go/src/github.com/operator-framework/operator-marketplace/build/_output/bin/marketplace-operator /usr/bin
 ADD manifests /manifests
 ADD defaults /defaults
+USER root
 RUN sed -i 's;registry.redhat.io;registry.access.redhat.com;' /defaults/03_community_operators.yaml
+USER marketplace-operator
 
 LABEL io.k8s.display-name="OpenShift Marketplace Operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the OpenShift Marketplace." \


### PR DESCRIPTION
Openshift builds run as unprivileged user, so Dockerfile has to
switch to root explicitly to edit this file.

See error in https://prow.ci.openshift.org/view/gs/origin-ci-test/pr-logs/pull/openshift_release/11529/rehearse-11529-pull-ci-operator-framework-operator-marketplace-master-okd-images/1301135639957213184

/cc @kevinrizza @ecordell