### PR TITLE
Bug 1936585: Add CVO specific annotations

### DIFF
--- a/manifests/12_prometheus_rule.yaml
+++ b/manifests/12_prometheus_rule.yaml
@@ -3,6 +3,10 @@ kind: PrometheusRule
 metadata:
   name: marketplace-alert-rules
   namespace: openshift-marketplace
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
   labels:
     prometheus: alert-rules
     role: alert-rules


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Follow up for #402. This PR adds the annotations required by CVO to
communicate the intention of applying the manifest on ocp installation.

**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
