### PR TITLE
AUTH-482: set required-scc for openshift workloads

### DIFF
--- a/defaults/01_redhat_operators.cr.yaml
+++ b/defaults/01_redhat_operators.cr.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "openshift-marketplace"
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    openshift.io/required-scc: restricted-v2
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/redhat-operator-index:v4.18

--- a/defaults/02_certified_operators.yaml
+++ b/defaults/02_certified_operators.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "openshift-marketplace"
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    openshift.io/required-scc: restricted-v2
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/certified-operator-index:v4.18

--- a/defaults/03_community_operators.yaml
+++ b/defaults/03_community_operators.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "openshift-marketplace"
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    openshift.io/required-scc: restricted-v2
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/community-operator-index:v4.18

--- a/defaults/04_redhat_marketplace.yaml
+++ b/defaults/04_redhat_marketplace.yaml
@@ -5,6 +5,7 @@ metadata:
   namespace: "openshift-marketplace"
   annotations:
     target.workload.openshift.io/management: '{"effect": "PreferredDuringScheduling"}'
+    openshift.io/required-scc: restricted-v2
 spec:
   sourceType: grpc
   image: registry.redhat.io/redhat/redhat-marketplace-index:v4.18


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**
This PR explicitly sets the required SCC to be used to admit pods of the `marketplace-operator` deployments:
- `redhat-operators`
- `certified-operators`
- `community-operators`
- `redhat-marketplace`

The SCC chosen is the one that the pods are already getting admitted with, which means that this brings no change to the SCC used.

**Motivation for the change:**
In some cases, custom SCCs can have higher priority than default SCCs, which means that they will be chosen over the default ones. This can lead to unexpected results; in order to protect openshift workloads from this, we must explicitly pin the required SCC to all our workloads in order to make sure that the expected one will be used.

<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
