### PR TITLE
OCPBUGS-13910: update community-operator-index to 4.14 tag

### DIFF
--- a/defaults/03_community_operators.yaml
+++ b/defaults/03_community_operators.yaml
@@ -7,7 +7,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/community-operator-index:v4.13
+  image: registry.redhat.io/redhat/community-operator-index:v4.14
   displayName: "Community Operators"
   publisher: "Red Hat"
   priority: -400


### PR DESCRIPTION
**Description of the change:**
- Updates the community operator index image to use the 4.14 tag

**Motivation for the change:**
- [OCPBUGS-13910](https://issues.redhat.com/browse/OCPBUGS-13910)

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive
