### PR TITLE
[release-4.15] OCPBUGS-37524: Set required-scc for openshift workloads

### DIFF
--- a/manifests/09_operator-ibm-cloud-managed.yaml
+++ b/manifests/09_operator-ibm-cloud-managed.yaml
@@ -16,6 +16,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         name: marketplace-operator
     spec:

--- a/manifests/09_operator.yaml
+++ b/manifests/09_operator.yaml
@@ -17,6 +17,7 @@ spec:
     metadata:
       annotations:
         target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+        openshift.io/required-scc: restricted-v2
       labels:
         name: marketplace-operator
     spec:


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->
Cherry-pick of #561 
[OCPBUGS-37524](https://issues.redhat.com/browse/OCPBUGS-37524)

**Description of the change:**
This PR explicitly sets the required SCC to be used to admit pods of the `marketplace-operator` deployments. The SCC chosen is the one that the pods are already getting admitted with, which means that this brings no change to the SCC used.

**Motivation for the change:**
In some cases, custom SCCs can have higher priority than default SCCs, which means that they will be chosen over the default ones. This can lead to unexpected results; in order to protect openshift workloads from this, we must explicitly pin the required SCC to all our workloads in order to make sure that the expected one will be used.


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
