### PR TITLE
Bug 2057558: increase polling time of status report to reduce log spam

### DIFF
--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -76,6 +76,7 @@ func main() {
 		tlsCertPath             string
 		leaderElectionNamespace string
 		version                 bool
+		loglvl                  string
 	)
 	flag.StringVar(&clusterOperatorName, "clusterOperatorName", "", "configures the name of the OpenShift ClusterOperator that should reflect this operator's status, or the empty string to disable ClusterOperator updates")
 	flag.StringVar(&defaults.Dir, "defaultsDir", "", "configures the directory where the default CatalogSources are stored")
@@ -83,9 +84,17 @@ func main() {
 	flag.StringVar(&tlsKeyPath, "tls-key", "", "Path to use for private key (requires tls-cert)")
 	flag.StringVar(&tlsCertPath, "tls-cert", "", "Path to use for certificate (requires tls-key)")
 	flag.StringVar(&leaderElectionNamespace, "leader-namespace", "openshift-marketplace", "configures the namespace that will contain the leader election lock")
+	flag.StringVar(&loglvl, "level", "info", "Sets level of logger with default verbosity info level. See https://github.com/sirupsen/logrus for other verbosity levels.")
 	flag.Parse()
-
 	logger := logrus.New()
+
+	// Set verbosity level
+	parsedLevel, err := logrus.ParseLevel(loglvl)
+	if err != nil {
+		logger.Error(err)
+		os.Exit(1)
+	}
+	logger.SetLevel(parsedLevel)
 
 	// Check if version flag was set
 	if version {

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// coStatusReportInterval is the interval at which the ClusterOperator status is updated
-	coStatusReportInterval = 20 * time.Second
+	coStatusReportInterval = 60 * time.Second
 
 	upgradeable = "Marketplace is upgradeable"
 

--- a/pkg/status/status.go
+++ b/pkg/status/status.go
@@ -23,7 +23,7 @@ import (
 
 const (
 	// coStatusReportInterval is the interval at which the ClusterOperator status is updated
-	coStatusReportInterval = 60 * time.Second
+	coStatusReportInterval = 20 * time.Second
 
 	upgradeable = "Marketplace is upgradeable"
 
@@ -118,24 +118,26 @@ func (r *reporter) setStatusCondition(statusCondition configv1.ClusterOperatorSt
 // updateStatus makes the API call to update the ClusterOperator if the status has changed.
 func (r *reporter) updateStatus(previousStatus *configv1.ClusterOperatorStatus) error {
 	if compareClusterOperatorStatusConditionArrays(previousStatus.Conditions, r.clusterOperator.Status.Conditions) {
-		log.Infof("[status] Previous and current ClusterOperator Status are the same, the ClusterOperator Status will not be updated.")
+		log.Debugf("[status] Previous and current ClusterOperator Status are the same, the ClusterOperator Status will not be updated.")
 		return nil
 	}
-	log.Debugf("[status] Previous and current ClusterOperator Status are different, attempting to update the ClusterOperator Status.")
-
+	log.Infof("[status] Previous and current ClusterOperator Status are different, attempting to update the ClusterOperator Status.")
 	// Check if the ClusterOperator version has changed and log the attempt to upgrade if it has
 	previousVersion := operatorhelpers.FindOperandVersion(previousStatus.Versions, "operator")
 	currentVersion := operatorhelpers.FindOperandVersion(r.clusterOperator.Status.Versions, "operator")
 	if currentVersion != nil {
 		if previousVersion == nil {
+
 			log.Infof("[status] Attempting to set ClusterOperator to version %s", currentVersion.Version)
 		} else if previousVersion.Version != currentVersion.Version {
+
 			log.Infof("[status] Attempting to upgrade ClusterOperator version from %s to %s", previousVersion.Version, currentVersion.Version)
 		}
 	}
 
 	log.Infof("[status] Attempting to set the ClusterOperator status conditions to:")
 	for _, statusCondition := range r.clusterOperator.Status.Conditions {
+
 		log.Infof("[status] ConditionType: %v ConditionStatus: %v ConditionMessage: %v", statusCondition.Type, statusCondition.Status, statusCondition.Message)
 	}
 


### PR DESCRIPTION
Description of the change:

This PR updates the log level to reduce log spam. Also, adds log-level knob on binary to allow users to adjust verbose level of logger.

Motivation for the change:

Reduce log spamming with poll status updates. 

Reviewer Checklist

 Implementation matches the proposed design, or proposal is updated to match implementation
 * Sufficient unit test coverage
 * Sufficient end-to-end test coverage
 * Docs updated or added to /docs
 * Commit messages sensible and descriptive

Signed-off-by: Jonathan Buchanan <jbuchananr19@gmail.com>
