### PR TITLE
fix(capabilities): add operatorhub crd manifest

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -8,8 +8,9 @@ FROM registry.svc.ci.openshift.org/openshift/origin-v4.0:base
 RUN useradd marketplace-operator
 USER marketplace-operator
 COPY --from=builder /go/src/github.com/operator-framework/operator-marketplace/build/_output/bin/marketplace-operator /usr/bin
-ADD manifests /manifests
-ADD defaults /defaults
+COPY defaults /defaults
+COPY manifests /manifests
+COPY vendor/github.com/openshift/api/config/v1/*operatorhub.crd.yaml /manifests
 
 LABEL io.k8s.display-name="OpenShift Marketplace Operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the OpenShift Marketplace." \

--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -1,4 +1,3 @@
-
 FROM registry.ci.openshift.org/openshift/release:golang-1.17 AS builder
 WORKDIR /go/src/github.com/operator-framework/operator-marketplace
 COPY . .
@@ -8,8 +7,10 @@ FROM registry.ci.openshift.org/openshift/origin-v4.0:base
 RUN useradd marketplace-operator
 USER marketplace-operator
 COPY --from=builder /go/src/github.com/operator-framework/operator-marketplace/build/_output/bin/marketplace-operator /usr/bin
-ADD manifests /manifests
-ADD defaults /defaults
+COPY defaults /defaults
+COPY manifests /manifests
+COPY vendor/github.com/openshift/api/config/v1/*operatorhub.crd.yaml /manifests
+
 USER root
 RUN sed -i 's;registry.redhat.io;registry.access.redhat.com;' /defaults/03_community_operators.yaml
 USER marketplace-operator

--- a/Dockerfile.rhel7
+++ b/Dockerfile.rhel7
@@ -1,4 +1,3 @@
-
 FROM registry.ci.openshift.org/ocp/builder:rhel-8-golang-1.17-openshift-4.11 AS builder
 WORKDIR /go/src/github.com/operator-framework/operator-marketplace
 COPY . .
@@ -8,8 +7,9 @@ FROM registry.ci.openshift.org/ocp/4.11:base
 RUN useradd marketplace-operator
 USER marketplace-operator
 COPY --from=builder /go/src/github.com/operator-framework/operator-marketplace/build/_output/bin/marketplace-operator /usr/bin
-ADD manifests /manifests
-ADD defaults /defaults
+COPY defaults /defaults
+COPY manifests /manifests
+COPY vendor/github.com/openshift/api/config/v1/*operatorhub.crd.yaml /manifests
 
 LABEL io.k8s.display-name="OpenShift Marketplace Operator" \
       io.k8s.description="This is a component of OpenShift Container Platform and manages the OpenShift Marketplace." \


### PR DESCRIPTION
Copy the vendored OperatorHub CRD manifest from the openshift/api
during image builds. This will be the first step in transferring
ownership of the CRD from the cluster-config-operator to marketplace,
which will allow the CRD to be enabled and disabled as part of the
marketplace capability.

Signed-off-by: Nick Hale <njohnhale@gmail.com>


Related:

- [OLM-2542](https://issues.redhat.com/browse/OLM-2542)
- [BZ-2073288](https://bugzilla.redhat.com/show_bug.cgi?id=2073288)

cc @bparees @wking @perdasilva 

Supersedes #466 
