### PR TITLE
Add summary and description for prometheus alerts

### DIFF
--- a/manifests/12_prometheus_rule.yaml
+++ b/manifests/12_prometheus_rule.yaml
@@ -17,7 +17,7 @@ spec:
         - alert: CommunityOperatorsCatalogError
           annotations:
             summary: Community-operators not ready for 10 minutes
-            description: Occurs whenever the community-operators source is not ready for more than 10 mins.
+            description: Fires whenever the community-operators source is not ready for more than 10 mins.
             message: Default OperatorHub source "community-operators" is in Non-Ready state for more than 10 mins.
           expr: catalogsource_ready{name="community-operators",exported_namespace="openshift-marketplace"} == 0
           for: 10m
@@ -28,7 +28,7 @@ spec:
         - alert: CertifiedOperatorsCatalogError
           annotations:
             summary: Certified-operators not ready for more than 10 minutes
-            description: Occurs whenever the certified-operators source is not ready for more than 10 mins.
+            description: Fires whenever the certified-operators source is not ready for more than 10 mins.
             message: Default OperatorHub source "certified-operators" is in Non-Ready state for more than 10 mins.
           expr: catalogsource_ready{name="certified-operators",exported_namespace="openshift-marketplace"} == 0
           for: 10m
@@ -39,7 +39,7 @@ spec:
         - alert: RedhatOperatorsCatalogError
           annotations:
             summary: Redhat-operators not ready for more than 10 minutes
-            description: Occurs whenever the redhat-operators source is not ready for more than 10 mins.
+            description: Fires whenever the redhat-operators source is not ready for more than 10 mins.
             message: Default OperatorHub source "redhat-operators" is in Non-Ready state for more than 10 mins.
           expr: catalogsource_ready{name="redhat-operators",exported_namespace="openshift-marketplace"} == 0
           for: 10m
@@ -50,7 +50,7 @@ spec:
         - alert: RedhatMarketplaceCatalogError
           annotations:
             summary: Redhat-marketplace not ready for more than 10 minutes
-            description: Occurs whenever the redhat-marketplace source is not ready for more than 10 mins.
+            description: Fires whenever the redhat-marketplace source is not ready for more than 10 mins.
             message: Default OperatorHub source "redhat-marketplace" is in Non-Ready state for more than 10 mins.
           expr: catalogsource_ready{name="redhat-marketplace",exported_namespace="openshift-marketplace"} == 0
           for: 10m

--- a/manifests/12_prometheus_rule.yaml
+++ b/manifests/12_prometheus_rule.yaml
@@ -16,6 +16,8 @@ spec:
       rules:
         - alert: CommunityOperatorsCatalogError
           annotations:
+            summary: Community-operators not ready for 10 minutes
+            description: Occurs whenever the community-operators source is not ready for more than 10 mins.
             message: Default OperatorHub source "community-operators" is in Non-Ready state for more than 10 mins.
           expr: catalogsource_ready{name="community-operators",exported_namespace="openshift-marketplace"} == 0
           for: 10m
@@ -25,6 +27,8 @@ spec:
       rules:
         - alert: CertifiedOperatorsCatalogError
           annotations:
+            summary: Certified-operators not ready for more than 10 minutes
+            description: Occurs whenever the certified-operators source is not ready for more than 10 mins.
             message: Default OperatorHub source "certified-operators" is in Non-Ready state for more than 10 mins.
           expr: catalogsource_ready{name="certified-operators",exported_namespace="openshift-marketplace"} == 0
           for: 10m
@@ -34,6 +38,8 @@ spec:
       rules:
         - alert: RedhatOperatorsCatalogError
           annotations:
+            summary: Redhat-operators not ready for more than 10 minutes
+            description: Occurs whenever the redhat-operators source is not ready for more than 10 mins.
             message: Default OperatorHub source "redhat-operators" is in Non-Ready state for more than 10 mins.
           expr: catalogsource_ready{name="redhat-operators",exported_namespace="openshift-marketplace"} == 0
           for: 10m
@@ -43,6 +49,8 @@ spec:
       rules:
         - alert: RedhatMarketplaceCatalogError
           annotations:
+            summary: Redhat-marketplace not ready for more than 10 minutes
+            description: Occurs whenever the redhat-marketplace source is not ready for more than 10 mins.
             message: Default OperatorHub source "redhat-marketplace" is in Non-Ready state for more than 10 mins.
           expr: catalogsource_ready{name="redhat-marketplace",exported_namespace="openshift-marketplace"} == 0
           for: 10m


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Adding a summary annotation and replace the message annotation with description for prometheus alerts.

**Motivation for the change:**

Fixing Bug 1992510 which references the [Open Shift alerting standards](https://github.com/openshift/enhancements/blob/master/enhancements/monitoring/alerting-consistency.md#documentation-required).

**Reviewer Checklist**
- [X] Implementation matches the proposed design, or proposal is updated to match implementation
- [X] Sufficient unit test coverage 
- [X] Sufficient end-to-end test coverage
- [X]  Docs updated or added to `/docs` 
- [X] Commit messages sensible and descriptive

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
