### PR TITLE
fix(manifests): add singleton operatorhub cr

### DIFF
--- a/manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
+++ b/manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
@@ -1,0 +1,13 @@
+# This name of this file must appear after that of the file containing the OperatorHub CRD when ordered lexicographically.
+# The OperatorHub CRD file is sourced from the following vendor directory: ./vendor/github.com/openshift/api/config/v1
+apiVersion: config.openshift.io/v1
+kind: OperatorHub
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+    capability.openshift.io/name: "marketplace"
+spec: {}


### PR DESCRIPTION
- Relocate the singleton OperatorHub CR instance from openshift/cluster-config-operator
- add the marketplace capability annotatation to CR instance

This consolidates ownership of OperatorHub-related manifests to the marketplace-operator
and will help prevent issues with resource application order.

Signed-off-by: Nick Hale <njohnhale@gmail.com>
