### PR TITLE
Fix upstream deployment

### DIFF
--- a/deploy/upstream/08_operator.yaml
+++ b/deploy/upstream/08_operator.yaml
@@ -24,8 +24,6 @@ spec:
             name: healthz
           command:
           - marketplace-operator
-          args:
-          - -registryServerImage=quay.io/openshift/origin-operator-registry
           imagePullPolicy: Always
           livenessProbe:
             httpGet:


### PR DESCRIPTION
Problem: The `registryServerImage` runtime argument was recently removed
from marketplace but the marketplace deployment defined for the upstream
build did not remove the argument which caused the upstream marketplace
pod to crash.

Solution: Update the deployment manifest so it does not include the
`registryServerImage` runtime argument.
