### PR TITLE
manifests/10_clusteroperator: Drop the unused namespace property

### DIFF
--- a/manifests/10_clusteroperator.yaml
+++ b/manifests/10_clusteroperator.yaml
@@ -2,7 +2,6 @@ apiVersion: config.openshift.io/v1
 kind: ClusterOperator
 metadata:
   name: marketplace
-  namespace: openshift-marketplace
   annotations:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"


### PR DESCRIPTION
ClusterOperator is cluster-scoped, [not namespaced][1].

I don't think this causes any issues though, so no bug, and we can land once we open for 4.9.

/hold

[1]: https://github.com/openshift/api/blob/e5fb810477d3f7e8c38e7c0d262f916c407576b8/config/v1/types_cluster_operator.go#L9