### PR TITLE
OPECO-3029:  Update image tag to 4.16 for all indexes except community-operators

### DIFF
--- a/defaults/01_redhat_operators.cr.yaml
+++ b/defaults/01_redhat_operators.cr.yaml
@@ -7,7 +7,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/redhat-operator-index:v4.15
+  image: registry.redhat.io/redhat/redhat-operator-index:v4.16
   displayName: "Red Hat Operators"
   publisher: "Red Hat"
   priority: -100

--- a/defaults/02_certified_operators.yaml
+++ b/defaults/02_certified_operators.yaml
@@ -7,7 +7,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/certified-operator-index:v4.15
+  image: registry.redhat.io/redhat/certified-operator-index:v4.16
   displayName: "Certified Operators"
   publisher: "Red Hat"
   priority: -200

--- a/defaults/04_redhat_marketplace.yaml
+++ b/defaults/04_redhat_marketplace.yaml
@@ -7,7 +7,7 @@ metadata:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
 spec:
   sourceType: grpc
-  image: registry.redhat.io/redhat/redhat-marketplace-index:v4.15
+  image: registry.redhat.io/redhat/redhat-marketplace-index:v4.16
   displayName: "Red Hat Marketplace"
   publisher: "Red Hat"
   priority: -300


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
Update the image tag for all default CatalogSource images except the community operators index

**Motivation for the change:**
Update to latest images

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
