### PR TITLE
OCPBUGS-61036: Update memoryTarget on catalog source pods

### DIFF
--- a/defaults/01_redhat_operators.cr.yaml
+++ b/defaults/01_redhat_operators.cr.yaml
@@ -32,7 +32,7 @@ spec:
       operator: "Exists"
       effect: "NoExecute"
       tolerationSeconds: 120
-    memoryTarget: 30Mi
+    memoryTarget: 50Mi
     extractContent:
       cacheDir: /tmp/cache
       catalogDir: /configs

--- a/defaults/02_certified_operators.yaml
+++ b/defaults/02_certified_operators.yaml
@@ -32,7 +32,7 @@ spec:
       operator: "Exists"
       effect: "NoExecute"
       tolerationSeconds: 120
-    memoryTarget: 40Mi
+    memoryTarget: 50Mi
     extractContent:
       cacheDir: /tmp/cache
       catalogDir: /configs

--- a/defaults/03_community_operators.yaml
+++ b/defaults/03_community_operators.yaml
@@ -32,7 +32,7 @@ spec:
       operator: "Exists"
       effect: "NoExecute"
       tolerationSeconds: 120
-    memoryTarget: 120Mi
+    memoryTarget: 60Mi
     extractContent:
       cacheDir: /tmp/cache
       catalogDir: /configs

--- a/defaults/04_redhat_marketplace.yaml
+++ b/defaults/04_redhat_marketplace.yaml
@@ -32,7 +32,7 @@ spec:
       operator: "Exists"
       effect: "NoExecute"
       tolerationSeconds: 120
-    memoryTarget: 20Mi
+    memoryTarget: 40Mi
     extractContent:
       cacheDir: /tmp/cache
       catalogDir: /configs


### PR DESCRIPTION
The current values of memoryTarget are too low for redhat-operator, redhat-marketplace and certified-operators. The result is that golang GC is run too frequently, and this slows down transfers (causing DealineExceeded errors), increases CPU usage (causing CPU spikes) and because it's the GC looking through all of memory, hits the disk more often than it should.

The value for community-operators is likely too high, and can be reduced to lessen the impact of the other increases.

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
