### PR TITLE
DNM: Disable sources for testing

### DIFF
--- a/manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
+++ b/manifests/0000_03_marketplace-operator_02_operatorhub.cr.yaml
@@ -11,4 +11,5 @@ metadata:
     include.release.openshift.io/single-node-developer: "true"
     release.openshift.io/create-only: "true"
     capability.openshift.io/name: "marketplace"
-spec: {}
+spec:
+  disableAllDefaultSources: true


### PR DESCRIPTION
Disabling sources to test upgrades without OLM being busy

/hold not to be merged