### PR TITLE
Bug 1908431: Preserve custom catsrc w/ default catsrc name on restart

### DIFF
--- a/pkg/defaults/catsrcHelpers.go
+++ b/pkg/defaults/catsrcHelpers.go
@@ -64,7 +64,9 @@ func processCatsrc(client wrapper.Client, def olm.CatalogSource, disable bool) e
 	}
 
 	if disable {
-		err = ensureCatsrcAbsent(client, def, cluster)
+		if cluster.Annotations[defaultCatsrcAnnotationKey] == defaultCatsrcAnnotationValue {
+			err = ensureCatsrcAbsent(client, def, cluster)
+		}
 	} else {
 		err = ensureCatsrcPresent(client, def, cluster)
 	}
@@ -98,6 +100,8 @@ func ensureCatsrcAbsent(client wrapper.Client, def olm.CatalogSource, cluster *o
 func ensureCatsrcPresent(client wrapper.Client, def olm.CatalogSource, cluster *olm.CatalogSource) error {
 	// Create if not present or is deleted
 	if cluster.Name == "" || (!cluster.ObjectMeta.DeletionTimestamp.IsZero() && len(cluster.Finalizers) == 0) {
+		def.Annotations = make(map[string]string)
+		def.Annotations[defaultCatsrcAnnotationKey] = defaultCatsrcAnnotationValue
 		err := client.Create(context.TODO(), &def)
 		if err != nil {
 			return err

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	olm "github.com/operator-framework/operator-marketplace/pkg/apis/olm/v1alpha1"
-	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	v1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	wrapper "github.com/operator-framework/operator-marketplace/pkg/client"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,6 +36,11 @@ var (
 	// The default is for all the OperatorSources in the globalDefinitions to be
 	// enabled.
 	defaultConfig = make(map[string]bool)
+)
+
+const (
+	defaultCatsrcAnnotationKey   string = "source"
+	defaultCatsrcAnnotationValue string = "marketplace-defaults"
 )
 
 // Defaults is the interface that can be used to ensure default OperatorSources

--- a/test/testsuites/defaultcatsrctests.go
+++ b/test/testsuites/defaultcatsrctests.go
@@ -171,6 +171,12 @@ func testDefaultCatsrcWhileDisabled(t *testing.T) {
 	})
 	require.NoError(t, err, "The update on the custom CatalogSource was reverted back")
 
+	err = helpers.RestartMarketplace(test.Global.Client, namespace)
+	require.NoError(t, err, "Could not restart marketplace operator")
+
+	customCatsrc, err = checkForCatsrc("redhat-operators", namespace)
+	require.NoError(t, err, "Custom CatalogSource redhat-operators was removed from the cluster after marketplace was restarted")
+
 	err = toggle(t, 4, false, false) //Re-enable all default CatalogSources
 	require.NoError(t, err, "Could not enable default CatalogSources")
 


### PR DESCRIPTION
In #362, marketplace's catalogsource reconciler was updated to allow custom
Catalogsources with the same name as one of the default Catalogsources, when
the default Catalogsource was disabled first with the operatorhub api. However,
when marketplace was restarted, the custom catalogsource was being force deleted
by marketplace's operatorhub controller.
This PR adds a special annotation to the default CatalogSources, and updates the
operator to delete any catalogsource with the same name as one of the default only
if the CatalogSource has that special annotation.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
