### PR TITLE
OCPBUGS-61036: Update memoryTarget on catalog source pods

### DIFF
--- a/defaults/01_redhat_operators.cr.yaml
+++ b/defaults/01_redhat_operators.cr.yaml
@@ -33,7 +33,7 @@ spec:
       operator: "Exists"
       effect: "NoExecute"
       tolerationSeconds: 120
-    memoryTarget: 30Mi
+    memoryTarget: 120Mi
     extractContent:
       cacheDir: /tmp/cache
       catalogDir: /configs

--- a/defaults/02_certified_operators.yaml
+++ b/defaults/02_certified_operators.yaml
@@ -33,7 +33,7 @@ spec:
       operator: "Exists"
       effect: "NoExecute"
       tolerationSeconds: 120
-    memoryTarget: 40Mi
+    memoryTarget: 120Mi
     extractContent:
       cacheDir: /tmp/cache
       catalogDir: /configs

--- a/defaults/04_redhat_marketplace.yaml
+++ b/defaults/04_redhat_marketplace.yaml
@@ -33,7 +33,7 @@ spec:
       operator: "Exists"
       effect: "NoExecute"
       tolerationSeconds: 120
-    memoryTarget: 20Mi
+    memoryTarget: 120Mi
     extractContent:
       cacheDir: /tmp/cache
       catalogDir: /configs


### PR DESCRIPTION
30Mi is too low, and causes performance issues in redhat-operators Bump them all up to 120Mi (which is what community-operators was set to, and is the largest of the bunch).

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
