### PR TITLE
OCPBUGS-697: [release-4.11] Dockerfile.okd: include custom OperatorHub manifest

### DIFF
--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -13,6 +13,7 @@ COPY vendor/github.com/openshift/api/config/v1/*operatorhub.crd.yaml /manifests
 
 USER root
 RUN sed -i 's;registry.redhat.io;registry.access.redhat.com;' /defaults/03_community_operators.yaml
+COPY hack/okd/ /manifests
 USER marketplace-operator
 
 LABEL io.k8s.display-name="OpenShift Marketplace Operator" \

--- a/hack/okd/0000_03_marketplace-operator_02_operatorhub.cr.yaml
+++ b/hack/okd/0000_03_marketplace-operator_02_operatorhub.cr.yaml
@@ -1,0 +1,17 @@
+# This file contains OKD-specific configuration for OperatorHub, it needs to be kept in sync 
+# with manifests/ and make sure only community-operators catalog is enabled by default
+apiVersion: config.openshift.io/v1
+kind: OperatorHub
+metadata:
+  name: cluster
+  annotations:
+    include.release.openshift.io/ibm-cloud-managed: "true"
+    include.release.openshift.io/self-managed-high-availability: "true"
+    include.release.openshift.io/single-node-developer: "true"
+    release.openshift.io/create-only: "true"
+    capability.openshift.io/name: "marketplace"
+spec:
+  disableAllDefaultSources: true
+  sources:
+  - name: "community-operators"
+    disabled: false


### PR DESCRIPTION
Since 4.11 OCP comes with OperatorHub definition which declares a capability
and enables all catalog sources. For OKD we want to enable just community-operators
as users may not have Red Hat pull secret set.
This commit would ensure that OKD version of marketplace operator gets
its own OperatorHub manifest with a custom set of operator catalogs enabled

Cherry-pick of https://github.com/operator-framework/operator-marketplace/pull/481 on release-4.11