### PR TITLE
OCPBUGS-28230: enforce termination message policy on all platform pods

### DIFF
--- a/manifests/09_operator.yaml
+++ b/manifests/09_operator.yaml
@@ -74,6 +74,7 @@ spec:
             requests:
               cpu: 1m
               memory: 5Mi
+          terminationMessagePolicy: FallbackToLogsOnError
           env:
             - name: WATCH_NAMESPACE
               valueFrom:


### PR DESCRIPTION
this makes debugging via the API much easier by including the last few kb of the sysout for the container if the container crashes.

/assign @joelanford 