### PR TITLE
Bug 1958888: Switch to controller-runtime's leader election

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -61,6 +61,7 @@ func main() {
 		tlsCertPath             string
 		version                 bool
 		leaderElectionNamespace string
+		logLevel                string
 	)
 	flag.StringVar(&clusterOperatorName, "clusterOperatorName", "", "the name of the OpenShift ClusterOperator that should reflect this operator's status, or the empty string to disable ClusterOperator updates")
 	flag.StringVar(&defaults.Dir, "defaultsDir", "", "the directory where the default CatalogSources are stored")
@@ -68,6 +69,7 @@ func main() {
 	flag.StringVar(&tlsKeyPath, "tls-key", "", "Path to use for private key (requires tls-cert)")
 	flag.StringVar(&tlsCertPath, "tls-cert", "", "Path to use for certificate (requires tls-key)")
 	flag.StringVar(&leaderElectionNamespace, "leader-namespace", "openshift-marketplace", "Namespace in which the leader election lock is stored.")
+	flag.StringVar(&logLevel, "log-level", "info", "controls the logging verbosity")
 	flag.Parse()
 
 	// Check if version flag was set
@@ -75,10 +77,16 @@ func main() {
 		logrus.Infof("%s", sourceCommit.String())
 		os.Exit(0)
 	}
+	level, err := logrus.ParseLevel(logLevel)
+	if err != nil {
+		logrus.Info("failed to parse the log level (%s): %v", logLevel, err)
+		os.Exit(1)
+	}
+	logrus.SetLevel(level)
 
 	// set TLS to serve metrics over a secure channel if cert is provided
 	// cert is provided by default by the marketplace-trusted-ca volume mounted as part of the marketplace-operator deployment
-	err := metrics.ServePrometheus(tlsCertPath, tlsKeyPath)
+	err = metrics.ServePrometheus(tlsCertPath, tlsKeyPath)
 	if err != nil {
 		logrus.Fatalf("failed to serve prometheus metrics: %s", err)
 	}

--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -117,9 +117,11 @@ rules:
   - ""
   resources:
   - configmaps
+  - events
   verbs:
   - get
   - create
+  - update
 - apiGroups:
   - ""
   resources:

--- a/manifests/09_operator.yaml
+++ b/manifests/09_operator.yaml
@@ -57,6 +57,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
+            initialDelaySeconds: 30
           readinessProbe:
             httpGet:
               path: /healthz

--- a/manifests/09_operator.yaml
+++ b/manifests/09_operator.yaml
@@ -61,6 +61,7 @@ spec:
             httpGet:
               path: /healthz
               port: 8080
+            initialDelaySeconds: 20
           resources:
             requests:
               cpu: 10m


### PR DESCRIPTION
**Description of the change:**
Switches to controller-runtime's leader election instead of the old sdk's leader package.

Also sets the default lock namespace to openshift-marketplace

**Motivation for the change:**
The old sdk leader election always assumed the lock could be found in
the same namespace as the pod. this is an issue if the operator
is running in a different cluster than the apiserver its talking to,
such as in a hypershift topology

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
