### PR TITLE
OPRUN-4628: restrict dynamic version selection for default catalogsources to only apply to v5.0->v4.y

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,13 +33,3 @@ A full writeup on Marketplace e2e testing can be found [here](docs/e2e-testing.m
 
 [upstream-community-operators]: deploy/upstream/07_upstream_operatorsource.cr.yaml
 [community-operators]: deploy/examples/community.operatorsource.cr.yaml
-
-## Default Catalogs
-
-Default sources applied to a cluster are present in the (defaults)[defaults/] directory. Each catalogsource present here is tagged with a corresponding OCP version similar to:
-
-```
-registry.redhat.io/redhat/community-operator-index:v4.22
-```
-
-The version of catalog used may be automatically configured based on the current OCP version by setting `-default-catalog-version="ocp-release"`, and setting `RELEASE_VERSION` to the appropriate OCP version on the (operator manifest)[manifests/09_operator.yaml]. `RELEASE_VERSION` is automatically configured by CVO on OCP clusters, and `-default-catalog-version` may be used to selectively enable default catalog image tag resolution based on the availability of specific default catalogs.

--- a/cmd/manager/main.go
+++ b/cmd/manager/main.go
@@ -8,7 +8,6 @@ import (
 	"net/http"
 	"os"
 	"runtime"
-	"strings"
 	"time"
 
 	ca "github.com/operator-framework/operator-marketplace/pkg/certificateauthority"
@@ -57,11 +56,6 @@ const (
 	defaultLeaseDuration               = 90 * time.Second
 	defaultPprofPort                   = 6060
 	healthPort                         = 8080
-
-	// defaultCatalogVersionModeOCPRelease is the value for -default-catalog-version
-	// that enables dynamic catalog tag resolution based on the cluster's OCP version.
-	// This only affects the default/operator-managed CatalogSources.
-	defaultCatalogVersionModeOCPRelease = "ocp-release"
 )
 
 func init() {
@@ -98,7 +92,6 @@ func main() {
 		pprofAddress                string
 		version                     bool
 		loglvl                      string
-		defaultCatalogVersionMode   string
 	)
 	flag.StringVar(&clusterOperatorName, "clusterOperatorName", "", "configures the name of the OpenShift ClusterOperator that should reflect this operator's status, or the empty string to disable ClusterOperator updates")
 	flag.StringVar(&defaults.Dir, "defaultsDir", "", "configures the directory where the default CatalogSources are stored")
@@ -108,7 +101,6 @@ func main() {
 	flag.StringVar(&tlsCertPath, "tls-cert", "", "Path to use for certificate (requires tls-key)")
 	flag.StringVar(&leaderElectionNamespace, "leader-namespace", "openshift-marketplace", "configures the namespace that will contain the leader election lock")
 	flag.StringVar(&loglvl, "level", "info", "Sets level of logger with default verbosity info level. See https://github.com/sirupsen/logrus for other verbosity levels.")
-	flag.StringVar(&defaultCatalogVersionMode, "default-catalog-version", "", "When set to 'ocp-release', enables automatically updating the image tags of default catalog sources to the OCP version of the cluster they are running on. Other values are ignored.")
 	flag.Parse()
 	logger := logrus.New()
 
@@ -227,18 +219,11 @@ func main() {
 			}
 		}
 
-		var operatorReleaseVersion string
-		if strings.Trim(defaultCatalogVersionMode, "'\"") == defaultCatalogVersionModeOCPRelease {
-			// The RELEASE_VERSION env variable is set to current OpenShift version
-			// by the Cluster Version Operator. If missing or set to the default of
-			// "0.0.1-snapshot", the cluster does not have CVO running, and the image
-			// tag override will be skipped.
-			operatorReleaseVersion = os.Getenv("RELEASE_VERSION")
-		}
+		operatorReleaseVersion := os.Getenv("RELEASE_VERSION")
 		overrideTag, err := defaults.GetCatalogSourceImageTagOverride(operatorReleaseVersion)
 		if err != nil {
 			overrideTag = ""
-			logger.Warnf("failed to parse RELEASE_VERSION %q for image tag override: %v (skipping override)", operatorReleaseVersion, err)
+			logger.Warnf("failed to parse RELEASE_VERSION %q for default CatalogSource image tag override: %v (skipping override)", operatorReleaseVersion, err)
 		}
 
 		if len(overrideTag) > 0 {

--- a/manifests/09_operator-ibm-cloud-managed.yaml
+++ b/manifests/09_operator-ibm-cloud-managed.yaml
@@ -62,7 +62,6 @@ spec:
             - /var/run/secrets/serving-cert/tls.crt
             - -tls-key
             - /var/run/secrets/serving-cert/tls.key
-            - -default-catalog-version=""
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/manifests/09_operator.yaml
+++ b/manifests/09_operator.yaml
@@ -63,7 +63,6 @@ spec:
           - /var/run/secrets/serving-cert/tls.crt
           - -tls-key
           - /var/run/secrets/serving-cert/tls.key
-          - -default-catalog-version=""
           imagePullPolicy: IfNotPresent
           livenessProbe:
             httpGet:

--- a/pkg/defaults/defaults.go
+++ b/pkg/defaults/defaults.go
@@ -165,6 +165,13 @@ func populateDefsConfig(dir, imageTagOverride string) (map[string]olmv1alpha1.Ca
 	return catsrcDefinitions, config, nil
 }
 
+// GetCatalogSourceImageTagOverride returns a tag of the form `v<major>.<minor>`
+// where <major> and <minor> are the major and minor version parts of the semver
+// argument provided through versionString, provided the version string has a
+// major version of 4. This is used for determining what image tag to use on
+// a default CatalogSource based on the OCP version of the cluster it is running on,
+// given the 5.0 catalogsources will be shipped to both 4.23 and 5.0 clusters.
+// This may be removed in 5.1+
 func GetCatalogSourceImageTagOverride(versionString string) (string, error) {
 	// Return empty if not in OpenShift or version is default/unknown
 	if len(versionString) == 0 || versionString == defaultCatsrcVersionString {
@@ -176,8 +183,8 @@ func GetCatalogSourceImageTagOverride(versionString string) (string, error) {
 		return "", fmt.Errorf("failed to parse version string %q: %w", versionString, err)
 	}
 
-	// Only override for valid OpenShift versions (4.x+)
-	if v.Major == 0 {
+	// Only override for 4.x OpenShift versions
+	if v.Major != 4 {
 		return "", nil
 	}
 
@@ -185,7 +192,7 @@ func GetCatalogSourceImageTagOverride(versionString string) (string, error) {
 }
 
 // overrideImageTag overrides the tag for a given CatalogSource's image with
-// a provided non-empty tag, provided the CatalogSource has a non-empty image field
+// a tag exactly matching `v5.0`, provided the CatalogSource has a non-empty image field
 // The image tag override only applies to non-digest based images. If called on a
 // CatalogSource with a digest based image, the image remains unchanged.
 func overrideImageTag(catsrc *olmv1alpha1.CatalogSource, imageTagOverride string) error {
@@ -209,6 +216,11 @@ func overrideImageTag(catsrc *olmv1alpha1.CatalogSource, imageTagOverride string
 	// Skip digest-based images - the default behavior of Canonical references
 	// when converted to string is to ignore tags in favor of digests
 	if _, ok := catsrcRef.(reference.Canonical); ok {
+		return nil
+	}
+
+	// Tag substitution should only happen on v5.0 images
+	if taggedRef, ok := catsrcRef.(reference.Tagged); !ok || taggedRef.Tag() != "v5.0" {
 		return nil
 	}
 

--- a/pkg/defaults/defaults_test.go
+++ b/pkg/defaults/defaults_test.go
@@ -35,9 +35,9 @@ func TestGetCatalogSourceImageTagOverride(t *testing.T) {
 			wantErr:       false,
 		},
 		{
-			name:          "valid OpenShift 5.0.0",
+			name:          "OpenShift 5.0.0 ignored",
 			versionString: "5.0.0",
-			wantTag:       "v5.0",
+			wantTag:       "",
 			wantErr:       false,
 		},
 		{
@@ -118,11 +118,11 @@ func TestOverrideImageTag(t *testing.T) {
 			catsrc: &olmv1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: olmv1alpha1.CatalogSourceSpec{
-					Image: "registry.io/catalog:v4.20",
+					Image: "registry.io/catalog:v5.0",
 				},
 			},
 			imageTagOverride: "",
-			wantImage:        "registry.io/catalog:v4.20",
+			wantImage:        "registry.io/catalog:v5.0",
 			wantErr:          false,
 		},
 		{
@@ -131,7 +131,7 @@ func TestOverrideImageTag(t *testing.T) {
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec:       olmv1alpha1.CatalogSourceSpec{},
 			},
-			imageTagOverride: "v5.0",
+			imageTagOverride: "v4.23",
 			wantImage:        "",
 			wantErr:          false,
 		},
@@ -140,35 +140,35 @@ func TestOverrideImageTag(t *testing.T) {
 			catsrc: &olmv1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: olmv1alpha1.CatalogSourceSpec{
-					Image: "registry.io/catalog:v4.23",
+					Image: "registry.io/catalog:v5.0",
 				},
 			},
-			imageTagOverride: "v5.0",
-			wantImage:        "registry.io/catalog:v5.0",
+			imageTagOverride: "v4.23",
+			wantImage:        "registry.io/catalog:v4.23",
 			wantErr:          false,
 		},
 		{
-			name: "non-semver tagged image override",
+			name: "non-v5.0 tagged image unchanged",
 			catsrc: &olmv1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: olmv1alpha1.CatalogSourceSpec{
 					Image: "registry.io/catalog:latest",
 				},
 			},
-			imageTagOverride: "v5.0",
-			wantImage:        "registry.io/catalog:v5.0",
+			imageTagOverride: "v4.23",
+			wantImage:        "registry.io/catalog:latest",
 			wantErr:          false,
 		},
 		{
-			name: "untagged image override",
+			name: "untagged image unchanged",
 			catsrc: &olmv1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: olmv1alpha1.CatalogSourceSpec{
 					Image: "registry.io/catalog",
 				},
 			},
-			imageTagOverride: "v5.0",
-			wantImage:        "registry.io/catalog:v5.0",
+			imageTagOverride: "v4.23",
+			wantImage:        "registry.io/catalog",
 			wantErr:          false,
 		},
 		{
@@ -179,7 +179,7 @@ func TestOverrideImageTag(t *testing.T) {
 					Image: "registry.io/catalog@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 				},
 			},
-			imageTagOverride: "v5.0",
+			imageTagOverride: "v4.23",
 			wantImage:        "registry.io/catalog@sha256:abcdef1234567890abcdef1234567890abcdef1234567890abcdef1234567890",
 			wantErr:          false,
 		},
@@ -188,11 +188,11 @@ func TestOverrideImageTag(t *testing.T) {
 			catsrc: &olmv1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: olmv1alpha1.CatalogSourceSpec{
-					Image: "registry.io:5000/catalog:v4.23",
+					Image: "registry.io:5000/catalog:v5.0",
 				},
 			},
-			imageTagOverride: "v5.0",
-			wantImage:        "registry.io:5000/catalog:v5.0",
+			imageTagOverride: "v4.23",
+			wantImage:        "registry.io:5000/catalog:v4.23",
 			wantErr:          false,
 		},
 		{
@@ -200,11 +200,11 @@ func TestOverrideImageTag(t *testing.T) {
 			catsrc: &olmv1alpha1.CatalogSource{
 				ObjectMeta: metav1.ObjectMeta{Name: "test"},
 				Spec: olmv1alpha1.CatalogSourceSpec{
-					Image: "registry.io/org/team/catalog:v4.23",
+					Image: "registry.io/org/team/catalog:v5.0",
 				},
 			},
-			imageTagOverride: "v5.0",
-			wantImage:        "registry.io/org/team/catalog:v5.0",
+			imageTagOverride: "v4.23",
+			wantImage:        "registry.io/org/team/catalog:v4.23",
 			wantErr:          false,
 		},
 		{
@@ -215,7 +215,7 @@ func TestOverrideImageTag(t *testing.T) {
 					Image: "not:::valid",
 				},
 			},
-			imageTagOverride: "v5.0",
+			imageTagOverride: "v4.23",
 			wantImage:        "not:::valid",
 			wantErr:          true,
 		},


### PR DESCRIPTION
The sentinel value approach in https://github.com/operator-framework/operator-marketplace/pull/750 risks breaking CI on branch cut for 5.1 based on the availability of the 5.1 catalogs. This PR restricts the catalog tag override to only apply to v5.0 catalogs, and only if the OCP version provided through the RELEASE_VERSION env variable is a 4.y semver version. 

<!--

Before making a PR, please read our contributing guidelines https://github.com/operator-framework/operator-lifecycle-manager/blob/master/CONTRIBUTING.MD

Note: Make sure your branch is rebased to the latest upstream master.

-->

**Description of the change:**


**Motivation for the change:**

**Reviewer Checklist**
- [ ] Implementation matches the proposed design, or proposal is updated to match implementation
- [ ] Sufficient unit test coverage 
- [ ] Sufficient end-to-end test coverage
- [ ] Docs updated or added to `/docs` 
- [ ] Commit messages sensible and descriptive


<!--

Note: If this PR is fixing an issue make sure to add a note saying:
Closes #<ISSUE_NUMBER>

-->
