### PR TITLE
Bug 1909217: Do not report degraded when Marketplace exits gracefully

### DIFF
--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -251,22 +251,7 @@ func (r *reporter) monitorClusterStatus() {
 		}
 		select {
 		case <-r.stopCh:
-			// If the stopCh is closed, set all ClusterOperatorStatus conditions to false.
-			reason := "OperatorExited"
-			msg := "The operator has exited"
-			conditionListBuilder := clusterStatusListBuilder()
-			conditionListBuilder(configv1.OperatorProgressing, configv1.ConditionFalse, msg, reason)
-			conditionListBuilder(configv1.OperatorAvailable, configv1.ConditionFalse, msg, reason)
-			if operatorUpgradeable {
-				conditionListBuilder(configv1.OperatorUpgradeable, configv1.ConditionTrue, upgradeableMessage, reason)
-			} else {
-				conditionListBuilder(configv1.OperatorUpgradeable, configv1.ConditionFalse, deprecatedAPIMessage, "DeprecatedAPIsInUse")
-			}
-			statusConditions := conditionListBuilder(configv1.OperatorDegraded, configv1.ConditionFalse, msg, reason)
-			statusErr := r.setStatus(statusConditions)
-			if statusErr != nil {
-				log.Error("[status] " + statusErr.Error())
-			}
+			log.Info("[status] Operator no longer reporting status")
 			return
 		// Attempt to update the ClusterOperator status whenever the seconds
 		// number of seconds defined by coStatusReportInterval passes.
@@ -309,6 +294,7 @@ func (r *reporter) monitorClusterStatus() {
 				} else {
 					conditionListBuilder(configv1.OperatorUpgradeable, configv1.ConditionFalse, deprecatedAPIMessage, "DeprecatedAPIsInUse")
 				}
+				conditionListBuilder(configv1.OperatorDegraded, configv1.ConditionFalse, fmt.Sprintf("Available release version: %s", r.version), reason)
 				statusConditions := conditionListBuilder(configv1.OperatorAvailable, configv1.ConditionTrue, fmt.Sprintf("Available release version: %s", r.version), reason)
 				statusErr = r.setStatus(statusConditions)
 				break


### PR DESCRIPTION
Problem: The Marketplace operator should not report that it is in a bad
state to Telemeter when it exits gracefully.

Solution: No longer report that the operator has exited when the
operator shuts down gracefully.
