### PR TITLE
Bug 1996928: Revert "Start without defaults on ARM"

### DIFF
--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -10,9 +10,6 @@ USER marketplace-operator
 COPY --from=builder /go/src/github.com/operator-framework/operator-marketplace/build/_output/bin/marketplace-operator /usr/bin
 ADD manifests /manifests
 ADD defaults /defaults
-USER root
-RUN if test "$(arch)" = "aarch64"; then sed -i '/defaultsDir/d' /manifests/09_operator.yaml; fi
-USER marketplace-operator
 
 LABEL io.k8s.display-name="OpenShift Marketplace Operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the OpenShift Marketplace." \


### PR DESCRIPTION
Reverts operator-framework/operator-marketplace#413

Depends on redhat-operator-index:v4.9 being available for arm64/aarch64:
/hold