### PR TITLE
Bug 1949277: Add operator manifest specific to ibm-cloud-managed profile

### DIFF
--- a/manifests/09_operator-ibm-cloud-managed.yaml
+++ b/manifests/09_operator-ibm-cloud-managed.yaml
@@ -5,8 +5,7 @@ metadata:
   namespace: openshift-marketplace
   annotations:
     config.openshift.io/inject-proxy: "marketplace-operator"
-    include.release.openshift.io/self-managed-high-availability: "true"
-    include.release.openshift.io/single-node-developer: "true"
+    include.release.openshift.io/ibm-cloud-managed: "true"
 spec:
   replicas: 1
   selector:
@@ -20,38 +19,37 @@ spec:
         name: marketplace-operator
     spec:
       serviceAccountName: marketplace-operator
-      nodeSelector:
-        node-role.kubernetes.io/master: ""
+      nodeSelector: {}
       priorityClassName: "system-cluster-critical"
       tolerations:
-      - key: "node-role.kubernetes.io/master"
-        operator: Exists
-        effect: "NoSchedule"
-      - key: "node.kubernetes.io/unreachable"
-        operator: "Exists"
-        effect: "NoExecute"
-        tolerationSeconds: 120
-      - key: "node.kubernetes.io/not-ready"
-        operator: "Exists"
-        effect: "NoExecute"
-        tolerationSeconds: 120
+        - key: "node-role.kubernetes.io/master"
+          operator: Exists
+          effect: "NoSchedule"
+        - key: "node.kubernetes.io/unreachable"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
+        - key: "node.kubernetes.io/not-ready"
+          operator: "Exists"
+          effect: "NoExecute"
+          tolerationSeconds: 120
       containers:
         - name: marketplace-operator
           image: quay.io/openshift/origin-operator-marketplace:latest
           ports:
-          - containerPort: 60000
-            name: metrics
-          - containerPort: 8080
-            name: healthz
+            - containerPort: 60000
+              name: metrics
+            - containerPort: 8080
+              name: healthz
           command:
-          - marketplace-operator
+            - marketplace-operator
           args:
-          - -defaultsDir=/defaults
-          - -clusterOperatorName=marketplace
-          - -tls-cert
-          - /var/run/secrets/serving-cert/tls.crt
-          - -tls-key
-          - /var/run/secrets/serving-cert/tls.key
+            - -defaultsDir=/defaults
+            - -clusterOperatorName=marketplace
+            - -tls-cert
+            - /var/run/secrets/serving-cert/tls.crt
+            - -tls-key
+            - /var/run/secrets/serving-cert/tls.key
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:
@@ -90,8 +88,8 @@ spec:
             optional: true
             name: marketplace-trusted-ca
             items:
-            - key: ca-bundle.crt
-              path: tls-ca-bundle.pem
+              - key: ca-bundle.crt
+                path: tls-ca-bundle.pem
         - name: marketplace-operator-metrics
           secret:
             secretName: marketplace-operator-metrics

--- a/scripts/update-manifests.sh
+++ b/scripts/update-manifests.sh
@@ -1,0 +1,17 @@
+#!/bin/bash
+
+MANIFESTS="$( cd "$( dirname "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )/../manifests"
+
+# Download yq
+YQ_DIR="$(mktemp -d)"
+YQ="${YQ_DIR}/yq"
+curl -Lo "${YQ}" https://github.com/mikefarah/yq/releases/download/3.4.1/yq_linux_amd64
+chmod +x "${YQ}"
+
+SOURCE_MANIFEST="${MANIFESTS}/09_operator.yaml"
+DESTINATION_MANIFEST="${MANIFESTS}/09_operator-ibm-cloud-managed.yaml"
+cp "${SOURCE_MANIFEST}" "${DESTINATION_MANIFEST}"
+${YQ} d -d'*' --inplace "${DESTINATION_MANIFEST}" 'metadata.annotations'
+${YQ} w -d'*' --inplace --style=double "${DESTINATION_MANIFEST}" 'metadata.annotations['config.openshift.io/inject-proxy']' "marketplace-operator"
+${YQ} w -d'*' --inplace --style=double "${DESTINATION_MANIFEST}" 'metadata.annotations['include.release.openshift.io/ibm-cloud-managed']' true
+${YQ} d -d'*' --inplace "${DESTINATION_MANIFEST}" 'spec.template.spec.nodeSelector."node-role.kubernetes.io/master"'


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Adds a script that generates a version of the operator manifest specific for the ibm-cloud-managed profile.
The resulting manifest has an annotation for ibm-cloud-managed and has no node selector.

**Motivation for the change:**
On IBM Cloud managed there are no master nodes, the control plane is externally managed. Therefore operator deployments cannot have a nodeselector for master nodes. Support for 'cluster profiles' in the CVO makes it possible to target manifests to a specific profile by setting an annotation on the manifest for the profile to which it belongs. This PR creates a version of the marketplace operator deployment that does not have a master node selector that will only be applied when running under an 'ibm-cloud-managed' profile.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
