### PR TITLE
Bug 2070792: chore(manifests): add missing capabilities annotation

### DIFF
--- a/manifests/08_service.yaml
+++ b/manifests/08_service.yaml
@@ -8,6 +8,7 @@ metadata:
     include.release.openshift.io/self-managed-high-availability: "true"
     include.release.openshift.io/single-node-developer: "true"
     service.alpha.openshift.io/serving-cert-secret-name: marketplace-operator-metrics
+    capability.openshift.io/name: "marketplace"
   labels:
     name: marketplace-operator
 spec:

--- a/manifests/09_operator-ibm-cloud-managed.yaml
+++ b/manifests/09_operator-ibm-cloud-managed.yaml
@@ -6,6 +6,7 @@ metadata:
   annotations:
     config.openshift.io/inject-proxy: "marketplace-operator"
     include.release.openshift.io/ibm-cloud-managed: "true"
+    capability.openshift.io/name: "marketplace"
 spec:
   replicas: 1
   selector:


### PR DESCRIPTION
Looks like I missed adding the capabilities annotation to a few manifests.
