### PR TITLE
Bug 1937986: wrong community catalog image reference

### DIFF
--- a/defaults/03_community_operators.yaml
+++ b/defaults/03_community_operators.yaml
@@ -5,7 +5,7 @@ metadata:
   namespace: "openshift-marketplace"
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/community-operator-index:latest
+  image: registry.redhat.io/redhat/community-operator-index:v4.6
   displayName: "Community Operators"
   publisher: "Red Hat"
   priority: -400


### PR DESCRIPTION
**Description of the change:**
Changes community cagalog image reference
 * from: `registry.redhat.io/redhat/community-operator-index:latest`
 * to: `registry.redhat.io/redhat/community-operator-index:v4.6`

**Motivation for the change:**
OpenShift clusters should pin to catalog images specific to their cluster version.
