### PR TITLE
Bug 1961341: [release-4.7] Update openshift rolebindings to v1

### DIFF
--- a/manifests/06_role_binding.yaml
+++ b/manifests/06_role_binding.yaml
@@ -1,5 +1,5 @@
 kind: ClusterRoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: marketplace-operator
   annotations:
@@ -14,7 +14,7 @@ roleRef:
   apiGroup: rbac.authorization.k8s.io
 ---
 kind: RoleBinding
-apiVersion: rbac.authorization.k8s.io/v1beta1
+apiVersion: rbac.authorization.k8s.io/v1
 metadata:
   name: marketplace-operator
   namespace: openshift-marketplace


### PR DESCRIPTION
Cherry-pick of https://github.com/operator-framework/operator-marketplace/pull/390 on `release-4.7`, so that we could drop v1beta1 support in 4.7 CVO