### PR TITLE
Start without defaults on ARM

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -10,6 +10,9 @@ USER marketplace-operator
 COPY --from=builder /go/src/github.com/operator-framework/operator-marketplace/build/_output/bin/marketplace-operator /usr/bin
 ADD manifests /manifests
 ADD defaults /defaults
+USER root
+RUN if test "$(arch)" = "aarch64"; then sed -i '/defaultsDir/d' /manifests/09_operator.yaml; fi
+USER marketplace-operator
 
 LABEL io.k8s.display-name="OpenShift Marketplace Operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the OpenShift Marketplace." \


### PR DESCRIPTION
**Description of the change:**

Remove the defaultDir argument from the operator manifest on ARM.

**Motivation for the change:**

﻿The defaults currently point to 4.8 indexes which do not yet exist on
ARM, which result in unnecessary alerts and the need for a post-install
command to silence them.  Removing the defaultDir argument from the
operator launch command on ARM should avoid this.

This should be reverted once 4.9 indexes are available.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
