### PR TITLE
OCPBUGS-4758: Unenforce PSA Restrictions

### DIFF
--- a/defaults/01_redhat_operators.cr.yaml
+++ b/defaults/01_redhat_operators.cr.yaml
@@ -11,6 +11,8 @@ spec:
   displayName: "Red Hat Operators"
   publisher: "Red Hat"
   priority: -100
+  grpcPodConfig:
+    securityContextConfig: restricted
   updateStrategy:
     registryPoll:
       interval: 10m

--- a/defaults/02_certified_operators.yaml
+++ b/defaults/02_certified_operators.yaml
@@ -11,6 +11,8 @@ spec:
   displayName: "Certified Operators"
   publisher: "Red Hat"
   priority: -200
+  grpcPodConfig:
+    securityContextConfig: restricted
   updateStrategy:
     registryPoll:
       interval: 10m

--- a/defaults/03_community_operators.yaml
+++ b/defaults/03_community_operators.yaml
@@ -11,6 +11,8 @@ spec:
   displayName: "Community Operators"
   publisher: "Red Hat"
   priority: -400
+  grpcPodConfig:
+    securityContextConfig: restricted
   updateStrategy:
     registryPoll:
       interval: 10m

--- a/defaults/04_redhat_marketplace.yaml
+++ b/defaults/04_redhat_marketplace.yaml
@@ -11,6 +11,8 @@ spec:
   displayName: "Red Hat Marketplace"
   publisher: "Red Hat"
   priority: -300
+  grpcPodConfig:
+    securityContextConfig: restricted
   updateStrategy:
     registryPoll:
       interval: 10m

--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -10,6 +10,8 @@ metadata:
     capability.openshift.io/name: "marketplace"
   labels:
     openshift.io/cluster-monitoring: "true"
-    pod-security.kubernetes.io/enforce: restricted
-    pod-security.kubernetes.io/enforce-version: v1.24
+    pod-security.kubernetes.io/enforce: baseline
+    pod-security.kubernetes.io/enforce-version: v1.25
+    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/warn: restricted
   name: "openshift-marketplace"


### PR DESCRIPTION
OpenShift v4.12 had previously enforced PSA restrictions by defaults in and namespace prefixed with `openshift-`. This change has been delayed until OpenShift v4.13 and users should be allowed to run catalogs without restricted permissions in the openshift-marketplace namespace.
