### PR TITLE
(namespace) remove PSA baseline enforcement

### DIFF
--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -10,7 +10,4 @@ metadata:
     capability.openshift.io/name: "marketplace"
   labels:
     openshift.io/cluster-monitoring: "true"
-    pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/warn: baseline
-    pod-security.kubernetes.io/enforce: baseline
   name: "openshift-marketplace"


### PR DESCRIPTION

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

This PR removes the PSA baseline enforcement for workloads in the
openshift-marketplace namespace, so that the default restricted
profile can be enforced by default like other openshift-* namespaces.

**Motivation for the change:**

This is possible due to the changes in
https://github.com/openshift/operator-framework-olm/pull/349

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
