### PR TITLE
OCPBUGS-5423: Remove PSA audit and warnings

### DIFF
--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -12,8 +12,8 @@ metadata:
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/enforce: baseline
     pod-security.kubernetes.io/enforce-version: v1.25
-    pod-security.kubernetes.io/audit: restricted
+    pod-security.kubernetes.io/audit: baseline
     pod-security.kubernetes.io/audit-version: v1.25
-    pod-security.kubernetes.io/warn: restricted
+    pod-security.kubernetes.io/warn: baseline
     pod-security.kubernetes.io/warn-version: v1.25
   name: "openshift-marketplace"


### PR DESCRIPTION
The openshift-marketplace namespace will not be enforcing PSA restricted mode in the foreseeable future, and so we will be disabling the PSA audit and warnings.
