### PR TITLE
Bug 1908431: Preserve custom catsrc w/ default catsrc name on restart

### DIFF
--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -6,7 +6,7 @@ import (
 	"os"
 
 	olm "github.com/operator-framework/operator-marketplace/pkg/apis/olm/v1alpha1"
-	"github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
+	v1 "github.com/operator-framework/operator-marketplace/pkg/apis/operators/v1"
 	wrapper "github.com/operator-framework/operator-marketplace/pkg/client"
 	utilerrors "k8s.io/apimachinery/pkg/util/errors"
 	"sigs.k8s.io/controller-runtime/pkg/client"
@@ -36,6 +36,11 @@ var (
 	// The default is for all the OperatorSources in the globalDefinitions to be
 	// enabled.
 	defaultConfig = make(map[string]bool)
+)
+
+const (
+	defaultCatsrcAnnotationKey   string = "operatorframework.io/managed-by"
+	defaultCatsrcAnnotationValue string = "marketplace-operator"
 )
 
 // Defaults is the interface that can be used to ensure default OperatorSources

--- a/test/helpers/helpers.go
+++ b/test/helpers/helpers.go
@@ -391,31 +391,6 @@ func WaitForDeploymentScaled(client test.FrameworkClient, name, namespace string
 	return nil
 }
 
-// RestartMarketplace scales the marketplace deployment down to zero and then scales
-// it back up to it's original number of replicas, and waits for a successful deployment.
-func RestartMarketplace(client test.FrameworkClient, namespace string) error {
-	marketplace := &apps.Deployment{}
-	err := client.Get(context.TODO(), types.NamespacedName{Name: "marketplace-operator", Namespace: namespace}, marketplace)
-	if err != nil {
-		return err
-	}
-	initialReplicas := marketplace.Spec.Replicas
-
-	// Scale down deployment
-	err = ScaleMarketplace(client, namespace, int32(0))
-	if err != nil {
-		return err
-	}
-
-	// Now scale it back up
-	ScaleMarketplace(client, namespace, *initialReplicas)
-	if err != nil {
-		return err
-	}
-
-	return nil
-}
-
 // ScaleMarketplace scales the marketplace deployment to the specified replica scale size
 func ScaleMarketplace(client test.FrameworkClient, namespace string, scale int32) error {
 	marketplace := &apps.Deployment{}

--- a/test/testsuites/defaultcatsrctests.go
+++ b/test/testsuites/defaultcatsrctests.go
@@ -171,6 +171,9 @@ func testDefaultCatsrcWhileDisabled(t *testing.T) {
 	})
 	require.NoError(t, err, "The update on the custom CatalogSource was reverted back")
 
+	customCatsrc, err = checkForCatsrc("redhat-operators", namespace)
+	require.NoError(t, err, "Custom CatalogSource redhat-operators was removed from the cluster after marketplace was restarted")
+
 	err = toggle(t, 4, false, false) //Re-enable all default CatalogSources
 	require.NoError(t, err, "Could not enable default CatalogSources")
 

--- a/test/testsuites/operatorhubtests.go
+++ b/test/testsuites/operatorhubtests.go
@@ -243,10 +243,6 @@ func testClusterStatusDefaultsDisabled(t *testing.T) {
 	err = checkClusterOperatorHub(t, 4)
 	assert.NoError(t, err, "Incorrect cluster OperatorHub")
 
-	// Restart marketplace operator
-	err = helpers.RestartMarketplace(test.Global.Client, namespace)
-	require.NoError(t, err, "Could not restart marketplace operator")
-
 	// Check that the ClusterOperator resource has the correct status
 	clusterOperatorName := "marketplace"
 	expectedTypeStatus := map[apiconfigv1.ClusterStatusConditionType]apiconfigv1.ConditionStatus{
@@ -300,10 +296,6 @@ func testSomeClusterStatusDefaultsDisabled(t *testing.T) {
 
 	err = checkClusterOperatorHub(t, 2)
 	assert.NoError(t, err, "Incorrect cluster OperatorHub")
-
-	// Restart marketplace operator
-	err = helpers.RestartMarketplace(test.Global.Client, namespace)
-	require.NoError(t, err, "Could not restart marketplace operator")
 
 	// Check that the ClusterOperator resource has the correct status
 	clusterOperatorName := "marketplace"


### PR DESCRIPTION
Superseding #372.

In #362, marketplace's catalogsource reconciler was updated to allow
custom Catalogsources with the same name as one of the default
Catalogsources, when the default Catalogsource was disabled first with
the operatorhub api. However, when marketplace was restarted, the
custom catalogsource was being force deleted by marketplace's
operatorhub controller.

This PR adds a special annotation to the default CatalogSources, and
updates the operator to delete any catalogsource with the same name as
one of the default only if the CatalogSource has that special
annotation. In addition, the behavior of the marketplace operator as
it relates to reconciling the default CatalogSources should no longer
be tied to its process lifecycle.