### PR TITLE
Annotate manifests for single-node-developer cluster profile

### DIFF
--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/04_service_account.yaml
+++ b/manifests/04_service_account.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"

--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -4,6 +4,7 @@ metadata:
   name: marketplace-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""
@@ -92,6 +93,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""
@@ -150,6 +152,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - config.openshift.io

--- a/manifests/06_role_binding.yaml
+++ b/manifests/06_role_binding.yaml
@@ -4,6 +4,7 @@ metadata:
   name: marketplace-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 subjects:
 - kind: ServiceAccount
   name: marketplace-operator
@@ -20,6 +21,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 subjects:
 - kind: ServiceAccount
   name: marketplace-operator

--- a/manifests/07_configmap.yaml
+++ b/manifests/07_configmap.yaml
@@ -9,3 +9,4 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"

--- a/manifests/08_service.yaml
+++ b/manifests/08_service.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: marketplace-operator-metrics
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     name: marketplace-operator
 spec:

--- a/manifests/09_operator.yaml
+++ b/manifests/09_operator.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     config.openshift.io/inject-proxy: "marketplace-operator"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/10_clusteroperator.yaml
+++ b/manifests/10_clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 status:
   versions:
     - name: operator

--- a/manifests/11_service_monitor.yaml
+++ b/manifests/11_service_monitor.yaml
@@ -7,6 +7,7 @@ metadata:
     name: marketplace-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -35,6 +36,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -51,6 +53,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
This partially implements phase 1 of https://github.com/openshift/enhancements#482
and does not change behavior. Initially, all operator-marketplace
manifests are included in the single-node-developer cluster profile.
Follow-on PRs may exclude any of these that are not needed in the
profile.


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->