### PR TITLE
Update dockerfile to use go 1.24 and OCP image 4.20

### DIFF
--- a/Dockerfile.okd
+++ b/Dockerfile.okd
@@ -1,9 +1,9 @@
-FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.23-openshift-4.19 AS builder
+FROM registry.ci.openshift.org/ocp/builder:rhel-9-golang-1.24-openshift-4.20 AS builder
 WORKDIR /go/src/github.com/operator-framework/operator-marketplace
 COPY . .
 RUN make osbs-build
 
-FROM registry.ci.openshift.org/origin/4.19:base
+FROM registry.ci.openshift.org/origin/4.20:base
 RUN useradd marketplace-operator
 USER marketplace-operator
 COPY --from=builder /go/src/github.com/operator-framework/operator-marketplace/build/_output/bin/marketplace-operator /usr/bin


### PR DESCRIPTION
Update dockerfile to use go 1.24 and OCP image 4.20