### PR TITLE
Bug 1877564: Sync remote app-registry

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -41,7 +41,6 @@ generate-mocks:
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_client.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=Client=Client $(PKG)/client Client
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_phase_reconciler_strategy.go -package=$(OPERATORSOURCE_MOCK_PKG) $(PKG)/operatorsource PhaseReconcilerFactory
 	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_appregistry.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=ClientFactory=AppRegistryClientFactory,Client=AppRegistryClient $(PKG)/appregistry ClientFactory,Client
-	$(mockgen) -destination=$(MOCKS_DIR)/$(OPERATORSOURCE_MOCK_PKG)/mock_syncer.go -package=$(OPERATORSOURCE_MOCK_PKG) -mock_names=PackageRefreshNotificationSender=SyncerPackageRefreshNotificationSender $(PKG)/operatorsource PackageRefreshNotificationSender
 
 clean-mocks:
 	@echo cleaning mock folder

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -11,6 +11,7 @@ import (
 
 	"github.com/operator-framework/operator-marketplace/pkg/metrics"
 	"github.com/operator-framework/operator-marketplace/pkg/migrator"
+	"github.com/operator-framework/operator-marketplace/pkg/operatorsource"
 
 	apiconfigv1 "github.com/openshift/api/config/v1"
 	olm "github.com/operator-framework/operator-lifecycle-manager/pkg/api/apis/operators/v1alpha1"
@@ -122,6 +123,8 @@ func main() {
 
 	log.Print("Registering Components.")
 
+	registrySyncer := operatorsource.NewRegistrySyncer(mgr.GetClient(), initialWait, resyncInterval)
+
 	// Setup Scheme for all defined resources
 	if err := apis.AddToScheme(mgr.GetScheme()); err != nil {
 		exit(err)
@@ -204,6 +207,8 @@ func main() {
 	}
 	// statusReportingDoneCh will be closed after the operator has successfully stopped reporting ClusterOperator status.
 	statusReportingDoneCh := statusReporter.StartReporting()
+
+	go registrySyncer.Sync(stopCh)
 
 	// Start the Cmd
 	err = mgr.Start(stopCh)

--- a/pkg/operatorsource/configuring.go
+++ b/pkg/operatorsource/configuring.go
@@ -17,8 +17,8 @@ import (
 
 // NewConfiguringReconciler returns a Reconciler that reconciles
 // an OperatorSource object in "Configuring" phase.
-func NewConfiguringReconciler(logger *log.Entry, factory appregistry.ClientFactory, datastore datastore.Writer, reader datastore.Reader, client client.Client, refresher PackageRefreshNotificationSender) Reconciler {
-	return NewConfiguringReconcilerWithClientInterface(logger, factory, datastore, reader, interface_client.NewClient(client), refresher)
+func NewConfiguringReconciler(logger *log.Entry, factory appregistry.ClientFactory, datastore datastore.Writer, reader datastore.Reader, client client.Client) Reconciler {
+	return NewConfiguringReconcilerWithClientInterface(logger, factory, datastore, reader, interface_client.NewClient(client))
 }
 
 // NewConfiguringReconcilerWithClientInterface returns a configuring
@@ -27,13 +27,12 @@ func NewConfiguringReconciler(logger *log.Entry, factory appregistry.ClientFacto
 // client provided by the operator-sdk, instead of the raw client itself.
 // Using this interface facilitates mocking of kube client interaction
 // with the cluster, while using fakeclient during unit testing.
-func NewConfiguringReconcilerWithClientInterface(logger *log.Entry, factory appregistry.ClientFactory, datastore datastore.Writer, reader datastore.Reader, client interface_client.Client, refresher PackageRefreshNotificationSender) Reconciler {
+func NewConfiguringReconcilerWithClientInterface(logger *log.Entry, factory appregistry.ClientFactory, datastore datastore.Writer, reader datastore.Reader, client interface_client.Client) Reconciler {
 	return &configuringReconciler{
 		logger:    logger,
 		factory:   factory,
 		datastore: datastore,
 		client:    client,
-		refresher: refresher,
 		reader:    reader,
 	}
 }
@@ -45,7 +44,6 @@ type configuringReconciler struct {
 	factory   appregistry.ClientFactory
 	datastore datastore.Writer
 	client    interface_client.Client
-	refresher PackageRefreshNotificationSender
 	reader    datastore.Reader
 }
 

--- a/pkg/operatorsource/configuring_test.go
+++ b/pkg/operatorsource/configuring_test.go
@@ -36,9 +36,8 @@ func TestReconcile_ScheduledForConfiguring_Succeeded(t *testing.T) {
 	reader := mocks.NewDatastoreReader(controller)
 	factory := mocks.NewAppRegistryClientFactory(controller)
 	fakeclient := NewFakeClientWithChildResources(&appsv1.Deployment{}, &corev1.Service{}, &corev1.Namespace{}, &v1alpha1.CatalogSource{})
-	refresher := mocks.NewSyncerPackageRefreshNotificationSender(controller)
 
-	reconciler := operatorsource.NewConfiguringReconcilerWithClientInterface(helperGetContextLogger(), factory, writer, reader, fakeclient, refresher)
+	reconciler := operatorsource.NewConfiguringReconcilerWithClientInterface(helperGetContextLogger(), factory, writer, reader, fakeclient)
 
 	ctx := context.TODO()
 	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.Configuring)
@@ -100,9 +99,8 @@ func TestReconcile_OperatorSourceReturnsEmptyManifestList_Failed(t *testing.T) {
 	reader := mocks.NewDatastoreReader(controller)
 	factory := mocks.NewAppRegistryClientFactory(controller)
 	fakeclient := NewFakeClient()
-	refresher := mocks.NewSyncerPackageRefreshNotificationSender(controller)
 
-	reconciler := operatorsource.NewConfiguringReconciler(helperGetContextLogger(), factory, writer, reader, fakeclient, refresher)
+	reconciler := operatorsource.NewConfiguringReconciler(helperGetContextLogger(), factory, writer, reader, fakeclient)
 
 	ctx := context.TODO()
 	opsrcIn := helperNewOperatorSourceWithPhase("marketplace", "foo", phase.Configuring)

--- a/pkg/operatorsource/factory.go
+++ b/pkg/operatorsource/factory.go
@@ -39,7 +39,6 @@ type phaseReconcilerFactory struct {
 	registryClientFactory appregistry.ClientFactory
 	datastore             datastore.Writer
 	client                client.Client
-	refresher             PackageRefreshNotificationSender
 }
 
 func (s *phaseReconcilerFactory) GetPhaseReconciler(logger *log.Entry, opsrc *v1.OperatorSource) (Reconciler, error) {
@@ -73,7 +72,7 @@ func (s *phaseReconcilerFactory) GetPhaseReconciler(logger *log.Entry, opsrc *v1
 		return NewValidatingReconciler(logger, s.datastore), nil
 
 	case phase.Configuring:
-		return NewConfiguringReconciler(logger, s.registryClientFactory, s.datastore, datastore.Cache, s.client, s.refresher), nil
+		return NewConfiguringReconciler(logger, s.registryClientFactory, s.datastore, datastore.Cache, s.client), nil
 
 	case phase.OperatorSourcePurging:
 		return NewPurgingReconciler(logger, s.datastore, s.client), nil

--- a/pkg/operatorsource/handler.go
+++ b/pkg/operatorsource/handler.go
@@ -36,7 +36,6 @@ func NewHandler(mgr manager.Manager, client client.Client, ss status.SyncSender)
 			registryClientFactory: appregistry.NewClientFactory(),
 			datastore:             datastore.Cache,
 			client:                client,
-			refresher:             cscRefresher,
 		},
 		transitioner:       phase.NewTransitioner(),
 		newCacheReconciler: NewOutOfSyncCacheReconciler,

--- a/pkg/operatorsource/syncer.go
+++ b/pkg/operatorsource/syncer.go
@@ -4,36 +4,16 @@ import (
 	"time"
 
 	wrapper "github.com/operator-framework/operator-marketplace/pkg/client"
-	"github.com/operator-framework/operator-marketplace/pkg/datastore"
 	log "github.com/sirupsen/logrus"
 )
 
 // NewRegistrySyncer returns a new instance of RegistrySyncer interface.
-func NewRegistrySyncer(client wrapper.Client, initialWait time.Duration, resyncInterval time.Duration, updateNotificationSendWait time.Duration, sender PackageUpdateNotificationSender, refresher PackageRefreshNotificationSender) RegistrySyncer {
+func NewRegistrySyncer(client wrapper.Client, initialWait time.Duration, resyncInterval time.Duration) RegistrySyncer {
 	return &registrySyncer{
 		initialWait:    initialWait,
 		resyncInterval: resyncInterval,
-		poller:         NewPoller(client, updateNotificationSendWait, sender, refresher),
+		poller:         NewPoller(client),
 	}
-}
-
-// PackageUpdateNotificationSender is an interface that wraps the Send method.
-//
-// Send sends package update notification to the underlying channel that
-// CatalogSourceConfig is waiting on. This method is expected to be a non
-// blocking operation.
-type PackageUpdateNotificationSender interface {
-	Send(notification datastore.PackageUpdateNotification)
-}
-
-// PackageRefreshNotificationSender is an interface that wraps the SendRefresh method.
-//
-// SendRefresh sends package refresh notification to the underlying channel that
-// CatalogSourceConfig is waiting on. This method is expected to be a non
-// blocking operation. When this notification is sent, all non datastore
-// catalogsourceconfigs check their version map in the status against the datastore.
-type PackageRefreshNotificationSender interface {
-	SendRefresh(opSrc string)
 }
 
 // RegistrySyncer is an interface that wraps the Sync method.
@@ -58,8 +38,6 @@ func (s *registrySyncer) Sync(stop <-chan struct{}) {
 	// reconciling existing OperatorSource CR(s). Let's give the process a
 	// grace period to reconcile and rebuild the local cache from existing CR(s).
 	<-time.After(s.initialWait)
-
-	s.poller.Initialize()
 
 	log.Info("[sync] Operator source sync loop has started")
 	for {


### PR DESCRIPTION
**Description of the change:**
The syncing of remote app-registry was removed by #302 since it was
    tied to the syncing of the child CatalogSourceConfig which was removed
    in #302. This PR puts the syncing of remote app-registry back in, minus
    the syncing of the non-existing child catalogSourceConfig.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

