### PR TITLE
OCPBUGS-52340: Ensure that PSA label use k8s version supported on the project

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -31,3 +31,24 @@ vendor:
 .PHONY: manifests
 manifests:
 	./hack/update-manifests.sh
+
+KUBE_MINOR ?= $(shell go list -m k8s.io/client-go | cut -d" " -f2 | sed 's/^v0\.\([[:digit:]]\{1,\}\)\.[[:digit:]]\{1,\}$$/1.\1/')
+.PHONY: update-k8s-values  # HELP Update PSA labels with k8s version used
+update-k8s-values:
+	sed -i.bak -E 's/(pod-security.kubernetes.io\/enforce-version:).*/\1 "v$(KUBE_MINOR)"/' ./manifests/01_namespace.yaml
+	sed -i.bak -E 's/(pod-security.kubernetes.io\/audit-version:).*/\1 "v$(KUBE_MINOR)"/' ./manifests/01_namespace.yaml
+	sed -i.bak -E 's/(pod-security.kubernetes.io\/warn-version:).*/\1 "v$(KUBE_MINOR)"/' ./manifests/01_namespace.yaml
+	rm ./manifests/01_namespace.yaml.bak
+
+#SECTION Verification
+
+.PHONY: diff
+diff:
+	git diff --exit-code
+
+.PHONY: verify-update-k8s-values
+verify-update-k8s-values: update-k8s-values #HELP Check if Helm Chart values are updated with k8s version
+	$(MAKE) diff
+
+.PHONY: verify #HELP Run all verification checks
+verify: verify-update-k8s-values

--- a/manifests/01_namespace.yaml
+++ b/manifests/01_namespace.yaml
@@ -12,9 +12,9 @@ metadata:
   labels:
     openshift.io/cluster-monitoring: "true"
     pod-security.kubernetes.io/enforce: baseline
-    pod-security.kubernetes.io/enforce-version: v1.25
+    pod-security.kubernetes.io/enforce-version: "v1.32"
     pod-security.kubernetes.io/audit: baseline
-    pod-security.kubernetes.io/audit-version: v1.25
+    pod-security.kubernetes.io/audit-version: "v1.32"
     pod-security.kubernetes.io/warn: baseline
-    pod-security.kubernetes.io/warn-version: v1.25
+    pod-security.kubernetes.io/warn-version: "v1.32"
   name: "openshift-marketplace"


### PR DESCRIPTION
**Description of the change:**
In this commit, a new Makefile target `update-k8s-values` was created to automatically update the
`pod-security.kubernetes.io/*-version` values (`enforceVersion`, `auditVersion`, `warnVersion`)
in the Helm chart's `values.yaml` file.

These values now align with the Kubernetes API version defined in `go.mod`, instead of using `latest`. This ensures better compatibility and avoids issues with unsupported versions in Kubernetes PSA.
