### PR TITLE
Bug 2093034: reverting promotion of marketplace catalogs to prevent liveness/readiness timer failures 

### DIFF
--- a/defaults/01_redhat_operators.cr.yaml
+++ b/defaults/01_redhat_operators.cr.yaml
@@ -7,7 +7,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/redhat-operator-index:v4.11
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.10
   displayName: "Red Hat Operators"
   publisher: "Red Hat"
   priority: -100

--- a/defaults/02_certified_operators.yaml
+++ b/defaults/02_certified_operators.yaml
@@ -7,7 +7,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/certified-operator-index:v4.11
+  image: registry.redhat.io/redhat/certified-operator-index:v4.10
   displayName: "Certified Operators"
   publisher: "Red Hat"
   priority: -200

--- a/defaults/03_community_operators.yaml
+++ b/defaults/03_community_operators.yaml
@@ -7,7 +7,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/community-operator-index:v4.11
+  image: registry.redhat.io/redhat/community-operator-index:v4.10
   displayName: "Community Operators"
   publisher: "Red Hat"
   priority: -400

--- a/defaults/04_redhat_marketplace.yaml
+++ b/defaults/04_redhat_marketplace.yaml
@@ -7,7 +7,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/redhat-marketplace-index:v4.11
+  image: registry.redhat.io/redhat/redhat-marketplace-index:v4.10
   displayName: "Red Hat Marketplace"
   publisher: "Red Hat"
   priority: -300


### PR DESCRIPTION
Signed-off-by: Jordan Keister <jordan@nimblewidget.com>

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
reverting 

**Motivation for the change:**
pods fail liveness/readiness probes and oscillate states, never stabilizing to ready.

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
