### PR TITLE
Bug 1936585: Configure alerts for Non-Ready Default CatalogSources

### DIFF
--- a/manifests/12_prometheus_rule.yaml
+++ b/manifests/12_prometheus_rule.yaml
@@ -1,0 +1,46 @@
+apiVersion: monitoring.coreos.com/v1
+kind: PrometheusRule
+metadata:
+  name: marketplace-alert-rules
+  namespace: openshift-marketplace
+  labels:
+    prometheus: alert-rules
+    role: alert-rules
+spec:
+  groups:
+    - name: marketplace.community_operators.rules
+      rules:
+        - alert: CommunityOperatorsCatalogError
+          annotations:
+            message: Default OperatorHub source "community-operators" is in Non-Ready state for more than 10 mins.
+          expr: catalogsource_ready{name="community-operators",exported_namespace="openshift-marketplace"} == 0
+          for: 10m
+          labels:
+            severity: warning
+    - name: marketplace.certified_operators.rules
+      rules:
+        - alert: CertifiedOperatorsCatalogError
+          annotations:
+            message: Default OperatorHub source "certified-operators" is in Non-Ready state for more than 10 mins.
+          expr: catalogsource_ready{name="certified-operators",exported_namespace="openshift-marketplace"} == 0
+          for: 10m
+          labels:
+            severity: warning
+    - name: marketplace.redhat_operators.rules
+      rules:
+        - alert: RedhatOperatorsCatalogError
+          annotations:
+            message: Default OperatorHub source "redhat-operators" is in Non-Ready state for more than 10 mins.
+          expr: catalogsource_ready{name="redhat-operators",exported_namespace="openshift-marketplace"} == 0
+          for: 10m
+          labels:
+            severity: warning
+    - name: marketplace.redhat_marketplace.rules
+      rules:
+        - alert: RedhatMarketplaceCatalogError
+          annotations:
+            message: Default OperatorHub source "redhat-marketplace" is in Non-Ready state for more than 10 mins.
+          expr: catalogsource_ready{name="redhat-marketplace",exported_namespace="openshift-marketplace"} == 0
+          for: 10m
+          labels:
+            severity: warning


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

With the [introduction of the `catalogsource_ready` metric in olm](https://github.com/operator-framework/operator-lifecycle-manager/pull/2152), alerts can be
fired for the default CatalogSources marketplace deploys if they are in	a non-ready state.
This PR introduces prometheus alerts for any default CatalogSources that have
been in a Non-Ready state for more than 10 mins.

**See it in action:**

![Screenshot from 2021-05-19 15-32-32](https://user-images.githubusercontent.com/3811058/118873408-ba5b3e80-b8b7-11eb-8eac-659eeaf8573e.png)

`CommunityOperatorsCatalogError` alert being fired on a deployment of marketplace with an intentional bad image for `community-operators`

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive



