### PR TITLE
Rename workload annotations

### DIFF
--- a/defaults/01_redhat_operators.cr.yaml
+++ b/defaults/01_redhat_operators.cr.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "redhat-operators"
   namespace: "openshift-marketplace"
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/redhat-operator-index:v4.7

--- a/defaults/02_certified_operators.yaml
+++ b/defaults/02_certified_operators.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "certified-operators"
   namespace: "openshift-marketplace"
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/certified-operator-index:v4.7

--- a/defaults/03_community_operators.yaml
+++ b/defaults/03_community_operators.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "community-operators"
   namespace: "openshift-marketplace"
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/community-operator-index:v4.7

--- a/defaults/04_redhat_marketplace.yaml
+++ b/defaults/04_redhat_marketplace.yaml
@@ -4,7 +4,7 @@ metadata:
   name: "redhat-marketplace"
   namespace: "openshift-marketplace"
   annotations:
-    workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/redhat-marketplace-index:v4.7

--- a/manifests/09_operator.yaml
+++ b/manifests/09_operator.yaml
@@ -16,7 +16,7 @@ spec:
   template:
     metadata:
       annotations:
-        workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
       labels:
         name: marketplace-operator
     spec:


### PR DESCRIPTION
**Description of the change:**

As per https://github.com/openshift/enhancements/pull/739, the workload
annotations names are changing.

**Motivation for the change:**

Changing requirements.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive

/hold
Hold until after openshift/kubernetes#632 is merged please