### PR TITLE
Bug 1954869: Add priorityclass annotation to default catalogsources

### DIFF
--- a/defaults/01_redhat_operators.cr.yaml
+++ b/defaults/01_redhat_operators.cr.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "openshift-marketplace"
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    operatorframework.io/priorityclass: 'system-cluster-critical'
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/redhat-operator-index:v4.8

--- a/defaults/02_certified_operators.yaml
+++ b/defaults/02_certified_operators.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "openshift-marketplace"
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    operatorframework.io/priorityclass: 'system-cluster-critical'
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/certified-operator-index:v4.8

--- a/defaults/03_community_operators.yaml
+++ b/defaults/03_community_operators.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "openshift-marketplace"
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    operatorframework.io/priorityclass: 'system-cluster-critical'
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/community-operator-index:v4.8

--- a/defaults/04_redhat_marketplace.yaml
+++ b/defaults/04_redhat_marketplace.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "openshift-marketplace"
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    operatorframework.io/priorityclass: 'system-cluster-critical'
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/redhat-marketplace-index:v4.8


### PR DESCRIPTION
This priorityclass annotation will contain priorityclass setting
for registry pods that are associated with default catalogsources.

The selected priorityclass for registry pod is 'system-cluster-critical'.

Signed-off-by: Vu Dinh <vudinh@outlook.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
