### PR TITLE
remove the unused resyncInterval

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -38,10 +38,6 @@ import (
 )
 
 const (
-	// TODO: resyncInterval is hardcoded to 1 hour now, it would have to be
-	// configurable on a per OperatorSource level.
-	resyncInterval = time.Duration(60) * time.Minute
-
 	initialWait                = time.Duration(1) * time.Minute
 	updateNotificationSendWait = time.Duration(10) * time.Minute
 )


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Remove the unused const variable `resyncInterval`.

**Motivation for the change:**

It's confusing for the users, see: https://bugzilla.redhat.com/show_bug.cgi?id=1888527 

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
