### PR TITLE
manifests/deployment: comply to restricted pod security level

### DIFF
--- a/manifests/09_operator-ibm-cloud-managed.yaml
+++ b/manifests/09_operator-ibm-cloud-managed.yaml
@@ -19,6 +19,10 @@ spec:
       labels:
         name: marketplace-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: marketplace-operator
       nodeSelector: {}
       priorityClassName: "system-cluster-critical"
@@ -36,6 +40,10 @@ spec:
           tolerationSeconds: 120
       containers:
         - name: marketplace-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           image: quay.io/openshift/origin-operator-marketplace:latest
           ports:
             - containerPort: 60000

--- a/manifests/09_operator.yaml
+++ b/manifests/09_operator.yaml
@@ -20,6 +20,10 @@ spec:
       labels:
         name: marketplace-operator
     spec:
+      securityContext:
+        runAsNonRoot: true
+        seccompProfile:
+          type: RuntimeDefault
       serviceAccountName: marketplace-operator
       nodeSelector:
         node-role.kubernetes.io/master: ""
@@ -38,6 +42,10 @@ spec:
         tolerationSeconds: 120
       containers:
         - name: marketplace-operator
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop: ["ALL"]
           image: quay.io/openshift/origin-operator-marketplace:latest
           ports:
           - containerPort: 60000


### PR DESCRIPTION
Starting from OpenShift 4.11 pod security admission is being activated. In OpenShift the default pod security admission level is going to be `restricted`. This PR fixes workloads from this repository. Concretely, the following violations have been detected:

```
{
  "objectRef": "openshift-marketplace/deployments/marketplace-operator",
  "pod-security.kubernetes.io/audit-violations": "would violate PodSecurity \"restricted:latest\": allowPrivilegeEscalation != false (container \"marketplace-operator\" must set securityContext.allowPrivilegeEscalation=false), unrestricted capab
ilities (container \"marketplace-operator\" must set securityContext.capabilities.drop=[\"ALL\"]), runAsNonRoot != true (pod or container \"marketplace-operator\" must set securityContext.runAsNonRoot=true), seccompProfile (pod or container \"ma
rketplace-operator\" must set securityContext.seccompProfile.type to \"RuntimeDefault\" or \"Localhost\")"
}
```

/cc @stlaz 