### PR TITLE
Bug 2079610: Fix operatorHub status

### DIFF
--- a/pkg/defaults/catsrcHelpers.go
+++ b/pkg/defaults/catsrcHelpers.go
@@ -59,15 +59,15 @@ func getCatsrcDefinition(fileName string) (*olmv1alpha1.CatalogSource, error) {
 func processCatsrc(ctx context.Context, client wrapper.Client, def olmv1alpha1.CatalogSource, disable bool) error {
 	// Get CatalogSource on the cluster
 	cluster := &olmv1alpha1.CatalogSource{}
-	err := client.Get(ctx, wrapper.ObjectKey{
+	if err := client.Get(ctx, wrapper.ObjectKey{
 		Name:      def.Name,
 		Namespace: def.Namespace,
-	}, cluster)
-	if err != nil && !k8sErrors.IsNotFound(err) {
+	}, cluster); err != nil && !k8sErrors.IsNotFound(err) {
 		logrus.Errorf("[defaults] Error getting CatalogSource %s - %v", def.Name, err)
 		return err
 	}
 
+	var err error
 	if disable {
 		if cluster.Annotations[defaultCatsrcAnnotationKey] == defaultCatsrcAnnotationValue {
 			err = ensureCatsrcAbsent(ctx, client, def, cluster)


### PR DESCRIPTION
Problem: Within the processCatsrc function a GET call is made to the
API for the catalogSource with a given namespace/name the error is
ignored if a 404 is returned. When defaultCatalogSources are disabled
and a new catalogSource named after one of the default catalogSources
exists it is possible for the previous 404 to be returned when no
error is encountered.

Fix: Do not allow the GET error to be returned at the end of the
processCatsrc function.

The error surfaces in the operatorHub status like so after the catalogSources are deleted:
```
apiVersion: config.openshift.io/v1
kind: OperatorHub
metadata:
  name: cluster
spec:
  disableAllDefaultSources: true
status:
  sources:
  - disabled: true
    message: CatalogSource.operators.coreos.com "redhat-operators" not found
    name: redhat-operators
    status: Error
  - disabled: true
    message: CatalogSource.operators.coreos.com "certified-operators" not found
    name: certified-operators
    status: Error
  - disabled: true
    message: CatalogSource.operators.coreos.com "community-operators" not found
    name: community-operators
    status: Error
  - disabled: true
    message: CatalogSource.operators.coreos.com "redhat-marketplace" not found
    name: redhat-marketplace
    status: Error
```

A bunch of logs are generated as well:
```
...
...
...
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource redhat-operators - CatalogSource.operators.coreos.com \"redhat-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource redhat-operators - CatalogSource.operators.coreos.com \"redhat-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource certified-operators - CatalogSource.operators.coreos.com \"certified-operators\" not found"
time="2022-04-27T20:48:01Z" level=info msg="[defaults] Deleting CatalogSource certified-operators"
time="2022-04-27T20:48:01Z" level=info msg="[defaults] error ensureCatsrcAbsent"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource redhat-operators - CatalogSource.operators.coreos.com \"redhat-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource certified-operators - CatalogSource.operators.coreos.com \"certified-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource certified-operators - CatalogSource.operators.coreos.com \"certified-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource redhat-operators - CatalogSource.operators.coreos.com \"redhat-operators\" not found"
time="2022-04-27T20:48:01Z" level=info msg="[defaults] Deleting CatalogSource community-operators"
time="2022-04-27T20:48:01Z" level=info msg="[defaults] error ensureCatsrcAbsent"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource community-operators - CatalogSource.operators.coreos.com \"community-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource community-operators - CatalogSource.operators.coreos.com \"community-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource certified-operators - CatalogSource.operators.coreos.com \"certified-operators\" not found"
time="2022-04-27T20:48:01Z" level=info msg="[defaults] Deleting CatalogSource redhat-marketplace"
time="2022-04-27T20:48:01Z" level=info msg="[defaults] error ensureCatsrcAbsent"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource redhat-marketplace - CatalogSource.operators.coreos.com \"redhat-marketplace\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource redhat-marketplace - CatalogSource.operators.coreos.com \"redhat-marketplace\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource community-operators - CatalogSource.operators.coreos.com \"community-operators\" not found"
time="2022-04-27T20:48:01Z" level=info msg="Reconciling OperatorHub cluster"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource certified-operators - CatalogSource.operators.coreos.com \"certified-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource community-operators - CatalogSource.operators.coreos.com \"community-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource redhat-marketplace - CatalogSource.operators.coreos.com \"redhat-marketplace\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource redhat-operators - CatalogSource.operators.coreos.com \"redhat-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource redhat-marketplace - CatalogSource.operators.coreos.com \"redhat-marketplace\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource community-operators - CatalogSource.operators.coreos.com \"community-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource redhat-operators - CatalogSource.operators.coreos.com \"redhat-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource certified-operators - CatalogSource.operators.coreos.com \"certified-operators\" not found"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource redhat-marketplace - CatalogSource.operators.coreos.com \"redhat-marketplace\" not found"
time="2022-04-27T20:48:01Z" level=info msg="Reconciling OperatorHub cluster"
time="2022-04-27T20:48:01Z" level=error msg="[defaults] Error processing CatalogSource certified-operators - C
...
...
...
```