### PR TITLE
chore(manifests): add openshift capability annotation

### DIFF
--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     openshift.io/node-selector: ""
     workload.openshift.io/allowed: "management"
+    capability.openshift.io/name: "marketplace"
   labels:
     openshift.io/cluster-monitoring: "true"
   name: "openshift-marketplace"

--- a/manifests/04_service_account.yaml
+++ b/manifests/04_service_account.yaml
@@ -7,3 +7,4 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"

--- a/manifests/05_role.yaml
+++ b/manifests/05_role.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"
 rules:
 - apiGroups:
   - ""
@@ -102,6 +103,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"
 rules:
 - apiGroups:
   - ""
@@ -162,6 +164,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"
 rules:
 - apiGroups:
   - config.openshift.io

--- a/manifests/06_role_binding.yaml
+++ b/manifests/06_role_binding.yaml
@@ -6,6 +6,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"
 subjects:
 - kind: ServiceAccount
   name: marketplace-operator
@@ -24,6 +25,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"
 subjects:
 - kind: ServiceAccount
   name: marketplace-operator

--- a/manifests/07_configmap.yaml
+++ b/manifests/07_configmap.yaml
@@ -11,3 +11,4 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"

--- a/manifests/09_operator.yaml
+++ b/manifests/09_operator.yaml
@@ -7,6 +7,7 @@ metadata:
     config.openshift.io/inject-proxy: "marketplace-operator"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"
 spec:
   replicas: 1
   selector:

--- a/manifests/10_clusteroperator.yaml
+++ b/manifests/10_clusteroperator.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"
 status:
   versions:
     - name: operator

--- a/manifests/11_service_monitor.yaml
+++ b/manifests/11_service_monitor.yaml
@@ -9,6 +9,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"
 spec:
   endpoints:
     - bearerTokenFile: /var/run/secrets/kubernetes.io/serviceaccount/token
@@ -39,6 +40,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"
 roleRef:
   apiGroup: rbac.authorization.k8s.io
   kind: Role
@@ -57,6 +59,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"
 rules:
 - apiGroups:
   - ""

--- a/manifests/12_prometheus_rule.yaml
+++ b/manifests/12_prometheus_rule.yaml
@@ -7,6 +7,7 @@ metadata:
     include.release.openshift.io/ibm-cloud-managed: "true"
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
+    capability.openshift.io/name: "marketplace"
   labels:
     prometheus: alert-rules
     role: alert-rules


### PR DESCRIPTION


<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Register CVO-managed manifests under the optional `marketplace` capability.

See also: 
- [Example w/ cluster-baremetal-operator](https://github.com/openshift/cluster-baremetal-operator/pull/249/files#diff-fd1ca771b89b4ffca6e3473d81aa894d2ba00f3e24a987a814a1ca41426ac1b9)
- [OpenShift "capabilities" EP](https://github.com/openshift/enhancements/blob/master/enhancements/installer/component-selection.md)

**Motivation for the change:**

We want OpenShift users to be able to disable/enable the marketplace operator without putting their cluster into an unmanaged state.

Jira: [OLM-2474](https://issues.redhat.com/browse/OLM-2474)

