### PR TITLE
Bug 1950417: Add the ability to override the operator-sdk binary in e2e tests

### DIFF
--- a/scripts/e2e-tests.sh
+++ b/scripts/e2e-tests.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
-set -eu
+set -o errexit
+set -o nounset
+set -o pipefail
 
 ARG1=${1-}
 if [ "$ARG1" = "minikube" ]; then
@@ -8,6 +10,10 @@ else
     TEST_NAMESPACE="openshift-marketplace"
 fi
 
+OPERATOR_SDK_BIN=${OPERATOR_SDK_BIN:=operator-sdk}
+export GO111MODULE=off
+
 # Run the tests through the operator-sdk
 echo "Running operator-sdk test"
-operator-sdk test local ./test/e2e/ --no-setup --go-test-flags "-v -timeout 50m" --namespace $TEST_NAMESPACE
+${OPERATOR_SDK_BIN} --version
+${OPERATOR_SDK_BIN} test local ./test/e2e/ --no-setup --go-test-flags "-v -timeout 50m" --namespace $TEST_NAMESPACE

--- a/scripts/run-e2e-job.sh
+++ b/scripts/run-e2e-job.sh
@@ -1,13 +1,15 @@
+#! /bin/bash
+
 set -o errexit
 set -o nounset
 set -o pipefail
 
-MARKETPLACE_OPERATOR_ROOT=$(dirname "${BASH_SOURCE}")/..
+ROOT_DIR=$(dirname "${BASH_SOURCE[0]}")/..
 SDK_VERSION=v0.3.0
 
 # Get operator-sdk binary.
 wget -O /tmp/operator-sdk https://github.com/operator-framework/operator-sdk/releases/download/${SDK_VERSION}/operator-sdk-${SDK_VERSION}-x86_64-linux-gnu && chmod +x /tmp/operator-sdk
 
-PATH=$PATH:/tmp
-cd $MARKETPLACE_OPERATOR_ROOT
-. ./scripts/e2e-tests.sh
+pushd "${ROOT_DIR}"
+OPERATOR_SDK_BIN=/tmp/operator-sdk "${ROOT_DIR}/scripts/e2e-tests.sh"
+popd


### PR DESCRIPTION
Update the e2e-job and e2e-tests bash scripts and fix the issue where
the /tmp/operator-sdk binary isn't in $PATH locally by adding the ability
to override the operator-sdk binary we're testing against.

Update the scripts/e2e-tests.sh script and export GO111MODULE=off now
that we're building and testing with Go 1.16, but we're still using dep
as the package manager.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
