### PR TITLE
add 'single-node-production-edge' annotations to CVO manifests.

### DIFF
--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -3,6 +3,7 @@ kind: Namespace
 metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
     openshift.io/node-selector: ""
   labels:
     openshift.io/cluster-monitoring: "true"

--- a/manifests/04_service_account.yaml
+++ b/manifests/04_service_account.yaml
@@ -5,3 +5,4 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -4,6 +4,7 @@ metadata:
   name: marketplace-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""
@@ -92,6 +93,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""
@@ -150,6 +152,7 @@ metadata:
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - config.openshift.io

--- a/manifests/06_role_binding.yaml
+++ b/manifests/06_role_binding.yaml
@@ -4,6 +4,7 @@ metadata:
   name: marketplace-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount
   name: marketplace-operator
@@ -20,6 +21,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 subjects:
 - kind: ServiceAccount
   name: marketplace-operator

--- a/manifests/07_configmap.yaml
+++ b/manifests/07_configmap.yaml
@@ -9,3 +9,4 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"

--- a/manifests/08_service.yaml
+++ b/manifests/08_service.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
     service.alpha.openshift.io/serving-cert-secret-name: marketplace-operator-metrics
+    include.release.openshift.io/single-node-production-edge: "true"
   labels:
     name: marketplace-operator
 spec:

--- a/manifests/09_operator.yaml
+++ b/manifests/09_operator.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     config.openshift.io/inject-proxy: "marketplace-operator"
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   replicas: 1
   selector:

--- a/manifests/10_clusteroperator.yaml
+++ b/manifests/10_clusteroperator.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 status:
   versions:
     - name: operator

--- a/manifests/11_service_monitor.yaml
+++ b/manifests/11_service_monitor.yaml
@@ -7,6 +7,7 @@ metadata:
     name: marketplace-operator
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -35,6 +36,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -51,6 +53,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-production-edge: "true"
 rules:
 - apiGroups:
   - ""


### PR DESCRIPTION
This adds annotations for the single-node-production-edge cluster profile. There's a growing requirement from several customers to enable creation of single-node (not high-available) Openshift clusters.
In stage one (following openshift/enhancements#504) there should be no implication on components logic.
In the next stage, the component's behavior will match a non high-availability profile if the customer is specifically interested in one.
This PR is separate from the 'single-node-developer' work, which will implement a different behavior and is currently on another stage of implementation.

For more info, please refer to the enhancement link and participate in the discussion.