### PR TITLE
manifests/10_clusteroperator: Drop namespace from cluster-scoped resource

### DIFF
--- a/manifests/10_clusteroperator.yaml
+++ b/manifests/10_clusteroperator.yaml
@@ -2,7 +2,6 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: marketplace
-  namespace: openshift-marketplace
 status:
   versions:
     - name: operator


### PR DESCRIPTION
ClusterOperator objects are [cluster-scoped and not namespaced][1].  Dropping the namespace here reverts the ClusterOperator namespace addition from 5a41001689 (#83).

[1]: https://github.com/openshift/api/blob/7ac89ba6b97136f09e68e06c32638dae78cad516/config/v1/types_cluster_operator.go#L9