### PR TITLE
OCPBUGS-10926: update image tag to 4.13 for all but community operators

### DIFF
--- a/defaults/01_redhat_operators.cr.yaml
+++ b/defaults/01_redhat_operators.cr.yaml
@@ -7,7 +7,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/redhat-operator-index:v4.12
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.13
   displayName: "Red Hat Operators"
   publisher: "Red Hat"
   priority: -100

--- a/defaults/02_certified_operators.yaml
+++ b/defaults/02_certified_operators.yaml
@@ -7,7 +7,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/certified-operator-index:v4.12
+  image: registry.redhat.io/redhat/certified-operator-index:v4.13
   displayName: "Certified Operators"
   publisher: "Red Hat"
   priority: -200

--- a/defaults/04_redhat_marketplace.yaml
+++ b/defaults/04_redhat_marketplace.yaml
@@ -7,7 +7,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/redhat-marketplace-index:v4.12
+  image: registry.redhat.io/redhat/redhat-marketplace-index:v4.13
   displayName: "Red Hat Marketplace"
   publisher: "Red Hat"
   priority: -300


### PR DESCRIPTION
**Description of the change:**
Update the image tag for all default CatalogSource images except the community operators index (pending ISV-3506)

Part 1 of a split of #511 