### PR TITLE
Add PSA enforcement label

### DIFF
--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -12,4 +12,5 @@ metadata:
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/audit: baseline
     pod-security.kubernetes.io/warn: baseline
+    pod-security.kubernetes.io/enforce: baseline
   name: "openshift-marketplace"


### PR DESCRIPTION
Add the label `pod-security.kubernetes.io/enforce: baseline` to the openshift manifests so that PSA enforcement doesn't cause catalog pods to fail to be scheduled.