### PR TITLE
OCPBUGS-12794: update community index to 4.13 tag

### DIFF
--- a/defaults/03_community_operators.yaml
+++ b/defaults/03_community_operators.yaml
@@ -7,7 +7,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/community-operator-index:v4.12
+  image: registry.redhat.io/redhat/community-operator-index:v4.13
   displayName: "Community Operators"
   publisher: "Red Hat"
   priority: -400


### PR DESCRIPTION
**Description of the change:**
Updates only the community operator index image tag to 4.13.

Part 2 of splitting #511 (Part 1 in #513)
