### PR TITLE
Makefile,test: Fix flaky e2e tests

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -30,7 +30,7 @@ unit-test:
 e2e: e2e-job
 
 e2e-job:
-	go test -v -race -failfast -timeout 90m ./test/e2e/...
+	go test -v -race -failfast -timeout 90m ./test/e2e/... --ginkgo.randomizeAllSpecs
 
 install-olm-crds:
 	kubectl apply -f https://github.com/operator-framework/operator-lifecycle-manager/releases/download/v0.17.0/crds.yaml

--- a/test/e2e/clusteroperator_test.go
+++ b/test/e2e/clusteroperator_test.go
@@ -13,6 +13,7 @@ import (
 
 var _ = Describe("clusteroperator", func() {
 	var (
+		co                  = &configv1.ClusterOperator{}
 		ctx                 = context.Background()
 		clusterOperatorName = "marketplace"
 		expectedTypeStatus  = map[configv1.ClusterStatusConditionType]configv1.ConditionStatus{
@@ -22,7 +23,6 @@ var _ = Describe("clusteroperator", func() {
 			configv1.OperatorDegraded:    configv1.ConditionFalse,
 		}
 	)
-	co := &configv1.ClusterOperator{}
 
 	It("Should contain the expected status conditions", func() {
 		err := k8sClient.Get(ctx, types.NamespacedName{Name: clusterOperatorName}, co)
@@ -35,6 +35,10 @@ var _ = Describe("clusteroperator", func() {
 	})
 
 	It("Should contain the correct related objects", func() {
+		err := k8sClient.Get(ctx, types.NamespacedName{Name: clusterOperatorName}, co)
+		Expect(err).ToNot(HaveOccurred())
+		Expect(co).ToNot(BeNil())
+
 		expectedRelatedObjects := []configv1.ObjectReference{
 			{
 				Resource: "namespaces",

--- a/test/e2e/operatorhub_test.go
+++ b/test/e2e/operatorhub_test.go
@@ -105,14 +105,15 @@ var _ = Describe("operatorhub", func() {
 
 			Eventually(func() error {
 				css := &olmv1alpha1.CatalogSourceList{}
-				err = k8sClient.List(ctx, css)
-				Expect(err).ToNot(HaveOccurred())
-				Expect(css).ToNot(BeNil())
-				Expect(css.Items).To(HaveLen(1), "unexpected number of catalogsource resources returned")
-
-				cs := css.Items[0]
-				Expect(cs).ToNot(BeNil())
-				Expect(cs.GetName()).To(Equal(nonDefaultCS.GetName()))
+				if err := k8sClient.List(ctx, css); err != nil {
+					return err
+				}
+				if len(css.Items) != 1 {
+					return fmt.Errorf("unexpected number of catalogsources returned from list call")
+				}
+				if css.Items[0].ObjectMeta.Name != nonDefaultName {
+					return fmt.Errorf("unexpected catalogsource returned from list call")
+				}
 				return nil
 			}, 15, 1).Should(BeNil())
 		})


### PR DESCRIPTION
Update the Makefile `e2e-job` target and add the --randomizeAllSpecs
ginkgo flag. This should help weed out any state flakes when tests are
run in completely random order.

Update relevant test/e2e test packages and fix flaky state behavior.