### PR TITLE
Add ROKS profile annotation

### DIFF
--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -2,6 +2,7 @@ apiVersion: v1
 kind: Namespace
 metadata:
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""

--- a/manifests/04_service_account.yaml
+++ b/manifests/04_service_account.yaml
@@ -4,5 +4,6 @@ metadata:
   name: marketplace-operator
   namespace: openshift-marketplace
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: marketplace-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 rules:
@@ -92,6 +93,7 @@ metadata:
   name: marketplace-operator
   namespace: openshift-marketplace
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 rules:
@@ -151,6 +153,7 @@ metadata:
   labels:
     rbac.authorization.k8s.io/aggregate-to-cluster-reader: "true"
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 rules:

--- a/manifests/06_role_binding.yaml
+++ b/manifests/06_role_binding.yaml
@@ -3,6 +3,7 @@ apiVersion: rbac.authorization.k8s.io/v1beta1
 metadata:
   name: marketplace-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 subjects:
@@ -20,6 +21,7 @@ metadata:
   name: marketplace-operator
   namespace: openshift-marketplace
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 subjects:

--- a/manifests/07_configmap.yaml
+++ b/manifests/07_configmap.yaml
@@ -8,5 +8,6 @@ metadata:
   name: marketplace-trusted-ca
   namespace: openshift-marketplace
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"

--- a/manifests/08_service.yaml
+++ b/manifests/08_service.yaml
@@ -4,9 +4,10 @@ metadata:
   name: marketplace-operator-metrics
   namespace: openshift-marketplace
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
-    service.alpha.openshift.io/serving-cert-secret-name: marketplace-operator-metrics
     include.release.openshift.io/single-node-developer: "true"
+    service.alpha.openshift.io/serving-cert-secret-name: marketplace-operator-metrics
   labels:
     name: marketplace-operator
 spec:

--- a/manifests/09_operator.yaml
+++ b/manifests/09_operator.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     config.openshift.io/inject-proxy: "marketplace-operator"
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:

--- a/manifests/10_clusteroperator.yaml
+++ b/manifests/10_clusteroperator.yaml
@@ -4,6 +4,7 @@ metadata:
   name: marketplace
   namespace: openshift-marketplace
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 status:

--- a/manifests/11_service_monitor.yaml
+++ b/manifests/11_service_monitor.yaml
@@ -6,6 +6,7 @@ metadata:
   labels:
     name: marketplace-operator
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 spec:
@@ -35,6 +36,7 @@ metadata:
   name: openshift-marketplace-metrics
   namespace: openshift-marketplace
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 roleRef:
@@ -52,6 +54,7 @@ metadata:
   name: openshift-marketplace-metrics
   namespace: openshift-marketplace
   annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
 rules:


### PR DESCRIPTION

**Description of the change:**
Part 1 of ibm-cloud-managed profile support. 
Updates existing manifests by adding ibm-cloud-managed profile
annotations. Function is not affected.

**Motivation for the change:**
This change allows the manifests for this operator to be included in an IBM cloud managed (ROKS) deployment of OpenShift.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

