### PR TITLE
OCPBUGS-62132: Remove Expect func so that the test case can use the retry logic

### DIFF
--- a/test/e2e/operatorhub_test.go
+++ b/test/e2e/operatorhub_test.go
@@ -367,10 +367,12 @@ var _ = Describe("operatorhub", func() {
 			By("checking the redhat-operators catalogsource has been re-created")
 			Eventually(func() error {
 				cs := &olmv1alpha1.CatalogSource{}
-				err := k8sClient.Get(ctx, disabledNN, cs)
-				Expect(err).ShouldNot(HaveOccurred())
-				Expect(cs).NotTo(BeNil())
-				Expect(cs.GetName()).To(Equal(disabledName))
+				if err := k8sClient.Get(ctx, disabledNN, cs); err != nil {
+					return err
+				}
+				if cs.GetName() != disabledName {
+					return fmt.Errorf("expected name %s, got %s", disabledName, cs.GetName())
+				}
 				return nil
 			}, defaultTimeout, 3).Should(BeNil())
 		})


### PR DESCRIPTION
<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**

Increase default timeout.

**Motivation for the change:**
Try to fix https://github.com/operator-framework/operator-marketplace/pull/664#issuecomment-3317267891 
Not only 4.16, but also the master, see: https://gcsweb-ci.apps.ci.l2s4.p1.openshiftapps.com/gcs/test-platform-results/pr-logs/pull/operator-framework_operator-marketplace/661/pull-ci-operator-framework-operator-marketplace-master-e2e-gcp-operator/1969926155641294848/artifacts/e2e-gcp-operator/test/build-log.txt

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [x] Sufficient unit test coverage 
- [x] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [x] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
