### PR TITLE
Add management workload annotations

### DIFF
--- a/defaults/01_redhat_operators.cr.yaml
+++ b/defaults/01_redhat_operators.cr.yaml
@@ -3,6 +3,8 @@ kind: "CatalogSource"
 metadata:
   name: "redhat-operators"
   namespace: "openshift-marketplace"
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/redhat-operator-index:v4.7

--- a/defaults/02_certified_operators.yaml
+++ b/defaults/02_certified_operators.yaml
@@ -3,6 +3,8 @@ kind: "CatalogSource"
 metadata:
   name: "certified-operators"
   namespace: "openshift-marketplace"
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/certified-operator-index:v4.7

--- a/defaults/03_community_operators.yaml
+++ b/defaults/03_community_operators.yaml
@@ -3,6 +3,8 @@ kind: "CatalogSource"
 metadata:
   name: "community-operators"
   namespace: "openshift-marketplace"
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/community-operator-index:v4.7

--- a/defaults/04_redhat_marketplace.yaml
+++ b/defaults/04_redhat_marketplace.yaml
@@ -3,6 +3,8 @@ kind: "CatalogSource"
 metadata:
   name: "redhat-marketplace"
   namespace: "openshift-marketplace"
+  annotations:
+    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/redhat-marketplace-index:v4.7

--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
+    workload.openshift.io/allowed: "management"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: "openshift-marketplace"

--- a/manifests/09_operator.yaml
+++ b/manifests/09_operator.yaml
@@ -15,6 +15,8 @@ spec:
       name: marketplace-operator
   template:
     metadata:
+      annotations:
+        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: marketplace-operator
     spec:


### PR DESCRIPTION
In support of the workload partitioning feature
(https://github.com/openshift/enhancements/pull/703), we need to add
annotations to all management pods and namespaces so they can be
properly identified and assigned to segregated management cores on
clusters configured to do so.

Note: The added CatalogSource annotations will not affect their
corresponding pods until after
https://github.com/operator-framework/operator-lifecycle-manager/pull/2085
is merged.

**Description of the change:**

Adds the new OpenShift management workload annotations to all namespaces, pods, and CatalogSources.

**Motivation for the change:**

These annotations will allow Kubelet and CRI-O to recognize "management" pods and allocate them to specific CPUs on resource-constrained systems, such as Single Node OpenShift.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
